### PR TITLE
feat: backup dictation via subprocess (fixes segfault)

### DIFF
--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -30,6 +30,14 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 - Communication uses request/response queues with `request_id` for correlation.
 - Between meeting pipeline stages, `_drain_priority()` processes pending dictation requests, allowing dictation during meeting transcription.
 
+## Backup Model Lifecycle
+
+- The backup model pre-loads on meeting start (background thread, CPU, ~1s load time).
+- Once loaded, the backup model stays in memory until the app closes. There is no unload timer.
+- `backup_device` is always CPU unless explicitly overridden to GPU in config.
+- Default backup model selection by VRAM tier: `small` (8+ GB VRAM), `tiny` (< 8 GB VRAM), `base` (no GPU).
+- Model merging: dictation and meeting share the primary model instance. The backup model is always a separate instance.
+
 ## Critical Rules
 
 - **Never change the multiprocessing context from "spawn"** - required for CUDA isolation.

--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -35,7 +35,7 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 - The backup model pre-loads on meeting start (background thread, CPU, ~1s load time).
 - Once loaded, the backup model stays in memory until the app closes. There is no unload timer.
 - `backup_device` is always CPU unless explicitly overridden to GPU in config.
-- Default backup model selection by VRAM tier: `small` (8+ GB VRAM), `tiny` (< 8 GB VRAM), `base` (no GPU).
+- Default backup_model is `base`. The installer can override to `small` or `tiny` based on detected VRAM during installation. No runtime auto-selection.
 - Model merging: dictation and meeting share the primary model instance. The backup model is always a separate instance.
 
 ## Critical Rules

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -70,3 +70,14 @@ No automated test suite exists. All verification is manual.
 3. Verify: main process detects the crash and shows an error state
 4. Verify: worker respawns automatically
 5. Start another dictation and verify it works
+
+## Backup Dictation Test
+
+1. Start a meeting recording (Ctrl+Shift+M)
+2. Press Ctrl+Shift+Space to trigger dictation
+3. Verify: dictation works on CPU (backup model)
+4. Verify: meeting recording continues uninterrupted during and after dictation
+5. Verify: yellow double-flash appears on rapid hotkey presses during model load
+6. Verify: Settings > Device label shows correct device (CPU when CPU selected)
+7. Verify: tray icon shows three rings with blue inner dot during meeting + dictation
+8. Verify: log output contains "Backup model loading [cpu]" confirming CPU device

--- a/.claude/rules/ui-patterns.md
+++ b/.claude/rules/ui-patterns.md
@@ -65,3 +65,27 @@ Four tiers controlled by the `log_window` config key:
 - **verbose** - full debug output, prefixed with `[WhisperSync]`
 
 File logging always captures DEBUG level regardless of console tier. Log files rotate daily.
+
+## Tray Icon Anatomy (Three-Ring Model)
+
+The tray icon uses a layered three-ring design:
+
+- **Outer ring** (3px): reflects speaker/channel health status.
+- **Middle circle**: primary indicator for mic status and recording state.
+- **Inner dot** (4px, optional): dictation overlay indicator. Appears ONLY during overlay dictation (dictation while a meeting is active).
+
+### Color State Table
+
+| State | Outer Ring | Middle Circle | Inner Dot |
+|-------|-----------|---------------|-----------|
+| Idle | Gray | Gray | None |
+| Recording (meeting) | Green | Red | None |
+| Dictation (standalone) | Gray | Blue | None |
+| Dictation (overlay, during meeting) | Green | Red | Blue |
+| Transcribing | Gray | Yellow | None |
+| Done (flash) | Gray | Green | None |
+| Error | Gray | Red (pulse) | None |
+
+### Yellow Double-Flash Convention
+
+The yellow double-flash is the universal "loading/queuing" signal. Timing: 150ms on, 150ms off, 150ms on. Used when a hotkey press is received while a model is still loading or a previous operation is queued.

--- a/.claude/rules/ui-patterns.md
+++ b/.claude/rules/ui-patterns.md
@@ -78,13 +78,18 @@ The tray icon uses a layered three-ring design:
 
 | State | Outer Ring | Middle Circle | Inner Dot |
 |-------|-----------|---------------|-----------|
