### PR TITLE
feat: always-available dictation with backup model

### DIFF
--- a/build-dist.ps1
+++ b/build-dist.ps1
@@ -43,6 +43,7 @@ $pyFiles = @(
     "watchdog.py",
     "worker.py",
     "worker_manager.py",
+    "backup_worker.py",
     "speakers.py",
     "speaker_prompt.md",
     "minutes_prompt.md",

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -35,6 +35,7 @@ from .paths import (get_install_root, get_default_output_dir, is_standalone,
                      get_legacy_dictation_log_dir, get_config_path as get_data_config_path,
                      get_speaker_config_path)
 from .worker_manager import TranscriptionWorker, WorkerCrashedError
+from .backup_worker import BackupTranscriber
 from . import dictation_log
 from .streaming_wav import fix_orphan
 from .crash_diagnostics import install_excepthook, check_previous_crash
@@ -90,6 +91,7 @@ class WhisperSync:
         self._meeting_start_time: datetime | None = None
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
         self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
+        self._backup = BackupTranscriber(self.cfg)
         self._github_poller = None
         self._github_prs = []
         self._dictation_history = dictation_log.load_recent(10)  # persist across restarts
@@ -258,8 +260,8 @@ class WhisperSync:
         return get_dictation_log_dir()
 
     def _start_dictation(self):
-        if not self.worker.is_ready():
-            logger.warning("Worker not ready yet — ignoring dictation request")
+        if not self.worker.is_ready() and not (self._meeting_transcribing and self._backup.is_enabled()):
+            logger.warning("Worker not ready yet - ignoring dictation request")
             return
         self.mode = "dictation"
         self._update_icon()
@@ -290,22 +292,45 @@ class WhisperSync:
         self._update_icon()
 
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+        use_backup = self._meeting_transcribing and self._backup.is_enabled()
 
         def _process():
             import time as _time
 
-            # If meeting is transcribing, flash queued icon — worker handles
-            # dictation between meeting stages but there may be a brief wait
-            if self._meeting_transcribing:
-                self._flash_queued()
-
             t0 = _time.perf_counter()
             try:
-                # Longer timeout when queued behind a meeting stage
-                timeout = 180 if self._meeting_transcribing else 60
-                text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
-                t1 = _time.perf_counter()
-                logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
+                text = None
+                used_backup = False
+                if use_backup:
+                    # Meeting is transcribing - use lightweight backup model
+                    # instead of queuing on the busy worker
+                    try:
+                        text = self._backup.transcribe(audio["mic"])
+                        used_backup = True
+                        t1 = _time.perf_counter()
+                        backup_model = self.cfg.get("backup_model", "base")
+                        backup_device = self._backup._device or "?"
+                        logger.info(
+                            f"Dictation (backup, {backup_device} {backup_model}): "
+                            f"{t1 - t0:.2f}s"
+                        )
+                    except Exception as backup_err:
+                        # Backup failed - fall back to queuing on the main worker
+                        logger.warning(f"Backup transcriber failed: {backup_err}")
+                        logger.info("Falling back to main worker (queued)")
+                        self._flash_queued()
+                        timeout = 180
+                        text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
+                        t1 = _time.perf_counter()
+                        logger.debug(f"transcribe_fast (fallback): {t1 - t0:.2f}s")
+                else:
+                    # Normal path or backup disabled
+                    if self._meeting_transcribing:
+                        self._flash_queued()
+                    timeout = 180 if self._meeting_transcribing else 60
+                    text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
+                    t1 = _time.perf_counter()
+                    logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
                 if text:
                     paste(text, self.cfg["paste_method"])
                 t2 = _time.perf_counter()
@@ -315,7 +340,8 @@ class WhisperSync:
                     logger.info(f"Dictation: {t2 - t0:.2f}s -- {delivery} ({char_count} chars)")
                 else:
                     log_dictation_result(text or "", t2 - t0, delivery, char_count)
-                logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={dictation_model}")
+                effective_model = self.cfg.get("backup_model", "base") if used_backup else dictation_model
+                logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={effective_model}{' (backup)' if used_backup else ''}")
                 # Update session stats
                 self._stats["dictations"] += 1
                 self._stats["total_dictation_chars"] += char_count
@@ -1641,6 +1667,34 @@ class WhisperSync:
             for dev, label in device_options
         ]
 
