### PR TITLE
feat: Windows toast notifications with action buttons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pystray
 Pillow
 keyboard
 pyperclip
+windows-toasts

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -39,6 +39,7 @@ from . import dictation_log
 from .streaming_wav import fix_orphan
 from .crash_diagnostics import install_excepthook, check_previous_crash
 from .flatten import flatten as flatten_transcript
+from .notifications import notify
 from .rebuild_index import rebuild_root_index
 from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
 
@@ -1731,15 +1732,37 @@ class WhisperSync:
             if not self.cfg.get("github_notifications", True):
                 return
             # Notify on actionable changes
+            repo = self.cfg.get("github_repo", "")
             old_map = {pr.number: pr.review_state for pr in old_prs}
             for pr in new_prs:
                 old_state = old_map.get(pr.number)
                 if old_state == pr.review_state:
                     continue
-                if pr.review_state == "suggestions":
-                    self._notify(f"PR #{pr.number} needs attention: {pr.suggestion_count} suggestion(s)")
+                if pr.review_state == "clean":
+                    self._notify(
+                        f"PR #{pr.number} ready to merge",
+                        pr.title,
+                        buttons=[
+                            {"label": "Merge", "action": lambda _pr=pr: self._merge_pr(repo, _pr.number)},
+                            {"label": "View on GitHub", "action": lambda _pr=pr: self._open_pr_url(_pr.url)},
+                        ],
+                    )
+                elif pr.review_state == "suggestions":
+                    self._notify(
+                        f"PR #{pr.number}: {pr.suggestion_count} suggestion(s)",
+                        pr.title,
+                        buttons=[
+                            {"label": "View on GitHub", "action": lambda _pr=pr: self._open_pr_url(_pr.url)},
+                        ],
+                    )
                 elif pr.review_state == "human-review":
-                    self._notify(f"PR #{pr.number} flagged for human review")
+                    self._notify(
+                        f"PR #{pr.number} flagged for human review",
+                        pr.title,
+                        buttons=[
+                            {"label": "View on GitHub", "action": lambda _pr=pr: self._open_pr_url(_pr.url)},
+                        ],
+                    )
 
         def _on_initial_poll(old_prs, new_prs):
             """First poll — update menu regardless of change detection."""
@@ -1761,16 +1784,9 @@ class WhisperSync:
                         break
             threading.Thread(target=_wait_first_poll, daemon=True).start()
 
-    def _notify(self, message: str):
-        """Show a Windows notification. Uses msg command (works on Win 10/11)."""
-        import subprocess as _sp
-        try:
-            _sp.Popen(
-                ["msg", "*", f"WhisperSync: {message}"],
-                creationflags=0x08000000,  # CREATE_NO_WINDOW
-            )
-        except Exception:
-            logger.debug(f"Notification failed: {message}")
+    def _notify(self, title: str, body: str = "", *, buttons=None, on_click=None):
+        """Show a Windows toast notification via windows-toasts."""
+        notify(title, body, buttons=buttons, on_click=on_click)
 
     def _github_menu_items(self) -> list:
         """Build menu items for GitHub PR status."""
@@ -1830,13 +1846,13 @@ class WhisperSync:
             )
             if result.returncode == 0:
                 logger.info(f"PR #{pr_number} merged successfully")
-                self._notify(f"PR #{pr_number} merged to main")
+                self._notify("PR merged", f"PR #{pr_number} merged to main")
                 # Refresh after merge
                 if self._github_poller:
                     self._github_poller.poll_now()
             else:
                 logger.warning(f"PR #{pr_number} merge failed: {result.stderr.strip()}")
-                self._notify(f"PR #{pr_number} merge failed")
+                self._notify("Merge failed", f"PR #{pr_number} merge failed -- check logs")
         except Exception as e:
             logger.warning(f"PR merge error: {e}")
 
@@ -2308,6 +2324,13 @@ class WhisperSync:
         if self.cfg.get("incognito"):
             logger.info("Incognito mode active -- dictation data not stored on disk")
         logger.info("Right-click tray icon for menu.")
+
+        # Startup toast notification
+        compute = self.cfg.get("compute_type", "float16")
+        notify(
+            "WhisperSync running",
+            f"Model: {dictation_model} | Compute: {compute}",
+        )
 
         # Start transcription worker subprocess (loads models in isolation)
         self.worker.start()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1836,7 +1836,12 @@ class WhisperSync:
             webbrowser.open(url)
 
     def _merge_pr(self, repo: str, pr_number: int):
