### PR TITLE
feat: GitHub PR status polling in tray menu

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -70,6 +70,8 @@ class WhisperSync:
         self._meeting_start_time: datetime | None = None
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
         self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
+        self._github_poller = None
+        self._github_prs = []
 
     def _update_icon(self):
         if self.tray is None:
@@ -1478,6 +1480,7 @@ class WhisperSync:
                 pystray.MenuItem(f"Output Folder ({self._truncate_path(self._output_dir())})",
                                  lambda: self._change_output_folder()),
             )),
+            *self._github_menu_items(),
             pystray.MenuItem("Restart", lambda: self._restart()),
             pystray.MenuItem("Quit", lambda: self.quit()),
         )
@@ -1492,6 +1495,83 @@ class WhisperSync:
     def _save_and_refresh(self):
         config.save(self.cfg)
         self._refresh_menu()
+
+    # --- GitHub PR Status ---
+
+    def _start_github_poller(self):
+        """Start the GitHub PR status poller if configured."""
+        repo = self.cfg.get("github_repo")
+        if not repo:
+            return
+
+        from .github_status import GitHubPoller
+        interval = self.cfg.get("github_poll_interval", 300)
+
+        def _on_change(old_prs, new_prs):
+            self._github_prs = new_prs
+            self._refresh_menu()
+            if not self.cfg.get("github_notifications", True):
+                return
+            # Notify on actionable changes
+            old_map = {pr.number: pr.review_state for pr in old_prs}
+            for pr in new_prs:
+                old_state = old_map.get(pr.number)
+                if old_state == pr.review_state:
+                    continue
+                if pr.review_state == "suggestions":
+                    self._notify(f"PR #{pr.number} needs attention: {pr.suggestion_count} suggestion(s)")
+                elif pr.review_state == "human-review":
+                    self._notify(f"PR #{pr.number} flagged for human review")
+
+        self._github_poller = GitHubPoller(
+            repo=repo, interval=interval, on_change=_on_change,
+        )
+        self._github_poller.start()
+        if self._github_poller.state.available:
+            self._github_prs = []
+
+    def _notify(self, message: str):
+        """Show a tray notification balloon."""
+        if self.tray:
+            try:
+                self.tray.notify(message, "WhisperSync")
+            except Exception:
+                logger.debug(f"Notification failed: {message}")
+
+    def _github_menu_items(self) -> list:
+        """Build menu items for GitHub PR status."""
+        repo = self.cfg.get("github_repo")
+        if not repo or not self._github_poller or not self._github_poller.state.available:
+            return []
+
+        items = [pystray.Menu.SEPARATOR]
+
+        prs = self._github_prs
+        if not prs:
+            items.append(pystray.MenuItem("GitHub (no open PRs)", None, enabled=False))
+        else:
+            label = f"GitHub ({len(prs)} open PR{'s' if len(prs) != 1 else ''})"
+            pr_items = []
+            for pr in prs:
+                pr_items.append(pystray.MenuItem(
+                    pr.display,
+                    self._cb(self._open_pr_url, pr.url),
+                ))
+            pr_items.append(pystray.Menu.SEPARATOR)
+            pr_items.append(pystray.MenuItem("Check now", lambda: self._github_poller.poll_now()))
+            pr_items.append(pystray.MenuItem(
+                "Open on GitHub",
+                self._cb(self._open_pr_url, f"https://github.com/{repo}/pulls"),
+            ))
+            items.append(pystray.MenuItem(label, pystray.Menu(*pr_items)))
+
+        return items
+
+    def _open_pr_url(self, url: str):
+        """Open a GitHub URL in the default browser."""
+        import webbrowser
+        if url:
+            webbrowser.open(url)
 
     def _show_error_popup(self, title: str, message: str):
         """Show a tkinter error dialog with the given message."""
@@ -1887,12 +1967,17 @@ class WhisperSync:
 
         threading.Thread(target=_wait_worker, daemon=True).start()
 
+        # Start GitHub PR status polling if configured
+        self._start_github_poller()
+
         try:
             self.tray.run()
         finally:
             # Always release keyboard hooks to prevent stuck modifier keys
             keyboard.unhook_all()
             self.worker.stop()
+            if self._github_poller:
+                self._github_poller.stop()
 
 
 def main():

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -15,5 +15,8 @@
   "batch_size": "auto",
   "use_system_devices": true,
   "left_click": "meeting",
-  "middle_click": "dictation"
+  "middle_click": "dictation",
+  "github_repo": null,
+  "github_poll_interval": 300,
+  "github_notifications": true
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -12,7 +12,8 @@ _VALID_KEYS = {
     "hotkeys", "paste_method", "language", "model", "dictation_model",
     "compute_type", "output_dir", "mic_device", "speaker_device",
     "sample_rate", "use_system_devices", "left_click", "middle_click",
-    "suppress_llm_warning",
+    "suppress_llm_warning", "github_repo", "github_poll_interval",
+    "github_notifications",
 }
 
 
@@ -53,6 +54,3 @@ def save(cfg: dict) -> None:
     with open(_USER, "w") as f:
         json.dump(clean, f, indent=2)
         f.write("\n")
-
-    from .logger import logger
-    logger.info(f"Config saved ({len(clean)} keys)")

