### PR TITLE
feat: log config save events

### DIFF
--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -53,4 +53,6 @@ def save(cfg: dict) -> None:
     with open(_USER, "w") as f:
         json.dump(clean, f, indent=2)
         f.write("\n")
-    print(f"[WhisperSync] Config saved ({len(clean)} keys)")
+
+    from .logger import logger
+    logger.info(f"Config saved ({len(clean)} keys)")


### PR DESCRIPTION
Adds a log line when config.json is written, showing how many keys were persisted. Useful for debugging config issues.