### PR TITLE
feat: toast notification enhancements (5 of 6)

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -388,7 +388,7 @@ class WhisperSync:
                         buttons=[{"label": "Copy to Clipboard", "action": _copy_recovered}],
                     )
                 except Exception:
-                    pass  # toast is best-effort, text is already on clipboard
+                    logger.debug("Recovery toast failed", exc_info=True)
             else:
                 logger.info("Crash-recovered dictation produced no text")
             # Clean up the WAV now that text is on clipboard + in the .md log
@@ -1747,7 +1747,7 @@ class WhisperSync:
             else:
                 notify(
                     "Incognito Mode Off",
-                    "Normal logging resumed",
+                    "Dictation data will be saved to disk",
                 )
         except Exception:
             pass  # toast is best-effort

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -376,6 +376,19 @@ class WhisperSync:
                 pyperclip.copy(text)
                 dictation_log.append(text, 0)
                 logger.info(f"Crash-recovered dictation copied to clipboard: {text[:80]}...")
+                # #38: Toast with recovered text info and Copy button
+                try:
+                    _recovered_text = text
+                    def _copy_recovered(t=_recovered_text):
+                        import pyperclip as _pc
+                        _pc.copy(t)
+                    notify(
+                        "Dictation recovered",
+                        f"{len(text)} chars recovered from crash",
+                        buttons=[{"label": "Copy to Clipboard", "action": _copy_recovered}],
+                    )
+                except Exception:
+                    pass  # toast is best-effort, text is already on clipboard
             else:
                 logger.info("Crash-recovered dictation produced no text")
             # Clean up the WAV now that text is on clipboard + in the .md log
@@ -1181,6 +1194,9 @@ class WhisperSync:
                     log_transcript_preview("", speakers=_meet_segments)
 
                 # --- Speaker identification (runs for BOTH Save and Save & Summarize) ---
+                # #37 (deferred): Toast-based speaker ID was explored but the tkinter
+                # dialog provides autocomplete, confidence colors, and multi-speaker
+                # editing that ToastInputTextBox cannot replicate. Keeping tkinter flow.
                 llm_ok = self._is_claude_cli_available()
                 if llm_ok:
                     try:
@@ -1265,6 +1281,22 @@ class WhisperSync:
                     rebuild_root_index(self._output_dir())
                 except Exception as e:
                     logger.warning(f"Index rebuild failed (non-fatal): {e}")
+
+                # #36: Toast with meeting stats and Open Folder button
+                try:
+                    _toast_body = f"{_meet_words} words, {_meet_speakers} speakers"
+                    _folder_path = str(meeting_dir)
+                    def _open_meeting_folder(p=_folder_path):
+                        import subprocess as _sp
+                        _sp.Popen(["explorer", p])
+                    notify(
+                        "Meeting transcribed",
+                        _toast_body,
+                        buttons=[{"label": "Open Folder", "action": _open_meeting_folder}],
+                    )
+                except Exception as e:
+                    logger.debug(f"Meeting toast failed (non-fatal): {e}")
+
                 self._meeting_transcribing = False
                 # Flash "done" only if user is idle (not mid-dictation)
                 if self.mode is None:
@@ -1705,6 +1737,20 @@ class WhisperSync:
         state = "on" if self.cfg["incognito"] else "off"
         logger.info(f"Incognito mode: {state}")
         self._save_and_refresh()
+        # #40: Toast warning when incognito toggles
+        try:
+            if self.cfg["incognito"]:
+                notify(
+                    "Incognito Mode Active",
+                    "No data saved to disk. Dictation recovery is OFF.",
+                )
+            else:
+                notify(
+                    "Incognito Mode Off",
+                    "Normal logging resumed",
+                )
+        except Exception:
+            pass  # toast is best-effort
 
     def _refresh_menu(self):
         if self.tray:
@@ -2092,9 +2138,21 @@ class WhisperSync:
 
         logger.info(f"Switching device: {old} -> {device} ({old_resolved} -> {new_resolved})")
         self.worker.update_config(dict(self.cfg))
