### PR TITLE
feat: backup dictation via subprocess (fixes segfault)

### DIFF
--- a/.github/governance/policy.yaml
+++ b/.github/governance/policy.yaml
@@ -6,6 +6,11 @@ merge_policy:
   auto_merge_enabled: true
   require_copilot_review: true
   require_zero_suggestions: true
+  manual_merge_prohibited: true
+  # All merges must go through auto-merge workflow after Copilot review.
+  # Manual gh pr merge or GitHub UI merge is a policy violation.
+  # The review-logger flags manual merges as anomalies.
+  # Emergency override: requires explicit user approval in conversation first.
   complexity_gates:
     low: auto
     medium: auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,13 @@ output_dir/
 - **Text style**: No em dash characters. Use single hyphens for asides.
 - **Author**: `--author="Pendentive <pendentive.info@gmail.com>"` for all commits.
 - **PRs**: Always wait for Copilot review before merging. Update docs in the same PR.
+- **Merging**: NEVER merge manually (gh pr merge, GitHub UI). All merges go through auto-merge workflow after Copilot review. No exceptions without explicit user approval in conversation first. See `.github/governance/policy.yaml`.
+- **Spec first**: Use superpowers:brainstorming to define spec, get user approval, then implement via PR.
 
 ## Guardrails
 
 ### Do NOT
+- Merge PRs manually (policy violation - logged by review-logger)
 - Modify `config.defaults.json` without updating `_VALID_KEYS` in `config.py`
 - Add blanket warning suppressions
 - Change multiprocessing context from "spawn"

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -315,7 +315,7 @@ class WhisperSync:
         return get_dictation_log_dir()
 
     def _start_dictation(self):
-        if not self.worker.is_ready() and not (self._meeting_transcribing and self._backup.is_enabled()):
+        if not self.worker.is_ready() and not (self._meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)):
             logger.warning("Worker not ready yet - ignoring dictation request")
             return
         self.mode = "dictation"
@@ -347,7 +347,7 @@ class WhisperSync:
         self._update_icon()
 
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
-        use_backup = self._meeting_transcribing and self._backup.is_enabled()
+        use_backup = self._meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)
 
         def _process():
             import time as _time
@@ -364,7 +364,7 @@ class WhisperSync:
                         used_backup = True
                         t1 = _time.perf_counter()
                         backup_model = self.cfg.get("backup_model", "base")
-                        backup_device = self._backup.device
+                        backup_device = self.cfg.get("backup_device", "cpu")
                         logger.info(
                             f"Dictation (backup, {backup_device} {backup_model}): "
                             f"{t1 - t0:.2f}s"
@@ -449,7 +449,7 @@ class WhisperSync:
 
         meeting_state = "recording" if self.mode == "meeting" else "transcribing"
         backup_model = self.cfg.get("backup_model", "base")
-        backup_device = self._backup.device
+        backup_device = self.cfg.get("backup_device", "cpu")
         logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)")
         logger.info(f"Backup model: {backup_model} on {backup_device}")
 
@@ -494,7 +494,7 @@ class WhisperSync:
                 duration = t1 - t0
                 char_count = len(text) if text else 0
                 backup_model = self.cfg.get("backup_model", "base")
