### PR TITLE
fix: backup dictation VRAM, debounce, three-ring icon, device label

### DIFF
--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -30,6 +30,14 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 - Communication uses request/response queues with `request_id` for correlation.
 - Between meeting pipeline stages, `_drain_priority()` processes pending dictation requests, allowing dictation during meeting transcription.
 
+## Backup Model Lifecycle
+
+- The backup model pre-loads on meeting start (background thread, CPU, ~1s load time).
+- Once loaded, the backup model stays in memory until the app closes. There is no unload timer.
+- `backup_device` is always CPU unless explicitly overridden to GPU in config.
+- Default backup model selection by VRAM tier: `small` (8+ GB VRAM), `tiny` (< 8 GB VRAM), `base` (no GPU).
+- Model merging: dictation and meeting share the primary model instance. The backup model is always a separate instance.
+
 ## Critical Rules
 
 - **Never change the multiprocessing context from "spawn"** - required for CUDA isolation.

--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -35,7 +35,7 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 - The backup model pre-loads on meeting start (background thread, CPU, ~1s load time).
 - Once loaded, the backup model stays in memory until the app closes. There is no unload timer.
 - `backup_device` is always CPU unless explicitly overridden to GPU in config.
-- Default backup model selection by VRAM tier: `small` (8+ GB VRAM), `tiny` (< 8 GB VRAM), `base` (no GPU).
+- Default backup_model is `base`. The installer can override to `small` or `tiny` based on detected VRAM during installation. No runtime auto-selection.
 - Model merging: dictation and meeting share the primary model instance. The backup model is always a separate instance.
 
 ## Critical Rules

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -70,3 +70,14 @@ No automated test suite exists. All verification is manual.
 3. Verify: main process detects the crash and shows an error state
 4. Verify: worker respawns automatically
 5. Start another dictation and verify it works
+
+## Backup Dictation Test
+
+1. Start a meeting recording (Ctrl+Shift+M)
+2. Press Ctrl+Shift+Space to trigger dictation
+3. Verify: dictation works on CPU (backup model)
+4. Verify: meeting recording continues uninterrupted during and after dictation
+5. Verify: yellow double-flash appears on rapid hotkey presses during model load
+6. Verify: Settings > Device label shows correct device (CPU when CPU selected)
+7. Verify: tray icon shows three rings with blue inner dot during meeting + dictation
+8. Verify: log output contains "Backup model loading [cpu]" confirming CPU device

--- a/.claude/rules/ui-patterns.md
+++ b/.claude/rules/ui-patterns.md
@@ -65,3 +65,27 @@ Four tiers controlled by the `log_window` config key:
 - **verbose** - full debug output, prefixed with `[WhisperSync]`
 
 File logging always captures DEBUG level regardless of console tier. Log files rotate daily.
+
+## Tray Icon Anatomy (Three-Ring Model)
+
+The tray icon uses a layered three-ring design:
+
+- **Outer ring** (3px): reflects speaker/channel health status.
+- **Middle circle**: primary indicator for mic status and recording state.
+- **Inner dot** (4px, optional): dictation overlay indicator. Appears ONLY during overlay dictation (dictation while a meeting is active).
+
+### Color State Table
+
+| State | Outer Ring | Middle Circle | Inner Dot |
+|-------|-----------|---------------|-----------|
+| Idle | Gray | Gray | None |
+| Recording (meeting) | Green | Red | None |
+| Dictation (standalone) | Gray | Blue | None |
+| Dictation (overlay, during meeting) | Green | Red | Blue |
+| Transcribing | Gray | Yellow | None |
+| Done (flash) | Gray | Green | None |
+| Error | Gray | Red (pulse) | None |
+
+### Yellow Double-Flash Convention
+
+The yellow double-flash is the universal "loading/queuing" signal. Timing: 150ms on, 150ms off, 150ms on. Used when a hotkey press is received while a model is still loading or a previous operation is queued.

--- a/.claude/rules/ui-patterns.md
+++ b/.claude/rules/ui-patterns.md
@@ -78,13 +78,18 @@ The tray icon uses a layered three-ring design:
 
 | State | Outer Ring | Middle Circle | Inner Dot |
 |-------|-----------|---------------|-----------|