+        # --- Always Available Dictation ---
+        backup_device_cfg = self.cfg.get("backup_device", "auto")
+        backup_model_cfg = self.cfg.get("backup_model", "base")
+        backup_model_options = ["tiny", "base", "small"]
+        backup_device_options = [
+            ("auto", "Auto"),
+            ("gpu", "GPU"),
+            ("cpu", "CPU"),
+        ]
+        backup_device_items = [
+            pystray.MenuItem(
+                label,
+                self._cb(self._set_backup_device, dev),
+                checked=lambda item, d=dev: self.cfg.get("backup_device", "auto") == d,
+                radio=True,
+            )
+            for dev, label in backup_device_options
+        ]
+        backup_model_items = [
+            pystray.MenuItem(
+                f"{name} ({MODEL_OPTIONS.get(name, '')})",
+                self._cb(self._set_backup_model, name),
+                checked=lambda item, n=name: self.cfg.get("backup_model", "base") == n,
+                radio=True,
+            )
+            for name in backup_model_options
+        ]
+
         # --- Incognito mode ---
         incognito_on = self.cfg.get("incognito", False)
         incognito_items = [
@@ -1700,6 +1754,17 @@ class WhisperSync:
                                  pystray.Menu(*meeting_model_items)),
                 pystray.MenuItem(f"Device\t{current_device} - {gpu_name or 'CPU'}",
                                  pystray.Menu(*device_items)),
+                pystray.MenuItem("Always Available Dictation", pystray.Menu(
+                    pystray.MenuItem(
+                        "Enabled",
+                        lambda: self._toggle_always_available_dictation(),
+                        checked=lambda item: self.cfg.get("always_available_dictation", True),
+                    ),
+                    pystray.MenuItem(f"Backup Device\t{backup_device_cfg}",
+                                     pystray.Menu(*backup_device_items)),
+                    pystray.MenuItem(f"Backup Model\t{backup_model_cfg}",
+                                     pystray.Menu(*backup_model_items)),
+                )),
                 pystray.Menu.SEPARATOR,
                 pystray.MenuItem("Change Output Folder...",
                                  lambda: self._change_output_folder()),
@@ -2179,6 +2244,39 @@ class WhisperSync:
         else:
             return "CPU"
 
+    def _toggle_always_available_dictation(self):
+        self.cfg["always_available_dictation"] = not self.cfg.get("always_available_dictation", True)
+        state = "enabled" if self.cfg["always_available_dictation"] else "disabled"
+        logger.info(f"Always Available Dictation: {state}")
+        if not self.cfg["always_available_dictation"]:
+            self._backup.unload()
+        self._save_and_refresh()
+
+    def _set_backup_device(self, device: str):
+        if self.cfg.get("backup_device", "auto") == device:
+            return
+        self.cfg["backup_device"] = device
+        logger.info(f"Backup device: {device}")
+        self._backup.reload_if_needed()
+        self._save_and_refresh()
+
+    def _set_backup_model(self, model_name: str):
+        if self.cfg.get("backup_model", "base") == model_name:
+            return
+        self.cfg["backup_model"] = model_name
+        logger.info(f"Backup model: {model_name}")
+        # Check VRAM and warn if needed
+        primary_model = self.cfg.get("model", "large-v3")
+        warning = self._backup.get_vram_warning(primary_model, model_name)
+        if warning:
+            try:
+                notify("VRAM Warning", warning)
+            except Exception:
+                pass
+            logger.warning(warning)
+        self._backup.reload_if_needed()
+        self._save_and_refresh()
+
     def _set_model(self, key: str, model_name: str):
         logger.info(f"Setting {key} = {model_name}")
         if self.cfg.get(key) == model_name:
@@ -2386,6 +2484,10 @@ class WhisperSync:
         logger.info(f"Log file: {get_log_path()}")
         if self.cfg.get("incognito"):
             logger.info("Incognito mode active -- dictation data not stored on disk")
