### PR TITLE
fix: dictation during meetings + icon redesign

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -157,7 +157,7 @@ class WhisperSync:
         # Dictation overlay during meeting takes priority for icon display
         if self._dictation_overlay:
             if self.mode == "meeting":
-                icon, title = dictation_during_recording_icon(), "Dictating (meeting recording)..."
+                icon, title = dictation_during_recording_icon(speaker_ok=speaker_ok), "Dictating (meeting recording)..."
             elif self._meeting_transcribing:
                 icon, title = dictation_during_transcription_icon(), "Dictating (meeting transcribing)..."
             else:
@@ -420,10 +420,8 @@ class WhisperSync:
         Uses an independent AudioRecorder so the meeting recording is never
         interrupted. Transcription uses the backup model (CPU or secondary GPU).
         """
-        if not self._backup.is_enabled():
-            logger.info("Overlay dictation unavailable - backup transcriber not enabled")
-            notify("Dictation unavailable", "Backup model not configured")
-            return
+        # Note: always_available_dictation config flag already gates the call to
+        # this method in toggle_dictation(), so no need to re-check is_enabled() here.
 
         meeting_state = "recording" if self.mode == "meeting" else "transcribing"
         backup_model = self.cfg.get("backup_model", "base")
@@ -516,7 +514,32 @@ class WhisperSync:
                     if text:
                         paste(text, self.cfg["paste_method"])
                     t1 = _time.perf_counter()
-                    logger.info(f"Overlay dictation fallback: {t1 - t0:.2f}s, {len(text or '')} chars")
+                    duration = t1 - t0
+                    char_count = len(text or "")
+                    logger.info(f"Overlay dictation fallback: {duration:.2f}s, {char_count} chars")
+
+                    # Post-dictation bookkeeping (same as the normal overlay path)
+                    self._stats["dictations"] += 1
+                    self._stats["total_dictation_chars"] += char_count
+                    self._stats["total_dictation_time"] += duration
+
+                    incognito = self.cfg.get("incognito", False)
+                    if text and not incognito:
+                        dictation_log.append(text, duration)
+                        self._dictation_history.append({
+                            "text": text,
+                            "timestamp": datetime.now().strftime("%H:%M"),
+                            "chars": len(text),
+                        })
+                        if len(self._dictation_history) > 10:
+                            self._dictation_history = self._dictation_history[-10:]
+                        self._refresh_menu()
+
+                    delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
+                    if incognito:
+                        logger.info(f"Overlay dictation fallback: {duration:.2f}s - {delivery} ({char_count} chars)")
+                    else:
+                        log_dictation_result(text or "", duration, delivery, char_count)
                 except Exception as fallback_err:
                     logger.error(f"Overlay dictation fallback also failed: {fallback_err}")
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -25,7 +25,9 @@ import pystray
 
 from . import config
 from .capture import AudioRecorder, get_default_devices, get_host_apis, list_devices, save_wav, save_stereo_wav
-from .icons import idle_icon, recording_icon, dictation_icon, saving_icon, transcribing_icon, done_icon, queued_icon, error_icon
+from .icons import (idle_icon, recording_icon, dictation_icon, saving_icon,
+                     transcribing_icon, done_icon, queued_icon, error_icon,
+                     dictation_during_recording_icon, dictation_during_transcription_icon)
 from .logger import logger, get_log_path, set_console_level, log_dictation_result, log_meeting_result, log_transcript_preview
 from .model_status import get_model_status, download_model, bootstrap_models
 from .paste import paste
@@ -92,6 +94,8 @@ class WhisperSync:
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
         self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
         self._backup = BackupTranscriber(self.cfg)
+        self._dictation_overlay = False  # True while dictation runs during a meeting
+        self._overlay_recorder = None    # Separate AudioRecorder for dictation during meetings
         self._github_poller = None
         self._github_prs = []
         self._dictation_history = dictation_log.load_recent(10)  # persist across restarts
@@ -149,13 +153,26 @@ class WhisperSync:
             return
         # For meeting mode, check speaker loopback health for outer ring
         speaker_ok = getattr(self.recorder, "speaker_loopback_active", True) if hasattr(self, "recorder") else True
+
+        # Dictation overlay during meeting takes priority for icon display
+        if self._dictation_overlay:
+            if self.mode == "meeting":
+                icon, title = dictation_during_recording_icon(), "Dictating (meeting recording)..."
+            elif self._meeting_transcribing:
+                icon, title = dictation_during_transcription_icon(), "Dictating (meeting transcribing)..."
+            else:
+                icon, title = dictation_icon(), "Dictating..."
+            self.tray.icon = icon
+            self.tray.title = f"WhisperSync: {title}"
+            return
+
         icons = {
             "meeting": (recording_icon(speaker_ok=speaker_ok), "Recording meeting..."),
             "dictation": (dictation_icon(), "Dictating..."),
             "saving": (saving_icon(), "Saving audio..."),
             "transcribing": (transcribing_icon(), "Transcribing..."),
             "done": (done_icon(), "Done!"),
-            "error": (error_icon(), "Error -- check console"),
+            "error": (error_icon(), "Error - check console"),
         }
         if self.mode:
             icon, title = icons[self.mode]
@@ -176,7 +193,7 @@ class WhisperSync:
 
     def _on_left_click(self):
         # Left-click while dictating = discard (stop recording, throw away audio)
-        if self.mode == "dictation":
+        if self.mode == "dictation" or self._dictation_overlay:
             self._discard_dictation()
             return
         self._dispatch_action(self.cfg.get("left_click", "meeting"))
@@ -251,8 +268,22 @@ class WhisperSync:
 
     def toggle_dictation(self):
         with self._lock:
+            # Handle overlay dictation during meetings
+            if self._dictation_overlay:
+                self._stop_overlay_dictation()
+                return
+
             if self.mode == "dictation":
                 self._stop_dictation()
+            elif self.mode == "meeting" or (self.mode is None and self._meeting_transcribing):
+                # Dictation during meeting recording or meeting transcription
+                if self.cfg.get("always_available_dictation", True):
+                    self._start_overlay_dictation()
+                else:
+                    logger.info("Dictation unavailable during meeting (always_available_dictation disabled)")
+                    notify("Dictation unavailable", "Enable always-available dictation in settings")
+            elif self.mode == "saving":
+                logger.debug("Dictation ignored - meeting is saving")
             elif self._can_record():
                 self._start_dictation()
 
@@ -380,6 +411,116 @@ class WhisperSync:
                 self._schedule_idle(2)
 
         threading.Thread(target=_process, daemon=True).start()
+
+    # --- Overlay dictation (dictation during meeting recording/transcription) ---
+
+    def _start_overlay_dictation(self):
+        """Start dictation using a separate audio stream while meeting continues.
+
+        Uses an independent AudioRecorder so the meeting recording is never
+        interrupted. Transcription uses the backup model (CPU or secondary GPU).
+        """
+        if not self._backup.is_enabled():
+            logger.info("Overlay dictation unavailable - backup transcriber not enabled")
+            notify("Dictation unavailable", "Backup model not configured")
+            return
+
+        meeting_state = "recording" if self.mode == "meeting" else "transcribing"
+        backup_model = self.cfg.get("backup_model", "base")
+        backup_device = self._backup.device
+        logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)")
+        logger.info(f"Backup model: {backup_model} on {backup_device}")
+
+        # Create a separate recorder for dictation audio (mic only)
+        self._overlay_recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
+        mic = self.cfg.get("mic_device")
+        if self.cfg.get("use_system_devices", True):
+            mic = None
+        self._overlay_recorder.start(mic_device=mic)
+        self._dictation_overlay = True
+        logger.info("Dictation during meeting: recording started")
+        self._update_icon()
+
+    def _stop_overlay_dictation(self):
+        """Stop overlay dictation, transcribe with backup model, paste result."""
+        if not self._overlay_recorder:
+            self._dictation_overlay = False
+            self._update_icon()
+            return
+
+        audio = self._overlay_recorder.stop()
+        self._dictation_overlay = False
+        self._update_icon()
+
+        if "mic" not in audio:
+            logger.debug("Overlay dictation stopped - no audio captured")
+            self._overlay_recorder = None
+            return
+
+        overlay_audio = audio["mic"]
+        self._overlay_recorder = None
+
+        logger.info("Dictation during meeting: transcribing...")
+
+        def _process_overlay():
+            import time as _time
+
+            t0 = _time.perf_counter()
+            try:
+                text = self._backup.transcribe(overlay_audio)
+                t1 = _time.perf_counter()
+                duration = t1 - t0
+                char_count = len(text) if text else 0
+                backup_model = self.cfg.get("backup_model", "base")
+                backup_device = self._backup.device
+                logger.info(
+                    f"Dictation during meeting: {duration:.1f}s, {char_count} chars "
+                    f"(backup {backup_device} {backup_model})"
+                )
+                if text:
+                    paste(text, self.cfg["paste_method"])
+
+                # Update session stats
+                self._stats["dictations"] += 1
+                self._stats["total_dictation_chars"] += char_count
+                self._stats["total_dictation_time"] += duration
+
+                incognito = self.cfg.get("incognito", False)
+                if text and not incognito:
+                    dictation_log.append(text, duration)
+                    self._dictation_history.append({
+                        "text": text,
+                        "timestamp": datetime.now().strftime("%H:%M"),
+                        "chars": len(text),
+                    })
+                    if len(self._dictation_history) > 10:
+                        self._dictation_history = self._dictation_history[-10:]
+                    self._refresh_menu()
+
+                delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
+                if incognito:
+                    logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)")
+                else:
+                    log_dictation_result(text or "", duration, delivery, char_count)
+
+            except Exception as e:
+                logger.error(f"Overlay dictation error: {e}")
+                import traceback
+                logger.debug(traceback.format_exc())
+                # Fall back to queuing on main worker if backup fails
+                try:
+                    logger.info("Falling back to main worker for overlay dictation")
+                    dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+                    timeout = 180
+                    text = self.worker.transcribe_fast(overlay_audio, model_override=dictation_model, timeout=timeout)
+                    if text:
+                        paste(text, self.cfg["paste_method"])
+                    t1 = _time.perf_counter()
+                    logger.info(f"Overlay dictation fallback: {t1 - t0:.2f}s, {len(text or '')} chars")
+                except Exception as fallback_err:
+                    logger.error(f"Overlay dictation fallback also failed: {fallback_err}")
+
+        threading.Thread(target=_process_overlay, daemon=True).start()
 
     def _recover_dictation(self, wav_path: str):
         """Transcribe a recovered dictation WAV from a previous crash.