+        _previous_device = old
         def _do_restart():
             self.worker.restart()
             logger.info(f"Worker restarted on {new_resolved}")
+            # #39: Toast confirming device switch with Switch Back button
+            try:
+                def _switch_back(prev=_previous_device):
+                    self._set_compute_device(prev)
+                notify(
+                    "Device switched",
+                    f"Now using {new_resolved}",
+                    buttons=[{"label": "Switch Back", "action": _switch_back}],
+                )
+            except Exception:
+                pass  # toast is best-effort
         threading.Thread(target=_do_restart, daemon=True).start()
 
     def _get_device_label(self) -> str:

--- a/whisper_sync/model_status.py
+++ b/whisper_sync/model_status.py
@@ -73,7 +73,7 @@ def bootstrap_models(cfg: dict, on_large_model=None):
     if auto:
         logger.info(f"Auto-downloading base models: {', '.join(sorted(auto))}...")
         for name in sorted(auto):
-            _download_whisper_model(name)
+            _download_whisper_model(name, silent=True)
 
     # Prompt for large models
     for name in sorted(prompt):
@@ -123,8 +123,19 @@ def _bootstrap_alignment_model():
         logger.warning("Word timing will download on first use instead")
 
 
-def _download_whisper_model(model_name: str):
-    """Download a whisper model by loading it once via whisperx."""
+def _download_whisper_model(model_name: str, silent: bool = False):
+    """Download a whisper model by loading it once via whisperx.
+
+    Args:
+        model_name: Model identifier (e.g. "large-v3", "tiny").
+        silent: If True, skip toast notifications (used for auto-download of small models).
+    """
+    from .notifications import notify
+
+    size = _estimate_download_size(model_name)
+    if not silent:
+        notify("Downloading model", f"{model_name} ({size}), please wait...")
+
     try:
         import whisperx
         logger.info(f"Downloading {model_name}...")
@@ -133,8 +144,12 @@ def _download_whisper_model(model_name: str):
             download_root=str(_HF_CACHE),
         )
         logger.info(f"{model_name} cached successfully")
+        if not silent:
+            notify("Model downloaded", f"{model_name} is ready to use")
     except Exception as e:
         logger.error(f"Failed to download {model_name}: {e}")
+        if not silent:
+            notify("Download failed", f"{model_name}: {e}")
 
 
 def get_model_status(model_name: str) -> dict:
@@ -189,9 +204,14 @@ def download_model(model_name: str) -> bool:
 
     Returns True on success.
     """
+    from .notifications import notify
+
     import tempfile
     import wave
     import numpy as np
+
+    size = _estimate_download_size(model_name)
+    notify("Downloading model", f"{model_name} ({size}), please wait...")
 
     # Create a 1-second silent WAV
     tmp_wav = Path(tempfile.mktemp(suffix=".wav"))
@@ -214,8 +234,14 @@ def download_model(model_name: str) -> bool:
              "--output_dir", str(tmp_out)],
             capture_output=True, text=True, timeout=600,
         )
-        return proc.returncode == 0
+        success = proc.returncode == 0
+        if success:
+            notify("Model downloaded", f"{model_name} is ready to use")
+        else:
+            notify("Download failed", f"{model_name} download did not complete")
+        return success
     except Exception:
+        notify("Download failed", f"{model_name} download encountered an error")
         return False
     finally:
         tmp_wav.unlink(missing_ok=True)

--- a/whisper_sync/model_status.py
+++ b/whisper_sync/model_status.py
@@ -1,5 +1,6 @@
 """Check and download whisperX model + alignment dependencies."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -214,7 +215,9 @@ def download_model(model_name: str) -> bool:
     notify("Downloading model", f"{model_name} ({size}), please wait...")
 
     # Create a 1-second silent WAV
-    tmp_wav = Path(tempfile.mktemp(suffix=".wav"))
+    fd, tmp_wav_str = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    tmp_wav = Path(tmp_wav_str)
     tmp_out = Path(tempfile.mkdtemp())
     try:
         silence = np.zeros(16000, dtype=np.int16)