-        """Merge a PR via gh CLI."""
+        """Merge a PR via gh CLI.
+
+        NOTE: This method may be called from a toast notification thread
+        (via notifications.py button callbacks). The threading is handled
+        in notifications.py -- this method itself is blocking.
+        """
         import subprocess as _sp
         try:
             result = _sp.run(

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -5,6 +5,7 @@ Handles AppUserModelID registration automatically.
 """
 
 import logging
+import threading
 
 _logger = logging.getLogger("whisper_sync.notifications")
 
@@ -53,13 +54,17 @@ def notify(title: str, body: str, *, buttons=None, on_click=None):
                 action = btn.get("action")
                 toast_btn = ToastButton(label)
                 if action:
-                    # Capture action in closure for the callback
+                    # Capture action in closure for the callback.
+                    # Run in a daemon thread so blocking callbacks (e.g. subprocess
+                    # calls like PR merge) don't block the notification system.
                     def _make_handler(fn):
                         def _handler(event: ToastActivatedEventArgs):
-                            try:
-                                fn()
-                            except Exception as exc:
-                                _logger.debug(f"Toast button callback error: {exc}")
+                            def _run():
+                                try:
+                                    fn()
+                                except Exception as exc:
+                                    _logger.exception(f"Toast button callback error: {exc}")
+                            threading.Thread(target=_run, daemon=True).start()
                         return _handler
 
                     toast_btn.on_activated = _make_handler(action)
@@ -67,10 +72,12 @@ def notify(title: str, body: str, *, buttons=None, on_click=None):
 
         if on_click:
             def _body_handler(event: ToastActivatedEventArgs):
-                try:
-                    on_click()
-                except Exception as exc:
-                    _logger.debug(f"Toast click callback error: {exc}")
+                def _run():
+                    try:
+                        on_click()
+                    except Exception as exc:
+                        _logger.exception(f"Toast click callback error: {exc}")
+                threading.Thread(target=_run, daemon=True).start()
 
             toast.on_activated = _body_handler
 

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -1,0 +1,80 @@
+"""Windows toast notifications for WhisperSync.
+
+Thin wrapper around `windows-toasts` with graceful fallback.
+Handles AppUserModelID registration automatically.
+"""
+
+import logging
+
+_logger = logging.getLogger("whisper_sync.notifications")
+
+_AUMID = "Pendentive.WhisperSync"
+_available = False
+
+try:
+    from windows_toasts import (
+        InteractableWindowsToaster,
+        Toast,
+        ToastActivatedEventArgs,
+        ToastButton,
+    )
+
+    _toaster = InteractableWindowsToaster(_AUMID)
+    _available = True
+except ImportError:
+    _logger.warning(
+        "windows-toasts not installed -- toast notifications disabled. "
+        "Install with: pip install windows-toasts"
+    )
+except Exception as exc:
+    _logger.warning(f"Toast notification init failed -- falling back to log: {exc}")
+
+
+def notify(title: str, body: str, *, buttons=None, on_click=None):
+    """Show a Windows toast notification.
+
+    Args:
+        title: Notification title (bold text).
+        body: Notification body text.
+        buttons: Optional list of dicts with "label" and "action" keys.
+            Example: [{"label": "Merge", "action": callback}]
+        on_click: Optional callback when the toast body is clicked.
+    """
+    if not _available:
+        _logger.info(f"[toast] {title}: {body}")
+        return
+
+    try:
+        toast = Toast([title, body])
+
+        if buttons:
+            for btn in buttons:
+                label = btn.get("label", "")
+                action = btn.get("action")
+                toast_btn = ToastButton(label)
+                if action:
+                    # Capture action in closure for the callback
+                    def _make_handler(fn):
+                        def _handler(event: ToastActivatedEventArgs):
+                            try:
+                                fn()
+                            except Exception as exc:
+                                _logger.debug(f"Toast button callback error: {exc}")
+                        return _handler
+
+                    toast_btn.on_activated = _make_handler(action)
+                toast.AddAction(toast_btn)
+
+        if on_click:
+            def _body_handler(event: ToastActivatedEventArgs):
+                try:
+                    on_click()
+                except Exception as exc:
+                    _logger.debug(f"Toast click callback error: {exc}")
+
+            toast.on_activated = _body_handler
+
+        _toaster.show_toast(toast)
+    except Exception as exc:
+        _logger.debug(f"Toast notification failed: {exc}")
+        _logger.info(f"[toast] {title}: {body}")


### PR DESCRIPTION
## Summary
Proper Windows Action Center notifications replacing the blocking msg dialogs.

### What's new
- Toast notifications appear bottom-right (non-blocking)
- Action buttons on PR notifications: "Merge" and "View on GitHub"
- Startup notification with model and device info
- Graceful fallback to logger.info() if windows-toasts unavailable

### PR status toasts
- PR ready to merge: [Merge] [View on GitHub] buttons
- PR has suggestions: [View on GitHub] button
- PR merged: notification only

### Technical
- Uses `windows-toasts` package (added to requirements.txt)
- AppUserModelID: Pendentive.WhisperSync
- New module: whisper_sync/notifications.py
- Replaces all msg command Popen calls in __main__.py

## Files changed
- requirements.txt -- added windows-toasts
- whisper_sync/notifications.py -- new notification wrapper
- whisper_sync/__main__.py -- replaced _notify, updated GitHub status handlers