--- a/whisper_sync/github_status.py
+++ b/whisper_sync/github_status.py
@@ -1,0 +1,207 @@
+"""GitHub PR status polling — surfaces PR state in the tray menu.
+
+Polls `gh pr list` on a background thread and parses results.
+Degrades gracefully if `gh` CLI is not installed or not authenticated.
+No LLM cost — pure CLI + JSON parsing.
+"""
+
+import json
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+
+from .logger import logger
+
+
+@dataclass
+class PRStatus:
+    """Parsed status of a single pull request."""
+    number: int
+    title: str
+    state: str  # OPEN, CLOSED, MERGED
+    complexity: str  # low, medium, high, unknown
+    review_state: str  # pending, clean, suggestions, human-review
+    suggestion_count: int = 0
+    url: str = ""
+
+    @property
+    def display(self) -> str:
+        """One-line summary for the tray menu."""
+        status_icon = {
+            "pending": "...",
+            "clean": "ok",
+            "suggestions": f"{self.suggestion_count} suggestion{'s' if self.suggestion_count != 1 else ''}",
+            "human-review": "needs review",
+        }.get(self.review_state, "?")
+        return f"#{self.number}: {self.title[:40]} — {status_icon}"
+
+
+@dataclass
+class GitHubState:
+    """Current state of all open PRs."""
+    prs: list = field(default_factory=list)
+    last_poll: float = 0
+    error: str | None = None
+    available: bool = False  # True if gh CLI is installed and authenticated
+
+
+def check_gh_available() -> bool:
+    """Check if gh CLI is installed and authenticated."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def poll_prs(repo: str) -> list[PRStatus]:
+    """Fetch open PRs and their review status from GitHub."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--repo", repo,
+             "--json", "number,title,state,url,labels,reviews,reviewRequests",
+             "--limit", "10"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return []
+
+        prs_raw = json.loads(result.stdout)
+        parsed = []
+
+        for pr in prs_raw:
+            # Determine complexity from labels
+            labels = [l.get("name", "") for l in pr.get("labels", [])]
+            complexity = "unknown"
+            for l in labels:
+                if l.startswith("complexity:"):
+                    complexity = l.split(":")[1]
+                    break
+
+            # Determine review state from Copilot reviews
+            reviews = pr.get("reviews", [])
+            copilot_reviews = [
+                r for r in reviews
+                if r.get("author", {}).get("login", "") == "copilot-pull-request-reviewer[bot]"
+            ]
+
+            review_state = "pending"
+            suggestion_count = 0
+
+            if copilot_reviews:
+                # Check for inline comments (suggestions) via separate API call
+                suggestion_count = _count_copilot_suggestions(repo, pr["number"])
+                if suggestion_count > 0:
+                    review_state = "suggestions"
+                elif complexity == "high":
+                    review_state = "human-review"
+                else:
+                    review_state = "clean"
+            elif complexity == "high":
+                review_state = "human-review"
+
+            parsed.append(PRStatus(
+                number=pr["number"],
+                title=pr["title"],
+                state=pr["state"],
+                complexity=complexity,
+                review_state=review_state,
+                suggestion_count=suggestion_count,
+                url=pr.get("url", ""),
+            ))
+
+        return parsed
+
+    except (json.JSONDecodeError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.debug(f"GitHub poll error: {e}")
+        return []
+
+
+def _count_copilot_suggestions(repo: str, pr_number: int) -> int:
+    """Count inline review comments from Copilot on a PR."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls/{pr_number}/comments",
+             "--jq", '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length'],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return int(result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        pass
+    return 0
+
+
+class GitHubPoller:
+    """Background thread that polls GitHub PR status."""
+
+    def __init__(self, repo: str, interval: int = 300, on_change=None):
+        self.repo = repo
+        self.interval = interval
+        self.on_change = on_change  # callback(old_state, new_state)
+        self.state = GitHubState()
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def start(self):
+        """Start polling in background. No-op if already running."""
+        if self._thread and self._thread.is_alive():
+            return
+
+        # Check gh availability once at startup
+        self.state.available = check_gh_available()
+        if not self.state.available:
+            logger.info("GitHub status: gh CLI not available, feature disabled")
+            return
+
+        logger.info(f"GitHub status: polling {self.repo} every {self.interval}s")
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        """Stop the polling thread."""
+        self._stop.set()
+
+    def poll_now(self):
+        """Trigger an immediate poll (non-blocking)."""
+        threading.Thread(target=self._do_poll, daemon=True).start()
+
+    def _poll_loop(self):
+        """Main polling loop."""
+        # Initial poll immediately
+        self._do_poll()
+
+        while not self._stop.wait(timeout=self.interval):
+            self._do_poll()
+
+    def _do_poll(self):
+        """Execute a single poll and process results."""
+        new_prs = poll_prs(self.repo)
+        old_prs = self.state.prs
+
+        self.state.prs = new_prs
+        self.state.last_poll = time.time()
+        self.state.error = None
+
+        # Detect changes
+        if self.on_change and _state_changed(old_prs, new_prs):
+            try:
+                self.on_change(old_prs, new_prs)
+            except Exception as e:
+                logger.debug(f"GitHub status change callback error: {e}")
+
+
+def _state_changed(old: list[PRStatus], new: list[PRStatus]) -> bool:
+    """Check if PR state changed between polls."""
+    if len(old) != len(new):
+        return True
+    old_map = {pr.number: pr.review_state for pr in old}
+    for pr in new:
+        if pr.number not in old_map or old_map[pr.number] != pr.review_state:
+            return True
+    return False


### PR DESCRIPTION
## Summary
- New `github_status.py` module — polls `gh pr list` every 5 min
- PR status shown in tray Settings menu with review state (pending, clean, suggestions, human-review)
- Toast notifications when PRs need attention
- Degrades gracefully if `gh` not installed (feature disabled)
- Config keys: `github_repo`, `github_poll_interval`, `github_notifications`

## Implementation
Per spec: `docs/plans/2026-03-20-github-status-in-tray.md`

## Testing
- [ ] Set `github_repo` in config.json → verify PRs appear in menu
- [ ] Open a PR → verify it shows within poll interval
- [ ] `gh` not installed → verify no errors, feature disabled
- [ ] No `github_repo` configured → verify no polling, no menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)