@@ -241,6 +244,7 @@ def download_model(model_name: str) -> bool:
             notify("Download failed", f"{model_name} download did not complete")
         return success
     except Exception:
+        logger.exception(f"Model download failed for {model_name}")
         notify("Download failed", f"{model_name} download encountered an error")
         return False
     finally:

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -114,13 +114,18 @@ def notify_progress(title: str, caption: str, *, progress=None, progress_overrid
         progress: Float 0.0-1.0 for determinate, None for indeterminate.
         progress_override: Custom status text (e.g. "3 GB remaining").
     """
-    if not _available or not _has_progress_bar:
+    if not _available:
         _logger.info(f"[toast] {title}: {caption}")
+        return
+
+    if not _has_progress_bar:
+        _logger.info("[toast] ToastProgressBar not available, falling back to plain toast")
+        notify(title, caption)
         return
 
     try:
         progress_bar = ToastProgressBar(
-            caption, title,
+            title, caption,
             progress=progress,
             progress_override=progress_override,
         )

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -11,6 +11,8 @@ _logger = logging.getLogger("whisper_sync.notifications")
 
 _AUMID = "Pendentive.WhisperSync"
 _available = False
+_has_progress_bar = False
+_has_input_text_box = False
 
 try:
     from windows_toasts import (
@@ -29,6 +31,20 @@ except ImportError:
     )
 except Exception as exc:
     _logger.warning(f"Toast notification init failed -- falling back to log: {exc}")
+
+# Optional imports for progress bar and text input support
+if _available:
+    try:
+        from windows_toasts import ToastProgressBar
+        _has_progress_bar = True
+    except ImportError:
+        pass
+
+    try:
+        from windows_toasts import ToastInputTextBox
+        _has_input_text_box = True
+    except ImportError:
+        pass
 
 
 def notify(title: str, body: str, *, buttons=None, on_click=None):
@@ -85,3 +101,36 @@ def notify(title: str, body: str, *, buttons=None, on_click=None):
     except Exception as exc:
         _logger.debug(f"Toast notification failed: {exc}")
         _logger.info(f"[toast] {title}: {body}")
+
+
+def notify_progress(title: str, caption: str, *, progress=None, progress_override=None):
+    """Show a toast with a progress bar (or indeterminate spinner).
+
+    Falls back to a plain notify() if ToastProgressBar is not available.
+
+    Args:
+        title: Notification title (bold text).
+        caption: Progress bar caption (e.g. "Downloading...").
+        progress: Float 0.0-1.0 for determinate, None for indeterminate.
+        progress_override: Custom status text (e.g. "3 GB remaining").
+    """
+    if not _available or not _has_progress_bar:
+        _logger.info(f"[toast] {title}: {caption}")
+        return
+
+    try:
+        progress_bar = ToastProgressBar(
+            caption, title,
+            progress=progress,
+            progress_override=progress_override,
+        )
+        toast = Toast(progress_bar=progress_bar)
+        _toaster.show_toast(toast)
+    except Exception as exc:
+        _logger.debug(f"Toast progress notification failed: {exc}")
+        _logger.info(f"[toast] {title}: {caption}")
+
+
+def has_input_text_box():
+    """Return True if ToastInputTextBox is available for speaker ID via toast."""
+    return _has_input_text_box


### PR DESCRIPTION
## Summary
Batch implementation of toast notification enhancements.

### Implemented
- #35: Model download start/complete toasts
- #36: Meeting transcribed toast with Open Folder button
- #38: Dictation recovery toast with Copy to Clipboard button
- #39: Device switch toast with Switch Back button
- #40: Incognito toggle toast warnings

### Deferred
- #37: Speaker ID via toast input - tkinter dialog is superior (autocomplete, multi-speaker editing, confidence display)

All toasts degrade gracefully to logger.info() on failure.

Closes #35, #36, #38, #39, #40