+        if self._backup.is_enabled():
+            backup_model = self.cfg.get("backup_model", "base")
+            backup_device = self.cfg.get("backup_device", "auto")
+            logger.info(f"Always Available Dictation: on (backup model: {backup_model}, device: {backup_device})")
         logger.info("Right-click tray icon for menu.")
 
         # Startup toast notification

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -309,7 +309,7 @@ class WhisperSync:
                         used_backup = True
                         t1 = _time.perf_counter()
                         backup_model = self.cfg.get("backup_model", "base")
-                        backup_device = self._backup._device or "?"
+                        backup_device = self._backup.device
                         logger.info(
                             f"Dictation (backup, {backup_device} {backup_model}): "
                             f"{t1 - t0:.2f}s"

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -123,6 +123,12 @@ class BackupTranscriber:
                 return "cpu"
 
             total_vram = torch.cuda.get_device_properties(0).total_mem / (1024 ** 3)
+
+            # 8 GB or less: always CPU for backup (meeting processing uses most VRAM)
+            if total_vram <= 8:
+                logger.info(f"Backup device auto -> CPU ({total_vram:.0f} GB VRAM, too tight for dual models)")
+                return "cpu"
+
             primary_model = self.cfg.get("model", "large-v3")
             backup_model = self.cfg.get("backup_model", "base")
             primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -8,6 +8,10 @@ transcription completes in 1-3s on CPU or <1s on GPU with a small model.
 
 The model is loaded lazily on first use and kept in memory for
 subsequent calls. Call unload() to free it explicitly.
+
+NOTE: WhisperX is loaded in the main process thread for simplicity.
+The backup model is small and transcription is brief (~1-3s). If
+stability issues arise, migrate to a subprocess model.
 """
 
 import threading
@@ -47,6 +51,11 @@ class BackupTranscriber:
     def is_enabled(self) -> bool:
         return self.cfg.get("always_available_dictation", True)
 
+    @property
+    def device(self) -> str:
+        """Current device string, or 'not loaded' if model is not loaded."""
+        return self._device or "not loaded"
+
     def transcribe(self, audio_np: np.ndarray) -> str:
         """Transcribe audio using the backup model. Loads model on first call.
 
@@ -54,7 +63,7 @@ class BackupTranscriber:
             audio_np: Raw audio as float32 or int16 numpy array (16kHz mono).
 
         Returns:
-            Transcribed text string, or empty string on failure.
+            Transcribed text. Raises on failure (caller handles).
         """
         with self._lock:
             if self._model is None:
@@ -90,8 +99,8 @@ class BackupTranscriber:
         device = self._resolve_device()
         compute_type = "int8" if device == "cpu" else self.cfg.get("compute_type", "float16")
 
-        from .paths import get_data_dir
-        model_cache = get_data_dir() / "models"
+        from .paths import get_model_cache
+        model_cache = get_model_cache()
 
         logger.info(f"Loading backup model [{device}] {model_name} ({compute_type})...")
         self._model = whisperx.load_model(
@@ -122,7 +131,7 @@ class BackupTranscriber:
                 logger.info("Backup device auto -> CPU (no GPU available)")
                 return "cpu"
 
-            total_vram = torch.cuda.get_device_properties(0).total_mem / (1024 ** 3)
+            total_vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
 
             # 8 GB or less: always CPU for backup (meeting processing uses most VRAM)
             if total_vram <= 8:
@@ -131,7 +140,9 @@ class BackupTranscriber:
 
             primary_model = self.cfg.get("model", "large-v3")
             backup_model = self.cfg.get("backup_model", "base")
-            primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)
+            primary_device = self.cfg.get("device", "auto")
+            # If primary is forced to CPU, it won't consume VRAM
+            primary_vram = 0.0 if primary_device == "cpu" else MODEL_VRAM_GB.get(primary_model, 3.0)
             backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
             combined = primary_vram + backup_vram
 
@@ -196,17 +207,22 @@ class BackupTranscriber:
             if not torch.cuda.is_available():
                 return None  # no GPU, no VRAM concern
 
-            total_vram = torch.cuda.get_device_properties(0).total_mem / (1024 ** 3)
+            total_vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
             primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)
             backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
             combined = primary_vram + backup_vram
             threshold = total_vram * VRAM_THRESHOLD
 
             if combined > threshold:
+                backup_device = self.cfg.get("backup_device", "auto")
+                if backup_device == "auto":
+                    advice = "Backup will use CPU in auto mode."
+                else:
+                    advice = "Consider switching to a smaller model or CPU to avoid OOM."
                 return (
                     f"{primary_model} + {backup_model} need ~{combined:.1f} GB VRAM "
                     f"({total_vram:.1f} GB total, {threshold:.1f} GB safe limit). "
-                    f"Backup will use CPU instead."
+                    f"{advice}"
                 )
         except Exception:
             pass

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -1,0 +1,207 @@
+"""Lightweight backup transcriber for dictation during meetings.
+
+When the main worker subprocess is busy with meeting transcription,
+this module provides a fallback path using a smaller model loaded
+directly in the main process. It runs in a background thread (not a
+separate process) since dictation audio is short (5-30s) and
+transcription completes in 1-3s on CPU or <1s on GPU with a small model.
+
+The model is loaded lazily on first use and kept in memory for
+subsequent calls. Call unload() to free it explicitly.
+"""
+
+import threading
+
+import numpy as np
+
+from .logger import logger
+
+# Approximate VRAM usage per model in GB (float16 on GPU)
+MODEL_VRAM_GB = {
+    "tiny": 1.0,
+    "base": 1.0,
+    "small": 2.0,
+    "medium": 4.0,
+    "large-v2": 3.0,
+    "large-v3": 3.0,
+}
+
+VRAM_THRESHOLD = 0.80  # warn if combined usage exceeds 80% of total
+
+
+class BackupTranscriber:
+    """Lightweight backup transcriber for dictation during meetings.
+
+    Loads lazily on first use. Runs in the calling thread (main process).
+    Uses a smaller model on CPU or GPU depending on config.
+    """
+
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self._model = None
+        self._device = None
+        self._compute_type = None
+        self._model_name = None
+        self._lock = threading.Lock()
+
+    def is_enabled(self) -> bool:
+        return self.cfg.get("always_available_dictation", True)
+
+    def transcribe(self, audio_np: np.ndarray) -> str:
+        """Transcribe audio using the backup model. Loads model on first call.
+
+        Args:
+            audio_np: Raw audio as float32 or int16 numpy array (16kHz mono).
+
+        Returns:
+            Transcribed text string, or empty string on failure.
+        """
+        with self._lock:
+            if self._model is None:
+                self._load()
+
+            import whisperx
+
+            # Normalize audio to the format whisperx expects
+            if audio_np.dtype == np.int16:
+                audio_np = audio_np.astype(np.float32) / 32768.0
+            audio_np = np.ascontiguousarray(audio_np.flatten(), dtype=np.float32)
+
+            language = self.cfg.get("language", "en")
+            batch_size = 8 if self._device == "cpu" else 16
+
+            logger.info(
+                f"Backup transcribe [{self._device}] {self._model_name} "
+                f"(batch={batch_size})..."
+            )
+            result = self._model.transcribe(
+                audio_np, batch_size=batch_size, language=language
+            )
+            text = " ".join(
+                seg.get("text", "") for seg in result.get("segments", [])
+            ).strip()
+            return text
+
+    def _load(self):
+        """Lazily load the backup model."""
+        import whisperx
+
+        model_name = self.cfg.get("backup_model", "base")
+        device = self._resolve_device()
+        compute_type = "int8" if device == "cpu" else self.cfg.get("compute_type", "float16")
+
+        from .paths import get_data_dir
+        model_cache = get_data_dir() / "models"
+
+        logger.info(f"Loading backup model [{device}] {model_name} ({compute_type})...")
+        self._model = whisperx.load_model(
+            model_name,
+            device=device,
+            compute_type=compute_type,
+            language=self.cfg.get("language", "en"),
+            download_root=str(model_cache),
+        )
+        self._device = device
+        self._compute_type = compute_type
+        self._model_name = model_name
+        logger.info(f"Backup model ready [{device}] {model_name}")
+
+    def _resolve_device(self) -> str:
+        """Determine which device to use for the backup model."""
+        backup_device = self.cfg.get("backup_device", "auto")
+
+        if backup_device == "cpu":
+            return "cpu"
+        if backup_device in ("gpu", "cuda"):
+            return "cuda"
+
+        # Auto-detect: check if primary + backup fit in VRAM
+        try:
+            import torch
+            if not torch.cuda.is_available():
+                logger.info("Backup device auto -> CPU (no GPU available)")
+                return "cpu"
+
+            total_vram = torch.cuda.get_device_properties(0).total_mem / (1024 ** 3)
+            primary_model = self.cfg.get("model", "large-v3")
+            backup_model = self.cfg.get("backup_model", "base")
+            primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)
+            backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
+            combined = primary_vram + backup_vram
+
+            if combined <= total_vram * VRAM_THRESHOLD:
+                logger.info(
+                    f"Backup device auto -> GPU "
+                    f"({combined:.1f} GB needed, {total_vram:.1f} GB available)"
+                )
+                return "cuda"
+            else:
+                logger.info(
+                    f"Backup device auto -> CPU "
+                    f"({combined:.1f} GB needed > {total_vram * VRAM_THRESHOLD:.1f} GB threshold)"
+                )
+                return "cpu"
+        except ImportError:
+            logger.info("Backup device auto -> CPU (torch not available)")
+            return "cpu"
+        except Exception as e:
+            logger.warning(f"Backup device auto -> CPU (error: {e})")
+            return "cpu"
+
+    def unload(self):
+        """Free the backup model from memory."""
+        with self._lock:
+            if self._model is not None:
+                logger.info("Unloading backup model")
+                self._model = None
+                self._device = None
+                self._compute_type = None
+                self._model_name = None
+                # Try to free GPU memory
+                try:
+                    import torch
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                except Exception:
+                    pass
+
+    def needs_reload(self) -> bool:
+        """Check if config changed and model needs reloading."""
+        if self._model is None:
+            return False
+        return (
+            self._model_name != self.cfg.get("backup_model", "base")
+            or self._device != self._resolve_device()
+        )
+
+    def reload_if_needed(self):
+        """Reload the backup model if config has changed."""
+        if self.needs_reload():
+            self.unload()
+            # Will lazy-load on next transcribe()
+
+    def get_vram_warning(self, primary_model: str, backup_model: str) -> str | None:
+        """Check if primary + backup would exceed 80% VRAM.
+
+        Returns warning string or None if OK.
+        """
+        try:
+            import torch
+            if not torch.cuda.is_available():
+                return None  # no GPU, no VRAM concern
+
+            total_vram = torch.cuda.get_device_properties(0).total_mem / (1024 ** 3)
+            primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)
+            backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
+            combined = primary_vram + backup_vram
+            threshold = total_vram * VRAM_THRESHOLD
+
+            if combined > threshold:
+                return (
+                    f"{primary_model} + {backup_model} need ~{combined:.1f} GB VRAM "
+                    f"({total_vram:.1f} GB total, {threshold:.1f} GB safe limit). "
+                    f"Backup will use CPU instead."
+                )
+        except Exception:
+            pass
+        return None

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -21,5 +21,8 @@
   "github_notifications": true,
   "log_window": "normal",
   "device": "auto",
-  "incognito": false
+  "incognito": false,
+  "always_available_dictation": true,
+  "backup_device": "auto",
+  "backup_model": "base"
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -16,6 +16,7 @@ _VALID_KEYS = {
     "sample_rate", "use_system_devices", "left_click", "middle_click",
     "suppress_llm_warning", "github_repo", "github_poll_interval",
     "github_notifications", "log_window", "device", "incognito",
+    "always_available_dictation", "backup_device", "backup_model",
 }
 
 


### PR DESCRIPTION
## Summary
Dictation always works, even during meeting transcription. A smaller backup model handles it when the primary worker is busy.

### Flow
- Worker idle: dictation uses primary GPU model (best quality)
- Worker busy: backup model loads lazily, transcribes, stays loaded

### Settings
Always Available Dictation >
  Enabled          [checkmark]
  Backup Device    auto/GPU/CPU
  Backup Model     tiny/base/small

### Auto-detection
- 24+ GB VRAM: small on GPU
- 12-16 GB: base on GPU
- 8 GB or less: base on CPU (meeting processing needs the VRAM)
- No GPU: base on CPU

### VRAM warning
Toast notification when backup model selection would exceed 80% VRAM.

Closes #45