### PR TITLE
fix: handle missing speaker key in channel merge

### DIFF
--- a/whisper_sync/channel_merge.py
+++ b/whisper_sync/channel_merge.py
@@ -199,7 +199,8 @@ def unify_speaker_labels(segments):
 
     for seg in segments:
         spk = seg.get("speaker", "UNKNOWN")
-        if seg["origin"] == "local" or (seg["origin"] == "ambiguous" and seg["source_channel"] == 0):
+        origin = seg.get("origin", "ambiguous")
+        if origin == "local" or (origin == "ambiguous" and seg.get("source_channel", 0) == 0):
             local_speakers.add(spk)
         else:
             remote_speakers.add(spk)
@@ -216,11 +217,12 @@ def unify_speaker_labels(segments):
     # Apply
     for seg in segments:
         spk = seg.get("speaker", "UNKNOWN")
-        origin = seg["origin"]
+        seg["speaker"] = spk  # ensure key exists
+        origin = seg.get("origin", "ambiguous")
         if origin == "ambiguous":
-            origin = "local" if seg["source_channel"] == 0 else "remote"
+            origin = "local" if seg.get("source_channel", 0) == 0 else "remote"
         key = (origin, spk)
-        seg["speaker"] = label_map.get(key, seg["speaker"])
+        seg["speaker"] = label_map.get(key, spk)
 
     return segments
 


### PR DESCRIPTION
## Summary
WhisperX segments don't always have a 'speaker' key after diarization.
The channel merge crashed with KeyError when trying to unify labels.

Fixed by using .get() with 'UNKNOWN' defaults throughout
unify_speaker_labels and the speaker collection loop.

## Root cause
Per-channel pipeline ran successfully on both channels but the merge
step crashed because some segments from WhisperX had no speaker
assigned. The balanced mono fallback caught it (working correctly).

## Test plan
- [ ] Re-run per-channel pipeline on 0324_0651 meeting
- [ ] Verify per-channel produces results (not just fallback)