-                backup_device = self._backup.device
+                backup_device = self.cfg.get("backup_device", "cpu")
                 logger.info(
                     f"Dictation during meeting: {duration:.1f}s, {char_count} chars "
                     f"(backup {backup_device} {backup_model})"
@@ -2479,7 +2479,7 @@ class WhisperSync:
         state = "enabled" if self.cfg["always_available_dictation"] else "disabled"
         logger.info(f"Always Available Dictation: {state}")
         if not self.cfg["always_available_dictation"]:
-            self._backup.unload()
+            self._backup.stop()
         self._save_and_refresh()
 
     def _set_backup_device(self, device: str):
@@ -2487,7 +2487,8 @@ class WhisperSync:
             return
         self.cfg["backup_device"] = device
         logger.info(f"Backup device: {device}")
-        self._backup.reload_if_needed()
+        self._backup.stop()
+        self._backup.preload()
         self._save_and_refresh()
 
     def _set_backup_model(self, model_name: str):
@@ -2495,16 +2496,8 @@ class WhisperSync:
             return
         self.cfg["backup_model"] = model_name
         logger.info(f"Backup model: {model_name}")
-        # Check VRAM and warn if needed
-        primary_model = self.cfg.get("model", "large-v3")
-        warning = self._backup.get_vram_warning(primary_model, model_name)
-        if warning:
-            try:
-                notify("VRAM Warning", warning)
-            except Exception:
-                pass
-            logger.warning(warning)
-        self._backup.reload_if_needed()
+        self._backup.stop()
+        self._backup.preload()
         self._save_and_refresh()
 
     def _set_model(self, key: str, model_name: str):
@@ -2603,6 +2596,7 @@ class WhisperSync:
         if self.recorder.is_recording:
             self.recorder.stop()
         self.worker.stop()
+        self._backup.stop()
         keyboard.unhook_all()
         subprocess.Popen(
             [sys.executable, "-m", "whisper_sync"],
@@ -2615,6 +2609,7 @@ class WhisperSync:
         if self.recorder.is_recording:
             self.recorder.stop()
         self.worker.stop()
+        self._backup.stop()
         keyboard.unhook_all()
         if self.tray:
             self.tray.stop()
@@ -2714,9 +2709,9 @@ class WhisperSync:
         logger.info(f"Log file: {get_log_path()}")
         if self.cfg.get("incognito"):
             logger.info("Incognito mode active -- dictation data not stored on disk")
-        if self._backup.is_enabled():
+        if BackupTranscriber.is_enabled(self.cfg):
             backup_model = self.cfg.get("backup_model", "base")
-            backup_device = self.cfg.get("backup_device", "auto")
+            backup_device = self.cfg.get("backup_device", "cpu")
             logger.info(f"Always Available Dictation: on (backup model: {backup_model}, device: {backup_device})")
         logger.info("Right-click tray icon for menu.")
 
@@ -2754,6 +2749,7 @@ class WhisperSync:
             # Always release keyboard hooks to prevent stuck modifier keys
             keyboard.unhook_all()
             self.worker.stop()
+            self._backup.stop()
             if self._github_poller:
                 self._github_poller.stop()
 

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -1,17 +1,8 @@
-"""Lightweight backup transcriber for dictation during meetings.
+"""Backup transcription worker for dictation during meetings.
 
-When the main worker subprocess is busy with meeting transcription,
-this module provides a fallback path using a smaller model loaded
-directly in the main process. It runs in a background thread (not a
-separate process) since dictation audio is short (5-30s) and
-transcription completes in 1-3s on CPU or <1s on GPU with a small model.
-
-The model is loaded lazily on first use and kept in memory for
-subsequent calls. Call unload() to free it explicitly.
-
-NOTE: WhisperX is loaded in the main process thread for simplicity.
-The backup model is small and transcription is brief (~1-3s). If
-stability issues arise, migrate to a subprocess model.
+Spawns a second TranscriptionWorker subprocess on CPU with a smaller model.
+The subprocess uses the same worker_main entry point as the primary worker.
+Main process never imports torch/CTranslate2 (avoids segfaults).
 """
 
 import threading
@@ -19,172 +10,93 @@ import threading
 import numpy as np
 
 from .logger import logger
-
-# Approximate VRAM usage per model in GB (float16 on GPU)
-MODEL_VRAM_GB = {
-    "tiny": 1.0,
-    "base": 1.0,
-    "small": 2.0,
-    "medium": 4.0,
-    "large-v2": 3.0,
-    "large-v3": 3.0,
-}
-
-VRAM_THRESHOLD = 0.80  # warn if combined usage exceeds 80% of total
+from . import config
 
 
 class BackupTranscriber:
-    """Lightweight backup transcriber for dictation during meetings.
+    """Manages a backup transcription subprocess for dictation during meetings.
 
-    Loads lazily on first use. Runs in the calling thread (main process).
-    Uses a smaller model on CPU or GPU depending on config.
+    Spawned on first meeting start. Stays alive until app closes.
+    Uses TranscriptionWorker (same as primary) but configured for CPU.
     """
 
     def __init__(self, cfg: dict):
         self.cfg = cfg
-        self._model = None
-        self._device = None
-        self._compute_type = None
-        self._model_name = None
-        self._loading = False
-        self._lock = threading.Lock()
+        self._worker = None
+        self._spawning = False
+        self._spawn_lock = threading.Lock()
+
+    def preload(self):
+        """Spawn backup subprocess and pre-load model. Called on meeting start.
+
+        Idempotent: does nothing if already spawned or spawning.
+        Runs spawn in a background thread so it doesn't block meeting start.
+        """
+        if self._worker is not None or self._spawning:
+            return
+
+        def _do_spawn():
+            with self._spawn_lock:
+                if self._worker is not None:
+                    return
+                self._spawning = True
+                try:
+                    from .worker_manager import TranscriptionWorker
+
+                    backup_model = self.cfg.get("backup_model", "base")
+                    backup_cfg = {**self.cfg}
+                    backup_cfg["device"] = "cpu"
+                    backup_cfg["model"] = backup_model
+                    backup_cfg["compute_type"] = "int8"
+
+                    logger.info(f"Spawning backup worker (CPU, {backup_model})...")
+                    worker = TranscriptionWorker(backup_cfg, preload_model=backup_model)
+                    worker.start()
+
+                    if worker.wait_ready(timeout=30):
+                        self._worker = worker
+                        logger.info(f"Backup worker ready (CPU, {backup_model})")
+                    else:
+                        logger.warning("Backup worker failed to start within 30s")
+                        worker.stop()
+                finally:
+                    self._spawning = False
+
+        threading.Thread(target=_do_spawn, daemon=True, name="backup-spawn").start()
 
     @property
     def is_loading(self) -> bool:
-        return self._loading
-
-    def is_enabled(self) -> bool:
-        return self.cfg.get("always_available_dictation", True)
-
-    def preload(self):
-        """Pre-load backup model. Currently disabled pending subprocess rewrite.
-
-        Loading any CTranslate2 model in the main process segfaults because the
-        worker subprocess already owns a CTranslate2/torch context. The backup
-        model needs its own subprocess (like TranscriptionWorker).
-        """
-        # TODO: Reimplement using a second TranscriptionWorker subprocess
-        logger.debug("Backup preload skipped (subprocess implementation pending)")
+        """True while subprocess is spawning or model is loading."""
+        return self._spawning
 
     @property
-    def device(self) -> str:
-        """Current device string, or 'not loaded' if model is not loaded."""
-        return self._device or "not loaded"
+    def is_ready(self) -> bool:
+        """True when backup worker is alive and model is loaded."""
+        return self._worker is not None and self._worker.is_ready()
 
     def transcribe(self, audio_np: np.ndarray) -> str:
-        """Transcribe audio using the backup model. Loads model on first call.
+        """Transcribe audio using the backup subprocess.
 
-        Args:
-            audio_np: Raw audio as float32 or int16 numpy array (16kHz mono).
-
-        Returns:
-            Transcribed text. Raises on failure (caller handles).
+        Sends a transcribe_fast request to the backup worker.
+        Raises RuntimeError if backup worker is not available.
         """
-        with self._lock:
-            # Backup transcription disabled - CTranslate2 cannot load in main process
-            # TODO: Reimplement with subprocess-based worker
-            raise RuntimeError(
-                "Backup transcription unavailable (subprocess implementation pending). "
-                "Dictation will queue on the primary worker instead."
-            )
+        if self._worker is None:
+            raise RuntimeError("Backup worker not started")
+        if not self._worker.is_ready():
+            raise RuntimeError("Backup worker not ready")
 
-    def _load(self):
-        """Lazily load the backup model.
+        return self._worker.transcribe_fast(audio_np)
 
-        Uses faster_whisper directly instead of whisperx.load_model to avoid
-        initializing PyAnnote VAD in the main process. WhisperX's load_model
-        triggers torch/MKL in a way that conflicts with the worker subprocess's
-        torch context, causing segfaults. The backup model only needs raw
-        transcription for dictation, not VAD/alignment/diarization.
-        """
-        from faster_whisper import WhisperModel
+    def stop(self):
+        """Shut down the backup subprocess."""
+        if self._worker is not None:
+            logger.info("Stopping backup worker...")
+            self._worker.stop()
+            self._worker = None
 
-        model_name = self.cfg.get("backup_model", "base")
-        device = self._resolve_device()
-        compute_type = "int8" if device == "cpu" else self.cfg.get("compute_type", "float16")
-
-        logger.info(f"Backup model loading [{device}] {model_name} ({compute_type})...")
-        self._model = WhisperModel(
-            model_name,
-            device=device,
-            compute_type=compute_type,
-        )
-        self._device = device
-        self._compute_type = compute_type
-        self._model_name = model_name
-        logger.info(f"Backup model ready [{device}] {model_name}")
-
-    def _resolve_device(self) -> str:
-        """Determine device for backup model. Always CPU unless explicitly overridden."""
-        backup_device = self.cfg.get("backup_device", "cpu")
-
-        if backup_device in ("gpu", "cuda"):
-            main_device = self.cfg.get("device", "auto")
-            if main_device in ("gpu", "cuda"):
-                logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
-            return "cuda"
-
-        return "cpu"
-
-    def unload(self):
-        """Free the backup model from memory."""
-        with self._lock:
-            if self._model is not None:
-                logger.info("Unloading backup model")
-                self._model = None
-                self._device = None
-                self._compute_type = None
-                self._model_name = None
-                # Try to free GPU memory
-                try:
-                    import torch
-                    if torch.cuda.is_available():
-                        torch.cuda.empty_cache()
-                except Exception:
-                    pass
-
-    def needs_reload(self) -> bool:
-        """Check if config changed and model needs reloading."""
-        if self._model is None:
-            return False
-        return (
-            self._model_name != self.cfg.get("backup_model", "base")
-            or self._device != self._resolve_device()
-        )
-
-    def reload_if_needed(self):
-        """Reload the backup model if config has changed."""
-        if self.needs_reload():
-            self.unload()
-            # Will lazy-load on next transcribe()
-
-    def get_vram_warning(self, primary_model: str, backup_model: str) -> str | None:
-        """Check if primary + backup would exceed 80% VRAM.
-
-        Returns warning string or None if OK.
-        """
-        try:
-            import torch
-            if not torch.cuda.is_available():
-                return None  # no GPU, no VRAM concern
-
-            total_vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
-            primary_vram = MODEL_VRAM_GB.get(primary_model, 3.0)
-            backup_vram = MODEL_VRAM_GB.get(backup_model, 1.0)
-            combined = primary_vram + backup_vram
-            threshold = total_vram * VRAM_THRESHOLD
-
-            if combined > threshold:
-                backup_device = self.cfg.get("backup_device", "auto")
-                if backup_device == "auto":
-                    advice = "Backup will use CPU in auto mode."
-                else:
-                    advice = "Consider switching to a smaller model or CPU to avoid OOM."
-                return (
-                    f"{primary_model} + {backup_model} need ~{combined:.1f} GB VRAM "
-                    f"({total_vram:.1f} GB total, {threshold:.1f} GB safe limit). "
-                    f"{advice}"
-                )
-        except Exception:
-            pass
-        return None
+    @staticmethod
+    def is_enabled(cfg: dict = None) -> bool:
+        """Check if always-available dictation is enabled."""
+        if cfg is None:
+            cfg = config.load()
+        return cfg.get("always_available_dictation", True)

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -1,8 +1,12 @@
 """Backup transcription worker for dictation during meetings.
 
-Spawns a second TranscriptionWorker subprocess on CPU with a smaller model.
+Spawns a second TranscriptionWorker subprocess with a smaller model.
 The subprocess uses the same worker_main entry point as the primary worker.
 Main process never imports torch/CTranslate2 (avoids segfaults).
+
+The config snapshot passed to the subprocess includes an ``override()`` call
+so that ``config.load()`` inside the subprocess returns the backup-specific
+device, model, and compute_type rather than the user's primary config.
 """
 
 import threading
@@ -17,7 +21,8 @@ class BackupTranscriber:
     """Manages a backup transcription subprocess for dictation during meetings.
 
     Spawned on first meeting start. Stays alive until app closes.
-    Uses TranscriptionWorker (same as primary) but configured for CPU.
+    Uses TranscriptionWorker (same as primary) but configured per
+    the user's backup_device setting (defaults to CPU).
     """
 
     def __init__(self, cfg: dict):
@@ -32,34 +37,46 @@ class BackupTranscriber:
         Idempotent: does nothing if already spawned or spawning.
         Runs spawn in a background thread so it doesn't block meeting start.
         """
-        if self._worker is not None or self._spawning:
-            return
+        # Fast check under lock to prevent race between concurrent callers
+        with self._spawn_lock:
+            if self._worker is not None or self._spawning:
+                return
+            self._spawning = True
 
         def _do_spawn():
-            with self._spawn_lock:
-                if self._worker is not None:
-                    return
-                self._spawning = True
-                try:
-                    from .worker_manager import TranscriptionWorker
+            try:
+                from .worker_manager import TranscriptionWorker
 
-                    backup_model = self.cfg.get("backup_model", "base")
-                    backup_cfg = {**self.cfg}
-                    backup_cfg["device"] = "cpu"
-                    backup_cfg["model"] = backup_model
-                    backup_cfg["compute_type"] = "int8"
+                backup_model = self.cfg.get("backup_model", "base")
+                backup_device = self.cfg.get("backup_device", "cpu")
+                backup_cfg = {**self.cfg}
+                backup_cfg["device"] = backup_device
+                backup_cfg["model"] = backup_model
+                backup_cfg["compute_type"] = (
+                    "int8" if backup_device == "cpu"
+                    else self.cfg.get("compute_type", "float16")
+                )
 
-                    logger.info(f"Spawning backup worker (CPU, {backup_model})...")
-                    worker = TranscriptionWorker(backup_cfg, preload_model=backup_model)
-                    worker.start()
+                main_device = self.cfg.get("device", "auto")
+                if backup_device in ("gpu", "cuda") and main_device != "cpu":
+                    logger.warning(
+                        "Backup model on GPU while main model also on GPU"
+                        " - may cause VRAM pressure"
+                    )
 
-                    if worker.wait_ready(timeout=30):
+                logger.info(f"Spawning backup worker ({backup_device}, {backup_model})...")
+                worker = TranscriptionWorker(backup_cfg, preload_model=backup_model)
+                worker.start()
+
+                if worker.wait_ready(timeout=30):
+                    with self._spawn_lock:
                         self._worker = worker
-                        logger.info(f"Backup worker ready (CPU, {backup_model})")
-                    else:
-                        logger.warning("Backup worker failed to start within 30s")
-                        worker.stop()
-                finally:
+                    logger.info(f"Backup worker ready ({backup_device}, {backup_model})")
+                else:
+                    logger.warning("Backup worker failed to start within 30s")
+                    worker.stop()
+            finally:
+                with self._spawn_lock:
                     self._spawning = False
 
         threading.Thread(target=_do_spawn, daemon=True, name="backup-spawn").start()
@@ -85,14 +102,18 @@ class BackupTranscriber:
         if not self._worker.is_ready():
             raise RuntimeError("Backup worker not ready")
 
-        return self._worker.transcribe_fast(audio_np)
+        backup_model = self.cfg.get("backup_model", "base")
+        return self._worker.transcribe_fast(
+            audio_np, model_override=backup_model
+        )
 
     def stop(self):
         """Shut down the backup subprocess."""
-        if self._worker is not None:
-            logger.info("Stopping backup worker...")
-            self._worker.stop()
-            self._worker = None
+        with self._spawn_lock:
+            if self._worker is not None:
+                logger.info("Stopping backup worker...")
+                self._worker.stop()
+                self._worker = None
 
     @staticmethod
     def is_enabled(cfg: dict = None) -> bool:

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -1,4 +1,10 @@
-"""Configuration loader -- three-tier: defaults (shipped) + user overrides (config.json)."""
+"""Configuration loader -- three-tier: defaults (shipped) + user overrides (config.json).
+
+Supports an in-process override dict for subprocess isolation: when set via
+``override(cfg_snapshot)``, ``load()`` returns the snapshot instead of reading
+from disk.  This lets the backup worker subprocess pin its own device/model
+without touching the user's config file.
+"""
 
 import json
 from pathlib import Path
@@ -8,6 +14,9 @@ from .paths import get_config_path, get_legacy_config_path
 
 _DIR = Path(__file__).parent
 _DEFAULTS = _DIR / "config.defaults.json"
+
+# When set, load() returns this dict instead of reading from disk.
+_override: dict | None = None
 
 # Only these keys are persisted -- prevents stray objects from corrupting the file
 _VALID_KEYS = {
@@ -31,12 +40,29 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
     return merged
 
 
+def override(cfg_snapshot: dict | None) -> None:
+    """Pin an in-process config override (or clear it with None).
+
+    When set, ``load()`` returns ``cfg_snapshot`` directly, bypassing the
+    config file on disk.  Used by the backup worker subprocess so that
+    transcribe.py sees the backup-specific device/model/compute_type.
+    """
+    global _override
+    _override = dict(cfg_snapshot) if cfg_snapshot is not None else None
+
+
 def load() -> dict:
     """Load defaults, then overlay user overrides from config.json if present.
+
+    If an in-process override has been set via ``override()``, returns that
+    instead of reading from disk.
 
     Checks output_dir/.whispersync/config.json first, then falls back to the
     legacy whisper_sync/config.json for backwards compatibility.
     """
+    if _override is not None:
+        return dict(_override)
+
     with open(_DEFAULTS) as f:
         cfg = json.load(f)
 

--- a/whisper_sync/worker.py
+++ b/whisper_sync/worker.py
@@ -109,6 +109,12 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
     logging.getLogger("whisperx.vads.pyannote").setLevel(logging.WARNING)
     logging.getLogger("whisperx.diarize").setLevel(logging.WARNING)
 
+    # Pin the config snapshot so transcribe.py's config.load() returns
+    # the spawner's cfg (including backup device/model overrides) instead
+    # of reading the user's config file from disk.
+    from . import config as _config_mod
+    _config_mod.override(cfg_snapshot)
+
     # Set model cache env vars before any torch/whisperx imports
     from .paths import get_model_cache
     _MODEL_CACHE = get_model_cache()


### PR DESCRIPTION
## Summary
Replaces in-process BackupTranscriber with subprocess-based worker.

### Root cause
CTranslate2 segfaults when initialized in a process that already has a worker subprocess.

### Fix
BackupTranscriber now wraps a second TranscriptionWorker subprocess (CPU, small model).
Same worker_main, same queue protocol. Main process never imports torch.

### Changes
- backup_worker.py: Complete rewrite (subprocess wrapper)
- __main__.py: Updated all old API references, added stop() to shutdown paths

## Test plan
- [ ] Start meeting, verify backup worker spawns on CPU
- [ ] Dictation during meeting works without segfault
- [ ] App shuts down cleanly