@@ -537,8 +678,17 @@ class WhisperSync:
         return "".join(c if c.isalnum() or c in " -_" else "" for c in name).strip().replace(" ", "-")
 
     def _discard_dictation(self):
-        """Discard current dictation — stop recording, throw away audio, return to idle."""
+        """Discard current dictation - stop recording, throw away audio, return to idle."""
         with self._lock:
+            # Handle overlay dictation discard
+            if self._dictation_overlay and self._overlay_recorder:
+                self._overlay_recorder.stop()
+                self._overlay_recorder = None
+                self._dictation_overlay = False
+                logger.info("Overlay dictation discarded (left-click)")
+                self._update_icon()
+                return
+
             if self.mode != "dictation":
                 return
             self.recorder.stop()  # stop recording, discard the audio

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -93,7 +93,6 @@ class BackupTranscriber:
 
     def _load(self):
         """Lazily load the backup model."""
-        import os
         import whisperx
 
         model_name = self.cfg.get("backup_model", "base")
@@ -103,8 +102,7 @@ class BackupTranscriber:
         from .paths import get_model_cache
         model_cache = get_model_cache()
 
-        logger.info(f"Loading backup model [{device}] {model_name} ({compute_type})...")
-        logger.info(f"Backup worker spawned (pid={os.getpid()})")
+        logger.info(f"Backup model loading [{device}] {model_name} ({compute_type})...")
         self._model = whisperx.load_model(
             model_name,
             device=device,
@@ -115,7 +113,6 @@ class BackupTranscriber:
         self._device = device
         self._compute_type = compute_type
         self._model_name = model_name
-        logger.info(f"Backup worker ready")
         logger.info(f"Backup model ready [{device}] {model_name}")
 
     def _resolve_device(self) -> str:

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -93,6 +93,7 @@ class BackupTranscriber:
 
     def _load(self):
         """Lazily load the backup model."""
+        import os
         import whisperx
 
         model_name = self.cfg.get("backup_model", "base")
@@ -103,6 +104,7 @@ class BackupTranscriber:
         model_cache = get_model_cache()
 
         logger.info(f"Loading backup model [{device}] {model_name} ({compute_type})...")
+        logger.info(f"Backup worker spawned (pid={os.getpid()})")
         self._model = whisperx.load_model(
             model_name,
             device=device,
@@ -113,6 +115,7 @@ class BackupTranscriber:
         self._device = device
         self._compute_type = compute_type
         self._model_name = model_name
+        logger.info(f"Backup worker ready")
         logger.info(f"Backup model ready [{device}] {model_name}")
 
     def _resolve_device(self) -> str:

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -6,11 +6,14 @@ from PIL import Image, ImageDraw
 # --- Color constants ---
 
 COLOR_IDLE = "#808080"
-COLOR_RECORDING = "#FF4444"
-COLOR_RECORDING_FAIL = "#FFAA00"  # Channel failing during recording
-COLOR_TRANSCRIBING = "#FFA500"
+COLOR_RECORDING_OUTER = "#CC3333"       # Dark red - meeting outer ring
+COLOR_RECORDING_INNER = "#FF4444"       # Lighter red - meeting inner circle
+COLOR_RECORDING_FAIL = "#FFAA00"        # Yellow - channel failing during recording
+COLOR_TRANSCRIBING_OUTER = "#CC8800"    # Dark amber - meeting transcribing outer
+COLOR_TRANSCRIBING_INNER = "#FFA500"    # Lighter amber - meeting transcribing inner
 COLOR_DONE = "#44FF44"
-COLOR_DICTATION = "#44AAFF"
+COLOR_DICTATION_INNER = "#4488FF"       # Blue - mic active
+COLOR_DICTATION_OUTER = "#CCCCCC"       # White/light gray - dictation outer ring
 COLOR_SAVING = "#FFB833"
 COLOR_SUMMARIZING = "#AA44FF"
 COLOR_QUEUED = "#FF8800"
@@ -33,7 +36,7 @@ def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image
     ring_width = 3
     gap = 2
 
-    # Outer ring -- draw filled ellipse then punch out interior
+    # Outer ring - draw filled ellipse then punch out interior
     outer_r = size - margin  # right/bottom edge
     draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
 
@@ -57,8 +60,51 @@ def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image
     return img
 
 
+def _make_overlay_icon(outer_color: str, size: int = 64) -> Image.Image:
+    """Generate a 64x64 icon with the outer ring in one color and a small blue dot centered.
+
+    Used for dictation-during-meeting: outer ring shows meeting state,
+    small centered blue dot shows dictation is active.
+
+    The blue dot is ~40% the size of the normal inner circle.
+    """
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    margin = 2
+    ring_width = 3
+    gap = 2
+
+    # Outer ring - same as _make_dual_icon
+    outer_r = size - margin
+    draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
+
+    inner_of_ring = margin + ring_width
+    draw.ellipse(
+        [inner_of_ring, inner_of_ring,
+         outer_r - 1 - ring_width, outer_r - 1 - ring_width],
+        fill=(0, 0, 0, 0),
+    )
+
+    # Small blue dot (~40% of the inner circle area)
+    inner_start = margin + ring_width + gap
+    inner_end = size - margin - ring_width - gap
+    inner_radius = (inner_end - inner_start) / 2
+    dot_radius = inner_radius * 0.4
+    center = size / 2
+    dot_start = int(center - dot_radius)
+    dot_end = int(center + dot_radius)
+    if dot_end > dot_start:
+        draw.ellipse(
+            [dot_start, dot_start, dot_end, dot_end],
+            fill=COLOR_DICTATION_INNER,
+        )
+
+    return img
+
+
 def _circle_icon(color: str, size: int = 64) -> Image.Image:
-    """Legacy single-color circle -- both rings same color."""
+    """Legacy single-color circle - both rings same color."""
     return _make_dual_icon(color, color, size)
 
 
@@ -72,14 +118,32 @@ def idle_icon() -> Image.Image:
 
 
 def recording_icon(speaker_ok: bool = True) -> Image.Image:
-    """Meeting recording -- outer ring reflects speaker loopback status."""
-    outer = COLOR_RECORDING if speaker_ok else COLOR_RECORDING_FAIL
-    return _make_dual_icon(COLOR_RECORDING, outer)
+    """Meeting recording - outer ring reflects speaker loopback status."""
+    outer = COLOR_RECORDING_OUTER if speaker_ok else COLOR_RECORDING_FAIL
+    return _make_dual_icon(COLOR_RECORDING_INNER, outer)
 
 
 def dictation_icon() -> Image.Image:
-    """Dictation -- mic active (inner blue), no speaker needed (outer gray)."""
-    return _make_dual_icon(COLOR_DICTATION, COLOR_IDLE)
+    """Dictation - mic active (inner blue), outer white/gray."""
+    return _make_dual_icon(COLOR_DICTATION_INNER, COLOR_DICTATION_OUTER)
+
+
+def dictation_during_recording_icon() -> Image.Image:
+    """Dictation active during meeting recording.
+
+    Outer ring = dark red (meeting still recording).
+    Inner = small blue dot (dictation active).
+    """
+    return _make_overlay_icon(COLOR_RECORDING_OUTER)
+
+
+def dictation_during_transcription_icon() -> Image.Image:
+    """Dictation active during meeting transcription.
+
+    Outer ring = dark amber (meeting transcribing).
+    Inner = small blue dot (dictation active).
+    """
+    return _make_overlay_icon(COLOR_TRANSCRIBING_OUTER)
 
 
 def saving_icon() -> Image.Image:
@@ -87,7 +151,7 @@ def saving_icon() -> Image.Image:
 
 
 def transcribing_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_TRANSCRIBING, COLOR_TRANSCRIBING)
+    return _make_dual_icon(COLOR_TRANSCRIBING_INNER, COLOR_TRANSCRIBING_OUTER)
 
 
 def done_icon() -> Image.Image:

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -128,13 +128,15 @@ def dictation_icon() -> Image.Image:
     return _make_dual_icon(COLOR_DICTATION_INNER, COLOR_DICTATION_OUTER)
 
 
-def dictation_during_recording_icon() -> Image.Image:
+def dictation_during_recording_icon(speaker_ok: bool = True) -> Image.Image:
     """Dictation active during meeting recording.
 
-    Outer ring = dark red (meeting still recording).
+    Outer ring = dark red (meeting still recording), or yellow if speaker
+    loopback is unhealthy.
     Inner = small blue dot (dictation active).
     """
-    return _make_overlay_icon(COLOR_RECORDING_OUTER)
+    outer = COLOR_RECORDING_OUTER if speaker_ok else COLOR_RECORDING_FAIL
+    return _make_overlay_icon(outer)
 
 
 def dictation_during_transcription_icon() -> Image.Image:


### PR DESCRIPTION
## Summary
Dictation now works during meeting recording and transcription.

### Root cause
`toggle_dictation()` checked `_can_record()` which blocked during meeting states. Dictation hotkey was silently dropped.

### Fix
- Overlay dictation: separate `AudioRecorder` (mic only) so meeting recording is never interrupted
- Routes through backup model (CPU/smaller GPU model) for transcription
- Falls back to main worker queue if backup unavailable

### Icon changes
- Outer ring widened to 3px for visibility
- Meeting recording: dark red outer (#CC3333), lighter red inner (#FF4444)
- Dictation only: blue inner (#4488FF), white outer (#CCCCCC)
- Dictation during meeting: meeting color outer + small blue center dot (~40% size)
- Meeting transcribing: dark amber outer, lighter amber inner
- Yellow = caution (speaker/mic failure)

### Logging (detailed tier)
- Backup worker spawn/ready
- Overlay dictation start/stop/transcribe/result
- Backup model and device info

## Test plan
- [ ] Start meeting recording, then press Ctrl+Shift+Space for dictation
- [ ] Verify meeting recording continues uninterrupted
- [ ] Verify dictation text pastes correctly
- [ ] Verify icon shows small blue dot during overlay dictation
- [ ] Try dictation during meeting transcription (post-recording)
- [ ] Try dictation with always_available_dictation disabled (should show notification)