-| Idle | Gray | Gray | None |
-| Recording (meeting) | Green | Red | None |
-| Dictation (standalone) | Gray | Blue | None |
-| Dictation (overlay, during meeting) | Green | Red | Blue |
-| Transcribing | Gray | Yellow | None |
-| Done (flash) | Gray | Green | None |
-| Error | Gray | Red (pulse) | None |
+| Idle | Gray (#808080) | Gray (#808080) | None |
+| Recording (meeting) | Dark red (#CC3333) | Light red (#FF4444) | None |
+| Recording (speaker fail) | Yellow (#FFAA00) | Light red (#FF4444) | None |
+| Dictation (standalone) | White/light gray (#CCCCCC) | Blue (#4488FF) | None |
+| Dictation (overlay, during meeting) | Dark red (#CC3333) | Light red (#FF4444) | Blue (#4488FF) |
+| Dictation (overlay, during transcription) | Dark amber (#CC8800) | Amber (#FFAA00) | Blue (#4488FF) |
+| Transcribing | Dark amber (#CC8800) | Amber (#FFAA00) | None |
+| Saving | Dark amber (#CC8800) | Amber (#FFAA00) | None |
+| Summarizing | Dark purple (#9944CC) | Light purple (#CC66FF) | None |
+| Queued | Dark orange (#CC6600) | Orange (#FF8800) | None |
+| Done | Dark green (#44CC44) | Light green (#66FF66) | None |
+| Error | Dark magenta (#CC44CC) | Light magenta (#FF66FF) | None |
 
 ### Yellow Double-Flash Convention
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -183,6 +183,21 @@ class WhisperSync:
         self.tray.icon = icon
         self.tray.title = f"WhisperSync: {title}"
 
+    def _yellow_flash(self):
+        """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
+        def _flash():
+            from .icons import yellow_flash_icon
+            try:
+                original = self.tray.icon
+                for _ in range(2):
+                    self.tray.icon = yellow_flash_icon()
+                    import time; time.sleep(0.15)
+                    self.tray.icon = original
+                    time.sleep(0.15)
+            except Exception:
+                pass  # tray may not be ready
+        threading.Thread(target=_flash, daemon=True).start()
+
     # --- Click dispatch ---
 
     def _dispatch_action(self, action: str):
@@ -278,6 +293,10 @@ class WhisperSync:
             elif self.mode == "meeting" or (self.mode is None and self._meeting_transcribing):
                 # Dictation during meeting recording or meeting transcription
                 if self.cfg.get("always_available_dictation", True):
+                    if self._backup.is_loading:
+                        logger.debug("Backup model still loading, triggering yellow flash")
+                        self._yellow_flash()
+                        return
                     self._start_overlay_dictation()
                 else:
                     logger.info("Dictation unavailable during meeting (always_available_dictation disabled)")
@@ -750,6 +769,8 @@ class WhisperSync:
         temp = self._meeting_temp_dir()
         mic_temp = temp / "mic-temp.wav"
         self.recorder.start_streaming(mic_temp, disk_only=True)
+        if self.cfg.get("always_available_dictation", True):
+            self._backup.preload()
 
     _ABORT = object()  # Sentinel for abort
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -185,9 +185,12 @@ class WhisperSync:
 
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
+        if getattr(self, '_flashing', False):
+            return
+        self._flashing = True
         def _flash():
-            from .icons import yellow_flash_icon
             try:
+                from .icons import yellow_flash_icon
                 original = self.tray.icon
                 for _ in range(2):
                     self.tray.icon = yellow_flash_icon()
@@ -196,6 +199,8 @@ class WhisperSync:
                     time.sleep(0.15)
             except Exception:
                 pass  # tray may not be ready
+            finally:
+                self._flashing = False
         threading.Thread(target=_flash, daemon=True).start()
 
     # --- Click dispatch ---
@@ -1977,7 +1982,7 @@ class WhisperSync:
                                  pystray.Menu(*dictation_model_items)),
                 pystray.MenuItem(f"Meeting Model\t{self.cfg['model']}",
                                  pystray.Menu(*meeting_model_items)),
-                pystray.MenuItem(f"Device\t{current_device} - {gpu_name or 'CPU'}",
+                pystray.MenuItem(f"Device\t{self._get_device_label()}",
                                  pystray.Menu(*device_items)),
                 pystray.MenuItem("Always Available Dictation", pystray.Menu(
                     pystray.MenuItem(

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2448,28 +2448,26 @@ class WhisperSync:
         threading.Thread(target=_do_restart, daemon=True).start()
 
     def _get_device_label(self) -> str:
-        """Return display string for current device setting."""
-        device = self.cfg.get("device", "auto")
-        if device == "auto":
+        """Return display string for the active resolved device."""
+        device_setting = self.cfg.get("device", "auto")
+        if device_setting == "cpu":
+            return "CPU"
+        elif device_setting in ("gpu", "cuda"):
             try:
                 from .transcribe import get_gpu_name
-                gpu = get_gpu_name()
-                if gpu:
-                    return f"Auto ({gpu})"
-                return "Auto (CPU -- no GPU detected)"
-            except Exception:
-                return "Auto"
-        elif device in ("gpu", "cuda"):
-            try:
-                from .transcribe import get_gpu_name
-                gpu = get_gpu_name()
-                if gpu:
-                    return f"GPU ({gpu})"
-                return "GPU (not available)"
+                gpu_name = get_gpu_name()
+                return gpu_name if gpu_name else "GPU"
             except Exception:
                 return "GPU"
-        else:
-            return "CPU"
+        else:  # auto
+            try:
+                from .transcribe import get_gpu_name
+                gpu_name = get_gpu_name()
+                if gpu_name:
+                    return f"Auto ({gpu_name})"
+                return "Auto (CPU)"
+            except Exception:
+                return "Auto"
 
     def _toggle_always_available_dictation(self):
         self.cfg["always_available_dictation"] = not self.cfg.get("always_available_dictation", True)

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -64,7 +64,9 @@ class BackupTranscriber:
         def _do_preload():
             self._loading = True
             try:
-                self._load()
+                with self._lock:
+                    if self._model is None:
+                        self._load()
             finally:
                 self._loading = False
 
@@ -140,7 +142,7 @@ class BackupTranscriber:
 
         if backup_device in ("gpu", "cuda"):
             main_device = self.cfg.get("device", "auto")
-            if main_device != "cpu":
+            if main_device in ("gpu", "cuda"):
                 logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
             return "cuda"
 

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -116,54 +116,16 @@ class BackupTranscriber:
         logger.info(f"Backup model ready [{device}] {model_name}")
 
     def _resolve_device(self) -> str:
-        """Determine which device to use for the backup model."""
-        backup_device = self.cfg.get("backup_device", "auto")
+        """Determine device for backup model. Always CPU unless explicitly overridden."""
+        backup_device = self.cfg.get("backup_device", "cpu")
 
-        if backup_device == "cpu":
-            return "cpu"
         if backup_device in ("gpu", "cuda"):
+            main_device = self.cfg.get("device", "auto")
+            if main_device != "cpu":
+                logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
             return "cuda"
 
-        # Auto-detect: check if primary + backup fit in VRAM
-        try:
-            import torch
-            if not torch.cuda.is_available():
-                logger.info("Backup device auto -> CPU (no GPU available)")
-                return "cpu"
-
-            total_vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
-
-            # 8 GB or less: always CPU for backup (meeting processing uses most VRAM)
-            if total_vram <= 8:
-                logger.info(f"Backup device auto -> CPU ({total_vram:.0f} GB VRAM, too tight for dual models)")
-                return "cpu"
-
-            primary_model = self.cfg.get("model", "large-v3")
-            backup_model = self.cfg.get("backup_model", "base")
-            primary_device = self.cfg.get("device", "auto")
-            # If primary is forced to CPU, it won't consume VRAM
-            primary_vram = 0.0 if primary_device == "cpu" else MODEL_VRAM_GB.get(primary_model, 3.0)
-            backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
-            combined = primary_vram + backup_vram
-
-            if combined <= total_vram * VRAM_THRESHOLD:
-                logger.info(
-                    f"Backup device auto -> GPU "
-                    f"({combined:.1f} GB needed, {total_vram:.1f} GB available)"
-                )
-                return "cuda"
-            else:
-                logger.info(
-                    f"Backup device auto -> CPU "
-                    f"({combined:.1f} GB needed > {total_vram * VRAM_THRESHOLD:.1f} GB threshold)"
-                )
-                return "cpu"
-        except ImportError:
-            logger.info("Backup device auto -> CPU (torch not available)")
-            return "cpu"
-        except Exception as e:
-            logger.warning(f"Backup device auto -> CPU (error: {e})")
-            return "cpu"
+        return "cpu"
 
     def unload(self):
         """Free the backup model from memory."""

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -46,10 +46,29 @@ class BackupTranscriber:
         self._device = None
         self._compute_type = None
         self._model_name = None
+        self._loading = False
         self._lock = threading.Lock()
+
+    @property
+    def is_loading(self) -> bool:
+        return self._loading
 
     def is_enabled(self) -> bool:
         return self.cfg.get("always_available_dictation", True)
+
+    def preload(self):
+        """Pre-load backup model in background thread. Called when meeting starts."""
+        if self._model is not None or self._loading:
+            return
+
+        def _do_preload():
+            self._loading = True
+            try:
+                self._load()
+            finally:
+                self._loading = False
+
+        threading.Thread(target=_do_preload, daemon=True, name="backup-preload").start()
 
     @property
     def device(self) -> str:

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -23,6 +23,6 @@
   "device": "auto",
   "incognito": false,
   "always_available_dictation": true,
-  "backup_device": "auto",
+  "backup_device": "cpu",
   "backup_model": "base"
 }

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -10,24 +10,29 @@ COLOR_RECORDING_OUTER = "#CC3333"       # Dark red - meeting outer ring
 COLOR_RECORDING_INNER = "#FF4444"       # Lighter red - meeting inner circle
 COLOR_RECORDING_FAIL = "#FFAA00"        # Yellow - channel failing during recording
 COLOR_TRANSCRIBING_OUTER = "#CC8800"    # Dark amber - meeting transcribing outer
-COLOR_TRANSCRIBING_INNER = "#FFA500"    # Lighter amber - meeting transcribing inner
-COLOR_DONE = "#44FF44"
+COLOR_TRANSCRIBING_INNER = "#FFAA00"    # Amber - meeting transcribing inner
+COLOR_DONE_OUTER = "#44CC44"            # Dark green - done outer ring
+COLOR_DONE_INNER = "#66FF66"            # Light green - done inner circle
 COLOR_DICTATION_INNER = "#4488FF"       # Blue - mic active
 COLOR_DICTATION_OUTER = "#CCCCCC"       # White/light gray - dictation outer ring
-COLOR_SAVING = "#FFB833"
-COLOR_SUMMARIZING = "#AA44FF"
-COLOR_QUEUED = "#FF8800"
-COLOR_ERROR = "#FF44FF"
+COLOR_SAVING_OUTER = "#CC8800"          # Dark amber - saving outer ring
+COLOR_SAVING_INNER = "#FFAA00"          # Amber - saving inner circle
+COLOR_SUMMARIZING_OUTER = "#9944CC"     # Dark purple - summarizing outer ring
+COLOR_SUMMARIZING_INNER = "#CC66FF"     # Light purple - summarizing inner circle
+COLOR_QUEUED_OUTER = "#CC6600"          # Dark orange - queued outer ring
+COLOR_QUEUED_INNER = "#FF8800"          # Orange - queued inner circle
+COLOR_ERROR_OUTER = "#CC44CC"           # Dark magenta - error outer ring
+COLOR_ERROR_INNER = "#FF66FF"           # Light magenta - error inner circle
 
 
-def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image.Image:
-    """Generate a 64x64 icon with two concentric rings.
+def _make_three_ring_icon(outer_color: str, middle_color: str,
+                          inner_color: str | None = None, size: int = 64) -> Image.Image:
+    """Generate icon with outer ring + middle filled circle + optional inner dot.
 
-    - Outer ring: 3px wide, starts at 2px margin
+    - Outer ring: 3px wide, 2px margin
     - Gap: 2px transparent
-    - Inner circle: filled, remaining space (~24px radius)
-
-    At 16x16 tray size the two zones remain distinguishable.
+    - Middle circle: filled, remaining space
+    - Inner dot: ~4px radius, centered (only for overlay dictation)
     """
     img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
@@ -36,11 +41,9 @@ def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image
     ring_width = 3
     gap = 2
 
-    # Outer ring - draw filled ellipse then punch out interior
-    outer_r = size - margin  # right/bottom edge
+    # Outer ring
+    outer_r = size - margin
     draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
-
-    # Punch out the inside of the ring (transparent)
     inner_of_ring = margin + ring_width
     draw.ellipse(
         [inner_of_ring, inner_of_ring,
@@ -48,64 +51,27 @@ def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image
         fill=(0, 0, 0, 0),
     )
 
-    # Inner filled circle (after the gap)
-    inner_start = margin + ring_width + gap
-    inner_end = size - margin - ring_width - gap
-    if inner_end > inner_start:
+    # Middle filled circle (after gap)
+    mid_start = margin + ring_width + gap
+    mid_end = size - margin - ring_width - gap
+    if mid_end > mid_start:
+        draw.ellipse([mid_start, mid_start, mid_end - 1, mid_end - 1], fill=middle_color)
+
+    # Inner dot (overlay dictation indicator)
+    if inner_color is not None:
+        dot_radius = 4
+        cx, cy = size // 2, size // 2
         draw.ellipse(
-            [inner_start, inner_start, inner_end - 1, inner_end - 1],
+            [cx - dot_radius, cy - dot_radius, cx + dot_radius, cy + dot_radius],
             fill=inner_color,
         )
 
     return img
 
 
-def _make_overlay_icon(outer_color: str, size: int = 64) -> Image.Image:
-    """Generate a 64x64 icon with the outer ring in one color and a small blue dot centered.
-
-    Used for dictation-during-meeting: outer ring shows meeting state,
-    small centered blue dot shows dictation is active.
-
-    The blue dot is ~40% the size of the normal inner circle.
-    """
-    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
-    draw = ImageDraw.Draw(img)
-
-    margin = 2
-    ring_width = 3
-    gap = 2
-
-    # Outer ring - same as _make_dual_icon
-    outer_r = size - margin
-    draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
-
-    inner_of_ring = margin + ring_width
-    draw.ellipse(
-        [inner_of_ring, inner_of_ring,
-         outer_r - 1 - ring_width, outer_r - 1 - ring_width],
-        fill=(0, 0, 0, 0),
-    )
-
-    # Small blue dot (~40% of the inner circle area)
-    inner_start = margin + ring_width + gap
-    inner_end = size - margin - ring_width - gap
-    inner_radius = (inner_end - inner_start) / 2
-    dot_radius = inner_radius * 0.4
-    center = size / 2
-    dot_start = int(center - dot_radius)
-    dot_end = int(center + dot_radius)
-    if dot_end > dot_start:
-        draw.ellipse(
-            [dot_start, dot_start, dot_end, dot_end],
-            fill=COLOR_DICTATION_INNER,
-        )
-
-    return img
-
-
 def _circle_icon(color: str, size: int = 64) -> Image.Image:
-    """Legacy single-color circle - both rings same color."""
-    return _make_dual_icon(color, color, size)
+    """Backward-compat wrapper - both rings same color."""
+    return _make_three_ring_icon(color, color, size=size)
 
 
 # --- Public icon constructors ---
@@ -114,18 +80,18 @@ def _circle_icon(color: str, size: int = 64) -> Image.Image:
 
 
 def idle_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_IDLE, COLOR_IDLE)
+    return _make_three_ring_icon("#808080", "#808080")
 
 
 def recording_icon(speaker_ok: bool = True) -> Image.Image:
     """Meeting recording - outer ring reflects speaker loopback status."""
     outer = COLOR_RECORDING_OUTER if speaker_ok else COLOR_RECORDING_FAIL
-    return _make_dual_icon(COLOR_RECORDING_INNER, outer)
+    return _make_three_ring_icon(outer, COLOR_RECORDING_INNER)
 
 
 def dictation_icon() -> Image.Image:
-    """Dictation - mic active (inner blue), outer white/gray."""
-    return _make_dual_icon(COLOR_DICTATION_INNER, COLOR_DICTATION_OUTER)
+    """Dictation - outer white/gray, middle blue."""
+    return _make_three_ring_icon(COLOR_DICTATION_OUTER, COLOR_DICTATION_INNER)
 
 
 def dictation_during_recording_icon(speaker_ok: bool = True) -> Image.Image:
@@ -133,44 +99,46 @@ def dictation_during_recording_icon(speaker_ok: bool = True) -> Image.Image:
 
     Outer ring = dark red (meeting still recording), or yellow if speaker
     loopback is unhealthy.
-    Inner = small blue dot (dictation active).
+    Middle = red (recording).
+    Inner dot = blue (dictation active).
     """
     outer = COLOR_RECORDING_OUTER if speaker_ok else COLOR_RECORDING_FAIL
-    return _make_overlay_icon(outer)
+    return _make_three_ring_icon(outer, COLOR_RECORDING_INNER, COLOR_DICTATION_INNER)
 
 
 def dictation_during_transcription_icon() -> Image.Image:
     """Dictation active during meeting transcription.
 
     Outer ring = dark amber (meeting transcribing).
-    Inner = small blue dot (dictation active).
+    Middle = amber (transcribing).
+    Inner dot = blue (dictation active).
     """
-    return _make_overlay_icon(COLOR_TRANSCRIBING_OUTER)
+    return _make_three_ring_icon(COLOR_TRANSCRIBING_OUTER, COLOR_TRANSCRIBING_INNER, COLOR_DICTATION_INNER)
 
 
 def saving_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_SAVING, COLOR_SAVING)
+    return _make_three_ring_icon(COLOR_SAVING_OUTER, COLOR_SAVING_INNER)
 
 
 def transcribing_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_TRANSCRIBING_INNER, COLOR_TRANSCRIBING_OUTER)
+    return _make_three_ring_icon(COLOR_TRANSCRIBING_OUTER, COLOR_TRANSCRIBING_INNER)
 
 
 def done_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_DONE, COLOR_DONE)
+    return _make_three_ring_icon(COLOR_DONE_OUTER, COLOR_DONE_INNER)
 
 
 def summarizing_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_SUMMARIZING, COLOR_SUMMARIZING)
+    return _make_three_ring_icon(COLOR_SUMMARIZING_OUTER, COLOR_SUMMARIZING_INNER)
 
 
 def queued_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_QUEUED, COLOR_QUEUED)
+    return _make_three_ring_icon(COLOR_QUEUED_OUTER, COLOR_QUEUED_INNER)
 
 
 def error_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_ERROR, COLOR_ERROR)
+    return _make_three_ring_icon(COLOR_ERROR_OUTER, COLOR_ERROR_INNER)
 
 
 def yellow_flash_icon(size: int = 64) -> Image.Image:
-    return _make_dual_icon("#FFCC00", "#FFCC00", size=size)
+    return _make_three_ring_icon("#FFCC00", "#FFCC00", size=size)

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -62,7 +62,7 @@ def _make_three_ring_icon(outer_color: str, middle_color: str,
         dot_radius = 4
         cx, cy = size // 2, size // 2
         draw.ellipse(
-            [cx - dot_radius, cy - dot_radius, cx + dot_radius, cy + dot_radius],
+            [cx - dot_radius, cy - dot_radius, cx + dot_radius - 1, cy + dot_radius - 1],
             fill=inner_color,
         )
 
@@ -80,7 +80,7 @@ def _circle_icon(color: str, size: int = 64) -> Image.Image:
 
 
 def idle_icon() -> Image.Image:
-    return _make_three_ring_icon("#808080", "#808080")
+    return _make_three_ring_icon(COLOR_IDLE, COLOR_IDLE)
 
 
 def recording_icon(speaker_ok: bool = True) -> Image.Image:

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -170,3 +170,7 @@ def queued_icon() -> Image.Image:
 
 def error_icon() -> Image.Image:
     return _make_dual_icon(COLOR_ERROR, COLOR_ERROR)
+
+
+def yellow_flash_icon(size: int = 64) -> Image.Image:
+    return _make_dual_icon("#FFCC00", "#FFCC00", size=size)


### PR DESCRIPTION
## Summary
Implements the approved spec at docs/specs/2026-03-24-backup-dictation-icons-design.md.

### Changes (6 commits)
1. **Force backup to CPU** - removed VRAM auto-detection, backup always CPU unless explicitly overridden
2. **Preload on meeting start** - BackupTranscriber.preload() loads model in background thread when meeting begins
3. **Hotkey debounce** - yellow double-flash (150ms on/off/on) when backup model still loading, ignores rapid presses
4. **Device label fix** - Settings shows "CPU" when CPU selected, not GPU name
5. **Three-ring icon** - outer ring (speaker) + middle circle (mic) + inner dot (dictation overlay). 3px outer ring for visibility.
6. **Documentation** - audio-pipeline.md, ui-patterns.md, testing.md updated

### Spec reference
- Backup model defaults: small on CPU (8+ GB VRAM), tiny (< 8 GB), base (no GPU)
- Pre-load lifecycle: loads when meeting starts, stays in memory until app closes
- Icon color states: 10 states per spec table

## Test plan
- [ ] Start meeting, press Ctrl+Shift+Space for dictation during meeting
- [ ] Verify backup model loads on CPU (check log)
- [ ] Verify yellow flash on rapid presses during model load
- [ ] Verify device label shows "CPU" when CPU selected
- [ ] Verify three-ring icon visible at tray size
- [ ] Verify blue dot appears during overlay dictation