-| Idle | Gray | Gray | None |
-| Recording (meeting) | Green | Red | None |
-| Dictation (standalone) | Gray | Blue | None |
-| Dictation (overlay, during meeting) | Green | Red | Blue |
-| Transcribing | Gray | Yellow | None |
-| Done (flash) | Gray | Green | None |
-| Error | Gray | Red (pulse) | None |
+| Idle | Gray (#808080) | Gray (#808080) | None |
+| Recording (meeting) | Dark red (#CC3333) | Light red (#FF4444) | None |
+| Recording (speaker fail) | Yellow (#FFAA00) | Light red (#FF4444) | None |
+| Dictation (standalone) | White/light gray (#CCCCCC) | Blue (#4488FF) | None |
+| Dictation (overlay, during meeting) | Dark red (#CC3333) | Light red (#FF4444) | Blue (#4488FF) |
+| Dictation (overlay, during transcription) | Dark amber (#CC8800) | Amber (#FFAA00) | Blue (#4488FF) |
+| Transcribing | Dark amber (#CC8800) | Amber (#FFAA00) | None |
+| Saving | Dark amber (#CC8800) | Amber (#FFAA00) | None |
+| Summarizing | Dark purple (#9944CC) | Light purple (#CC66FF) | None |
+| Queued | Dark orange (#CC6600) | Orange (#FF8800) | None |
+| Done | Dark green (#44CC44) | Light green (#66FF66) | None |
+| Error | Dark magenta (#CC44CC) | Light magenta (#FF66FF) | None |
 
 ### Yellow Double-Flash Convention
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -183,6 +183,21 @@ class WhisperSync:
         self.tray.icon = icon
         self.tray.title = f"WhisperSync: {title}"
 
+    def _yellow_flash(self):
+        """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
+        def _flash():
+            from .icons import yellow_flash_icon
+            try:
+                original = self.tray.icon
+                for _ in range(2):
+                    self.tray.icon = yellow_flash_icon()
+                    import time; time.sleep(0.15)
+                    self.tray.icon = original
+                    time.sleep(0.15)
+            except Exception:
+                pass  # tray may not be ready
+        threading.Thread(target=_flash, daemon=True).start()
+
     # --- Click dispatch ---
 
     def _dispatch_action(self, action: str):
@@ -278,6 +293,10 @@ class WhisperSync:
             elif self.mode == "meeting" or (self.mode is None and self._meeting_transcribing):
                 # Dictation during meeting recording or meeting transcription
                 if self.cfg.get("always_available_dictation", True):
+                    if self._backup.is_loading:
+                        logger.debug("Backup model still loading, triggering yellow flash")
+                        self._yellow_flash()
+                        return
                     self._start_overlay_dictation()
                 else:
                     logger.info("Dictation unavailable during meeting (always_available_dictation disabled)")
@@ -750,6 +769,8 @@ class WhisperSync:
         temp = self._meeting_temp_dir()
         mic_temp = temp / "mic-temp.wav"
         self.recorder.start_streaming(mic_temp, disk_only=True)
+        if self.cfg.get("always_available_dictation", True):
+            self._backup.preload()
 
     _ABORT = object()  # Sentinel for abort
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -185,9 +185,12 @@ class WhisperSync:
 
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
+        if getattr(self, '_flashing', False):
+            return
+        self._flashing = True
         def _flash():
-            from .icons import yellow_flash_icon
             try:
+                from .icons import yellow_flash_icon
                 original = self.tray.icon
                 for _ in range(2):
                     self.tray.icon = yellow_flash_icon()
@@ -196,6 +199,8 @@ class WhisperSync:
                     time.sleep(0.15)
             except Exception:
                 pass  # tray may not be ready
+            finally:
+                self._flashing = False
         threading.Thread(target=_flash, daemon=True).start()
 
     # --- Click dispatch ---
@@ -1977,7 +1982,7 @@ class WhisperSync:
                                  pystray.Menu(*dictation_model_items)),
                 pystray.MenuItem(f"Meeting Model\t{self.cfg['model']}",
                                  pystray.Menu(*meeting_model_items)),
-                pystray.MenuItem(f"Device\t{current_device} - {gpu_name or 'CPU'}",
+                pystray.MenuItem(f"Device\t{self._get_device_label()}",
                                  pystray.Menu(*device_items)),
                 pystray.MenuItem("Always Available Dictation", pystray.Menu(
                     pystray.MenuItem(

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2448,28 +2448,26 @@ class WhisperSync:
         threading.Thread(target=_do_restart, daemon=True).start()
 
     def _get_device_label(self) -> str:
-        """Return display string for current device setting."""
-        device = self.cfg.get("device", "auto")
-        if device == "auto":
+        """Return display string for the active resolved device."""
+        device_setting = self.cfg.get("device", "auto")
+        if device_setting == "cpu":
+            return "CPU"
+        elif device_setting in ("gpu", "cuda"):
             try:
                 from .transcribe import get_gpu_name
-                gpu = get_gpu_name()
-                if gpu:
-                    return f"Auto ({gpu})"
-                return "Auto (CPU -- no GPU detected)"
-            except Exception:
-                return "Auto"
-        elif device in ("gpu", "cuda"):
-            try:
-                from .transcribe import get_gpu_name
-                gpu = get_gpu_name()
-                if gpu:
-                    return f"GPU ({gpu})"
-                return "GPU (not available)"
+                gpu_name = get_gpu_name()
+                return gpu_name if gpu_name else "GPU"
             except Exception:
                 return "GPU"
-        else:
-            return "CPU"
+        else:  # auto
+            try:
+                from .transcribe import get_gpu_name
+                gpu_name = get_gpu_name()
+                if gpu_name:
+                    return f"Auto ({gpu_name})"
+                return "Auto (CPU)"
+            except Exception:
+                return "Auto"
 
     def _toggle_always_available_dictation(self):
         self.cfg["always_available_dictation"] = not self.cfg.get("always_available_dictation", True)

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -315,7 +315,7 @@ class WhisperSync:
         return get_dictation_log_dir()
 
     def _start_dictation(self):
-        if not self.worker.is_ready() and not (self._meeting_transcribing and self._backup.is_enabled()):
+        if not self.worker.is_ready() and not (self._meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)):
             logger.warning("Worker not ready yet - ignoring dictation request")
             return
         self.mode = "dictation"
@@ -347,7 +347,7 @@ class WhisperSync:
         self._update_icon()
 
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
-        use_backup = self._meeting_transcribing and self._backup.is_enabled()
+        use_backup = self._meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)
 
         def _process():
             import time as _time
@@ -364,7 +364,7 @@ class WhisperSync:
                         used_backup = True
                         t1 = _time.perf_counter()
                         backup_model = self.cfg.get("backup_model", "base")
-                        backup_device = self._backup.device
+                        backup_device = self.cfg.get("backup_device", "cpu")
                         logger.info(
                             f"Dictation (backup, {backup_device} {backup_model}): "
                             f"{t1 - t0:.2f}s"
@@ -449,7 +449,7 @@ class WhisperSync:
 
         meeting_state = "recording" if self.mode == "meeting" else "transcribing"
         backup_model = self.cfg.get("backup_model", "base")
-        backup_device = self._backup.device
+        backup_device = self.cfg.get("backup_device", "cpu")
         logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)")
         logger.info(f"Backup model: {backup_model} on {backup_device}")
 
@@ -494,7 +494,7 @@ class WhisperSync:
                 duration = t1 - t0
                 char_count = len(text) if text else 0
                 backup_model = self.cfg.get("backup_model", "base")
-                backup_device = self._backup.device
+                backup_device = self.cfg.get("backup_device", "cpu")
                 logger.info(
                     f"Dictation during meeting: {duration:.1f}s, {char_count} chars "
                     f"(backup {backup_device} {backup_model})"
@@ -2479,7 +2479,7 @@ class WhisperSync:
         state = "enabled" if self.cfg["always_available_dictation"] else "disabled"
         logger.info(f"Always Available Dictation: {state}")
         if not self.cfg["always_available_dictation"]:
-            self._backup.unload()
+            self._backup.stop()
         self._save_and_refresh()
 
     def _set_backup_device(self, device: str):
@@ -2487,7 +2487,8 @@ class WhisperSync:
             return
         self.cfg["backup_device"] = device
         logger.info(f"Backup device: {device}")
-        self._backup.reload_if_needed()
+        self._backup.stop()
+        self._backup.preload()
         self._save_and_refresh()
 
     def _set_backup_model(self, model_name: str):
@@ -2495,16 +2496,8 @@ class WhisperSync:
             return
         self.cfg["backup_model"] = model_name
         logger.info(f"Backup model: {model_name}")
-        # Check VRAM and warn if needed
-        primary_model = self.cfg.get("model", "large-v3")
-        warning = self._backup.get_vram_warning(primary_model, model_name)
-        if warning:
-            try:
-                notify("VRAM Warning", warning)
-            except Exception:
-                pass
-            logger.warning(warning)
-        self._backup.reload_if_needed()
+        self._backup.stop()
+        self._backup.preload()
         self._save_and_refresh()
 
     def _set_model(self, key: str, model_name: str):
@@ -2603,6 +2596,7 @@ class WhisperSync:
         if self.recorder.is_recording:
             self.recorder.stop()
         self.worker.stop()
+        self._backup.stop()
         keyboard.unhook_all()
         subprocess.Popen(
             [sys.executable, "-m", "whisper_sync"],
@@ -2615,6 +2609,7 @@ class WhisperSync:
         if self.recorder.is_recording:
             self.recorder.stop()
         self.worker.stop()
+        self._backup.stop()
         keyboard.unhook_all()
         if self.tray:
             self.tray.stop()
@@ -2714,7 +2709,7 @@ class WhisperSync:
         logger.info(f"Log file: {get_log_path()}")
         if self.cfg.get("incognito"):
             logger.info("Incognito mode active -- dictation data not stored on disk")
-        if self._backup.is_enabled():
+        if BackupTranscriber.is_enabled(self.cfg):
             backup_model = self.cfg.get("backup_model", "base")
             backup_device = self.cfg.get("backup_device", "auto")
             logger.info(f"Always Available Dictation: on (backup model: {backup_model}, device: {backup_device})")
@@ -2754,6 +2749,7 @@ class WhisperSync:
             # Always release keyboard hooks to prevent stuck modifier keys
             keyboard.unhook_all()
             self.worker.stop()
+            self._backup.stop()
             if self._github_poller:
                 self._github_poller.stop()
 

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -64,7 +64,9 @@ class BackupTranscriber:
         def _do_preload():
             self._loading = True
             try:
-                self._load()
+                with self._lock:
+                    if self._model is None:
+                        self._load()
             finally:
                 self._loading = False
 
@@ -140,7 +142,7 @@ class BackupTranscriber:
 
         if backup_device in ("gpu", "cuda"):
             main_device = self.cfg.get("device", "auto")
-            if main_device != "cpu":
+            if main_device in ("gpu", "cuda"):
                 logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
             return "cuda"
 

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -116,54 +116,16 @@ class BackupTranscriber:
         logger.info(f"Backup model ready [{device}] {model_name}")
 
     def _resolve_device(self) -> str:
-        """Determine which device to use for the backup model."""
-        backup_device = self.cfg.get("backup_device", "auto")
+        """Determine device for backup model. Always CPU unless explicitly overridden."""
+        backup_device = self.cfg.get("backup_device", "cpu")
 
-        if backup_device == "cpu":
-            return "cpu"
         if backup_device in ("gpu", "cuda"):
+            main_device = self.cfg.get("device", "auto")
+            if main_device != "cpu":
+                logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
             return "cuda"
 
-        # Auto-detect: check if primary + backup fit in VRAM
-        try:
-            import torch
-            if not torch.cuda.is_available():
-                logger.info("Backup device auto -> CPU (no GPU available)")
-                return "cpu"
-
-            total_vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
-
-            # 8 GB or less: always CPU for backup (meeting processing uses most VRAM)
-            if total_vram <= 8:
-                logger.info(f"Backup device auto -> CPU ({total_vram:.0f} GB VRAM, too tight for dual models)")
-                return "cpu"
-
-            primary_model = self.cfg.get("model", "large-v3")
-            backup_model = self.cfg.get("backup_model", "base")
-            primary_device = self.cfg.get("device", "auto")
-            # If primary is forced to CPU, it won't consume VRAM
-            primary_vram = 0.0 if primary_device == "cpu" else MODEL_VRAM_GB.get(primary_model, 3.0)
-            backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
-            combined = primary_vram + backup_vram
-
-            if combined <= total_vram * VRAM_THRESHOLD:
-                logger.info(
-                    f"Backup device auto -> GPU "
-                    f"({combined:.1f} GB needed, {total_vram:.1f} GB available)"
-                )
-                return "cuda"
-            else:
-                logger.info(
-                    f"Backup device auto -> CPU "
-                    f"({combined:.1f} GB needed > {total_vram * VRAM_THRESHOLD:.1f} GB threshold)"
-                )
-                return "cpu"
-        except ImportError:
-            logger.info("Backup device auto -> CPU (torch not available)")
-            return "cpu"
-        except Exception as e:
-            logger.warning(f"Backup device auto -> CPU (error: {e})")
-            return "cpu"
+        return "cpu"
 
     def unload(self):
         """Free the backup model from memory."""

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -1,17 +1,8 @@
-"""Lightweight backup transcriber for dictation during meetings.
+"""Backup transcription worker for dictation during meetings.
 
-When the main worker subprocess is busy with meeting transcription,
-this module provides a fallback path using a smaller model loaded
-directly in the main process. It runs in a background thread (not a
-separate process) since dictation audio is short (5-30s) and
-transcription completes in 1-3s on CPU or <1s on GPU with a small model.
-
-The model is loaded lazily on first use and kept in memory for
-subsequent calls. Call unload() to free it explicitly.
-
-NOTE: WhisperX is loaded in the main process thread for simplicity.
-The backup model is small and transcription is brief (~1-3s). If
-stability issues arise, migrate to a subprocess model.
+Spawns a second TranscriptionWorker subprocess on CPU with a smaller model.
+The subprocess uses the same worker_main entry point as the primary worker.
+Main process never imports torch/CTranslate2 (avoids segfaults).
 """
 
 import threading
@@ -19,194 +10,93 @@ import threading
 import numpy as np
 
 from .logger import logger
-
-# Approximate VRAM usage per model in GB (float16 on GPU)
-MODEL_VRAM_GB = {
-    "tiny": 1.0,
-    "base": 1.0,
-    "small": 2.0,
-    "medium": 4.0,
-    "large-v2": 3.0,
-    "large-v3": 3.0,
-}
-
-VRAM_THRESHOLD = 0.80  # warn if combined usage exceeds 80% of total
+from . import config
 
 
 class BackupTranscriber:
-    """Lightweight backup transcriber for dictation during meetings.
+    """Manages a backup transcription subprocess for dictation during meetings.
 
-    Loads lazily on first use. Runs in the calling thread (main process).
-    Uses a smaller model on CPU or GPU depending on config.
+    Spawned on first meeting start. Stays alive until app closes.
+    Uses TranscriptionWorker (same as primary) but configured for CPU.
     """
 
     def __init__(self, cfg: dict):
         self.cfg = cfg
-        self._model = None
-        self._device = None
-        self._compute_type = None
-        self._model_name = None
-        self._loading = False
-        self._lock = threading.Lock()
+        self._worker = None
+        self._spawning = False
+        self._spawn_lock = threading.Lock()
+
+    def preload(self):
+        """Spawn backup subprocess and pre-load model. Called on meeting start.
+
+        Idempotent: does nothing if already spawned or spawning.
+        Runs spawn in a background thread so it doesn't block meeting start.
+        """
+        if self._worker is not None or self._spawning:
+            return
+
+        def _do_spawn():
+            with self._spawn_lock:
+                if self._worker is not None:
+                    return
+                self._spawning = True
+                try:
+                    from .worker_manager import TranscriptionWorker
+
+                    backup_model = self.cfg.get("backup_model", "base")
+                    backup_cfg = {**self.cfg}
+                    backup_cfg["device"] = "cpu"
+                    backup_cfg["model"] = backup_model
+                    backup_cfg["compute_type"] = "int8"
+
+                    logger.info(f"Spawning backup worker (CPU, {backup_model})...")
+                    worker = TranscriptionWorker(backup_cfg, preload_model=backup_model)
+                    worker.start()
+
+                    if worker.wait_ready(timeout=30):
+                        self._worker = worker
+                        logger.info(f"Backup worker ready (CPU, {backup_model})")
+                    else:
+                        logger.warning("Backup worker failed to start within 30s")
+                        worker.stop()
+                finally:
+                    self._spawning = False
+
+        threading.Thread(target=_do_spawn, daemon=True, name="backup-spawn").start()
 
     @property
     def is_loading(self) -> bool:
-        return self._loading
-
-    def is_enabled(self) -> bool:
-        return self.cfg.get("always_available_dictation", True)
-
-    def preload(self):
-        """Pre-load backup model in background thread. Called when meeting starts."""
-        if self._model is not None or self._loading:
-            return
-
-        def _do_preload():
-            self._loading = True
-            try:
-                with self._lock:
-                    if self._model is None:
-                        self._load()
-            finally:
-                self._loading = False
-
-        threading.Thread(target=_do_preload, daemon=True, name="backup-preload").start()
+        """True while subprocess is spawning or model is loading."""
+        return self._spawning
 
     @property
-    def device(self) -> str:
-        """Current device string, or 'not loaded' if model is not loaded."""
-        return self._device or "not loaded"
+    def is_ready(self) -> bool:
+        """True when backup worker is alive and model is loaded."""
+        return self._worker is not None and self._worker.is_ready()
 
     def transcribe(self, audio_np: np.ndarray) -> str:
-        """Transcribe audio using the backup model. Loads model on first call.
+        """Transcribe audio using the backup subprocess.
 
-        Args:
-            audio_np: Raw audio as float32 or int16 numpy array (16kHz mono).
-
-        Returns:
-            Transcribed text. Raises on failure (caller handles).
+        Sends a transcribe_fast request to the backup worker.
+        Raises RuntimeError if backup worker is not available.
         """
-        with self._lock:
-            if self._model is None:
-                self._load()
+        if self._worker is None:
+            raise RuntimeError("Backup worker not started")
+        if not self._worker.is_ready():
+            raise RuntimeError("Backup worker not ready")
 
-            import whisperx
+        return self._worker.transcribe_fast(audio_np)
 
-            # Normalize audio to the format whisperx expects
-            if audio_np.dtype == np.int16:
-                audio_np = audio_np.astype(np.float32) / 32768.0
-            audio_np = np.ascontiguousarray(audio_np.flatten(), dtype=np.float32)
+    def stop(self):
+        """Shut down the backup subprocess."""
+        if self._worker is not None:
+            logger.info("Stopping backup worker...")
+            self._worker.stop()
+            self._worker = None
 
-            language = self.cfg.get("language", "en")
-            batch_size = 8 if self._device == "cpu" else 16
-
-            logger.info(
-                f"Backup transcribe [{self._device}] {self._model_name} "
-                f"(batch={batch_size})..."
-            )
-            result = self._model.transcribe(
-                audio_np, batch_size=batch_size, language=language
-            )
-            text = " ".join(
-                seg.get("text", "") for seg in result.get("segments", [])
-            ).strip()
-            return text
-
-    def _load(self):
-        """Lazily load the backup model."""
-        import whisperx
-
-        model_name = self.cfg.get("backup_model", "base")
-        device = self._resolve_device()
-        compute_type = "int8" if device == "cpu" else self.cfg.get("compute_type", "float16")
-
-        from .paths import get_model_cache
-        model_cache = get_model_cache()
-
-        logger.info(f"Backup model loading [{device}] {model_name} ({compute_type})...")
-        self._model = whisperx.load_model(
-            model_name,
-            device=device,
-            compute_type=compute_type,
-            language=self.cfg.get("language", "en"),
-            download_root=str(model_cache),
-        )
-        self._device = device
-        self._compute_type = compute_type
-        self._model_name = model_name
-        logger.info(f"Backup model ready [{device}] {model_name}")
-
-    def _resolve_device(self) -> str:
-        """Determine device for backup model. Always CPU unless explicitly overridden."""
-        backup_device = self.cfg.get("backup_device", "cpu")
-
-        if backup_device in ("gpu", "cuda"):
-            main_device = self.cfg.get("device", "auto")
-            if main_device in ("gpu", "cuda"):
-                logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
-            return "cuda"
-
-        return "cpu"
-
-    def unload(self):
-        """Free the backup model from memory."""
-        with self._lock:
-            if self._model is not None:
-                logger.info("Unloading backup model")
-                self._model = None
-                self._device = None
-                self._compute_type = None
-                self._model_name = None
-                # Try to free GPU memory
-                try:
-                    import torch
-                    if torch.cuda.is_available():
-                        torch.cuda.empty_cache()
-                except Exception:
-                    pass
-
-    def needs_reload(self) -> bool:
-        """Check if config changed and model needs reloading."""
-        if self._model is None:
-            return False
-        return (
-            self._model_name != self.cfg.get("backup_model", "base")
-            or self._device != self._resolve_device()
-        )
-
-    def reload_if_needed(self):
-        """Reload the backup model if config has changed."""
-        if self.needs_reload():
-            self.unload()
-            # Will lazy-load on next transcribe()
-
-    def get_vram_warning(self, primary_model: str, backup_model: str) -> str | None:
-        """Check if primary + backup would exceed 80% VRAM.
-
-        Returns warning string or None if OK.
-        """
-        try:
-            import torch
-            if not torch.cuda.is_available():
-                return None  # no GPU, no VRAM concern
-
-            total_vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
-            primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)
-            backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
-            combined = primary_vram + backup_vram
-            threshold = total_vram * VRAM_THRESHOLD
-
-            if combined > threshold:
-                backup_device = self.cfg.get("backup_device", "auto")
-                if backup_device == "auto":
-                    advice = "Backup will use CPU in auto mode."
-                else:
-                    advice = "Consider switching to a smaller model or CPU to avoid OOM."
-                return (
-                    f"{primary_model} + {backup_model} need ~{combined:.1f} GB VRAM "
-                    f"({total_vram:.1f} GB total, {threshold:.1f} GB safe limit). "
-                    f"{advice}"
-                )
-        except Exception:
-            pass
-        return None
+    @staticmethod
+    def is_enabled(cfg: dict = None) -> bool:
+        """Check if always-available dictation is enabled."""
+        if cfg is None:
+            cfg = config.load()
+        return cfg.get("always_available_dictation", True)

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -46,10 +46,29 @@ class BackupTranscriber:
         self._device = None
         self._compute_type = None
         self._model_name = None
+        self._loading = False
         self._lock = threading.Lock()
+
+    @property
+    def is_loading(self) -> bool:
+        return self._loading
 
     def is_enabled(self) -> bool:
         return self.cfg.get("always_available_dictation", True)
+
+    def preload(self):
+        """Pre-load backup model in background thread. Called when meeting starts."""
+        if self._model is not None or self._loading:
+            return
+
+        def _do_preload():
+            self._loading = True
+            try:
+                self._load()
+            finally:
+                self._loading = False
+
+        threading.Thread(target=_do_preload, daemon=True, name="backup-preload").start()
 
     @property
     def device(self) -> str:

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -23,6 +23,6 @@
   "device": "auto",
   "incognito": false,
   "always_available_dictation": true,
-  "backup_device": "auto",
+  "backup_device": "cpu",
   "backup_model": "base"
 }

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -10,24 +10,29 @@ COLOR_RECORDING_OUTER = "#CC3333"       # Dark red - meeting outer ring
 COLOR_RECORDING_INNER = "#FF4444"       # Lighter red - meeting inner circle
 COLOR_RECORDING_FAIL = "#FFAA00"        # Yellow - channel failing during recording
 COLOR_TRANSCRIBING_OUTER = "#CC8800"    # Dark amber - meeting transcribing outer
-COLOR_TRANSCRIBING_INNER = "#FFA500"    # Lighter amber - meeting transcribing inner
-COLOR_DONE = "#44FF44"
+COLOR_TRANSCRIBING_INNER = "#FFAA00"    # Amber - meeting transcribing inner
+COLOR_DONE_OUTER = "#44CC44"            # Dark green - done outer ring
+COLOR_DONE_INNER = "#66FF66"            # Light green - done inner circle
 COLOR_DICTATION_INNER = "#4488FF"       # Blue - mic active
 COLOR_DICTATION_OUTER = "#CCCCCC"       # White/light gray - dictation outer ring
-COLOR_SAVING = "#FFB833"
-COLOR_SUMMARIZING = "#AA44FF"
-COLOR_QUEUED = "#FF8800"
-COLOR_ERROR = "#FF44FF"
+COLOR_SAVING_OUTER = "#CC8800"          # Dark amber - saving outer ring
+COLOR_SAVING_INNER = "#FFAA00"          # Amber - saving inner circle
+COLOR_SUMMARIZING_OUTER = "#9944CC"     # Dark purple - summarizing outer ring
+COLOR_SUMMARIZING_INNER = "#CC66FF"     # Light purple - summarizing inner circle
+COLOR_QUEUED_OUTER = "#CC6600"          # Dark orange - queued outer ring
+COLOR_QUEUED_INNER = "#FF8800"          # Orange - queued inner circle
+COLOR_ERROR_OUTER = "#CC44CC"           # Dark magenta - error outer ring
+COLOR_ERROR_INNER = "#FF66FF"           # Light magenta - error inner circle
 
 
-def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image.Image:
-    """Generate a 64x64 icon with two concentric rings.
+def _make_three_ring_icon(outer_color: str, middle_color: str,
+                          inner_color: str | None = None, size: int = 64) -> Image.Image:
+    """Generate icon with outer ring + middle filled circle + optional inner dot.
 
-    - Outer ring: 3px wide, starts at 2px margin
+    - Outer ring: 3px wide, 2px margin
     - Gap: 2px transparent
-    - Inner circle: filled, remaining space (~24px radius)
-
-    At 16x16 tray size the two zones remain distinguishable.
+    - Middle circle: filled, remaining space
+    - Inner dot: ~4px radius, centered (only for overlay dictation)
     """
     img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
@@ -36,11 +41,9 @@ def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image
     ring_width = 3
     gap = 2
 
-    # Outer ring - draw filled ellipse then punch out interior
-    outer_r = size - margin  # right/bottom edge
+    # Outer ring
+    outer_r = size - margin
     draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
-
-    # Punch out the inside of the ring (transparent)
     inner_of_ring = margin + ring_width
     draw.ellipse(
         [inner_of_ring, inner_of_ring,
@@ -48,64 +51,27 @@ def _make_dual_icon(inner_color: str, outer_color: str, size: int = 64) -> Image
         fill=(0, 0, 0, 0),
     )
 
-    # Inner filled circle (after the gap)
-    inner_start = margin + ring_width + gap
-    inner_end = size - margin - ring_width - gap
-    if inner_end > inner_start:
+    # Middle filled circle (after gap)
+    mid_start = margin + ring_width + gap
+    mid_end = size - margin - ring_width - gap
+    if mid_end > mid_start:
+        draw.ellipse([mid_start, mid_start, mid_end - 1, mid_end - 1], fill=middle_color)
+
+    # Inner dot (overlay dictation indicator)
+    if inner_color is not None:
+        dot_radius = 4
+        cx, cy = size // 2, size // 2
         draw.ellipse(
-            [inner_start, inner_start, inner_end - 1, inner_end - 1],
+            [cx - dot_radius, cy - dot_radius, cx + dot_radius, cy + dot_radius],
             fill=inner_color,
         )
 
     return img
 
 
-def _make_overlay_icon(outer_color: str, size: int = 64) -> Image.Image:
-    """Generate a 64x64 icon with the outer ring in one color and a small blue dot centered.
-
-    Used for dictation-during-meeting: outer ring shows meeting state,
-    small centered blue dot shows dictation is active.
-
-    The blue dot is ~40% the size of the normal inner circle.
-    """
-    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
-    draw = ImageDraw.Draw(img)
-
-    margin = 2
-    ring_width = 3
-    gap = 2
-
-    # Outer ring - same as _make_dual_icon
-    outer_r = size - margin
-    draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
-
-    inner_of_ring = margin + ring_width
-    draw.ellipse(
-        [inner_of_ring, inner_of_ring,
-         outer_r - 1 - ring_width, outer_r - 1 - ring_width],
-        fill=(0, 0, 0, 0),
-    )
-
-    # Small blue dot (~40% of the inner circle area)
-    inner_start = margin + ring_width + gap
-    inner_end = size - margin - ring_width - gap
-    inner_radius = (inner_end - inner_start) / 2
-    dot_radius = inner_radius * 0.4
-    center = size / 2
-    dot_start = int(center - dot_radius)
-    dot_end = int(center + dot_radius)
-    if dot_end > dot_start:
-        draw.ellipse(
-            [dot_start, dot_start, dot_end, dot_end],
-            fill=COLOR_DICTATION_INNER,
-        )
-
-    return img
-
-
 def _circle_icon(color: str, size: int = 64) -> Image.Image:
-    """Legacy single-color circle - both rings same color."""
-    return _make_dual_icon(color, color, size)
+    """Backward-compat wrapper - both rings same color."""
+    return _make_three_ring_icon(color, color, size=size)
 
 
 # --- Public icon constructors ---
@@ -114,18 +80,18 @@ def _circle_icon(color: str, size: int = 64) -> Image.Image:
 
 
 def idle_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_IDLE, COLOR_IDLE)
+    return _make_three_ring_icon("#808080", "#808080")
 
 
 def recording_icon(speaker_ok: bool = True) -> Image.Image:
     """Meeting recording - outer ring reflects speaker loopback status."""
     outer = COLOR_RECORDING_OUTER if speaker_ok else COLOR_RECORDING_FAIL
-    return _make_dual_icon(COLOR_RECORDING_INNER, outer)
+    return _make_three_ring_icon(outer, COLOR_RECORDING_INNER)
 
 
 def dictation_icon() -> Image.Image:
-    """Dictation - mic active (inner blue), outer white/gray."""
-    return _make_dual_icon(COLOR_DICTATION_INNER, COLOR_DICTATION_OUTER)
+    """Dictation - outer white/gray, middle blue."""
+    return _make_three_ring_icon(COLOR_DICTATION_OUTER, COLOR_DICTATION_INNER)
 
 
 def dictation_during_recording_icon(speaker_ok: bool = True) -> Image.Image:
@@ -133,44 +99,46 @@ def dictation_during_recording_icon(speaker_ok: bool = True) -> Image.Image:
 
     Outer ring = dark red (meeting still recording), or yellow if speaker
     loopback is unhealthy.
-    Inner = small blue dot (dictation active).
+    Middle = red (recording).
+    Inner dot = blue (dictation active).
     """
     outer = COLOR_RECORDING_OUTER if speaker_ok else COLOR_RECORDING_FAIL
-    return _make_overlay_icon(outer)
+    return _make_three_ring_icon(outer, COLOR_RECORDING_INNER, COLOR_DICTATION_INNER)
 
 
 def dictation_during_transcription_icon() -> Image.Image:
     """Dictation active during meeting transcription.
 
     Outer ring = dark amber (meeting transcribing).
-    Inner = small blue dot (dictation active).
+    Middle = amber (transcribing).
+    Inner dot = blue (dictation active).
     """
-    return _make_overlay_icon(COLOR_TRANSCRIBING_OUTER)
+    return _make_three_ring_icon(COLOR_TRANSCRIBING_OUTER, COLOR_TRANSCRIBING_INNER, COLOR_DICTATION_INNER)
 
 
 def saving_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_SAVING, COLOR_SAVING)
+    return _make_three_ring_icon(COLOR_SAVING_OUTER, COLOR_SAVING_INNER)
 
 
 def transcribing_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_TRANSCRIBING_INNER, COLOR_TRANSCRIBING_OUTER)
+    return _make_three_ring_icon(COLOR_TRANSCRIBING_OUTER, COLOR_TRANSCRIBING_INNER)
 
 
 def done_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_DONE, COLOR_DONE)
+    return _make_three_ring_icon(COLOR_DONE_OUTER, COLOR_DONE_INNER)
 
 
 def summarizing_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_SUMMARIZING, COLOR_SUMMARIZING)
+    return _make_three_ring_icon(COLOR_SUMMARIZING_OUTER, COLOR_SUMMARIZING_INNER)
 
 
 def queued_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_QUEUED, COLOR_QUEUED)
+    return _make_three_ring_icon(COLOR_QUEUED_OUTER, COLOR_QUEUED_INNER)
 
 
 def error_icon() -> Image.Image:
-    return _make_dual_icon(COLOR_ERROR, COLOR_ERROR)
+    return _make_three_ring_icon(COLOR_ERROR_OUTER, COLOR_ERROR_INNER)
 
 
 def yellow_flash_icon(size: int = 64) -> Image.Image:
-    return _make_dual_icon("#FFCC00", "#FFCC00", size=size)
+    return _make_three_ring_icon("#FFCC00", "#FFCC00", size=size)

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -62,7 +62,7 @@ def _make_three_ring_icon(outer_color: str, middle_color: str,
         dot_radius = 4
         cx, cy = size // 2, size // 2
         draw.ellipse(
-            [cx - dot_radius, cy - dot_radius, cx + dot_radius, cy + dot_radius],
+            [cx - dot_radius, cy - dot_radius, cx + dot_radius - 1, cy + dot_radius - 1],
             fill=inner_color,
         )
 
@@ -80,7 +80,7 @@ def _circle_icon(color: str, size: int = 64) -> Image.Image:
 
 
 def idle_icon() -> Image.Image:
-    return _make_three_ring_icon("#808080", "#808080")
+    return _make_three_ring_icon(COLOR_IDLE, COLOR_IDLE)
 
 
 def recording_icon(speaker_ok: bool = True) -> Image.Image:

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -170,3 +170,7 @@ def queued_icon() -> Image.Image:
 
 def error_icon() -> Image.Image:
     return _make_dual_icon(COLOR_ERROR, COLOR_ERROR)
+
+
+def yellow_flash_icon(size: int = 64) -> Image.Image:
+    return _make_dual_icon("#FFCC00", "#FFCC00", size=size)


### PR DESCRIPTION
## Summary
Replaces the in-process BackupTranscriber (which segfaulted) with a subprocess-based worker.

### Root cause
CTranslate2 cannot initialize in a process that already has a worker subprocess with its own C++ runtime context. Both whisperx.load_model and faster_whisper.WhisperModel crash when loaded in the main process.

### Fix
BackupTranscriber now wraps a second TranscriptionWorker subprocess configured for CPU. Same worker_main entry point, same queue protocol. Main process never imports torch/CTranslate2.

### Changes
- `backup_worker.py`: Complete rewrite. Removed all model loading code. Now spawns TranscriptionWorker subprocess.
- `__main__.py`: Added backup.stop() to shutdown paths. Replaced old API references (unload, reload_if_needed, device, get_vram_warning) with subprocess equivalents.

### Architecture
```
Main process (UI only)
  +-- Primary worker subprocess (GPU, large-v3)
  +-- Backup worker subprocess (CPU, small) - spawned on first meeting
```

## Test plan
- [ ] Start meeting, verify "Spawning backup worker" in log
- [ ] Dictation during meeting (Ctrl+Shift+Space)
- [ ] Verify no segfault
- [ ] Verify app shuts down cleanly (both workers stop)
- [ ] Verify dictation falls back to primary if backup fails