### PR TITLE
feat: color-coded secondary log lines (light purple)

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -395,7 +395,7 @@ class WhisperSync:
                 if self.cfg.get("incognito"):
                     logger.info(f"Dictation: {t2 - t0:.2f}s -- {delivery} ({char_count} chars)")
                 else:
-                    log_dictation_result(text or "", t2 - t0, delivery, char_count)
+                    log_dictation_result(text or "", t2 - t0, delivery, char_count, secondary=used_backup)
                 effective_model = self.cfg.get("backup_model", "base") if used_backup else dictation_model
                 logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={effective_model}{' (backup)' if used_backup else ''}")
                 # Update session stats
@@ -525,7 +525,7 @@ class WhisperSync:
                 if incognito:
                     logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
                 else:
-                    log_dictation_result(text or "", duration, delivery, char_count)
+                    log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
 
             except Exception as e:
                 logger.error(f"Overlay dictation error: {e}", extra={"secondary": True})
@@ -565,7 +565,7 @@ class WhisperSync:
                     if incognito:
                         logger.info(f"Overlay dictation fallback: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
                     else:
-                        log_dictation_result(text or "", duration, delivery, char_count)
+                        log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
                 except Exception as fallback_err:
                     logger.error(f"Overlay dictation fallback also failed: {fallback_err}", extra={"secondary": True})
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -299,12 +299,12 @@ class WhisperSync:
                 # Dictation during meeting recording or meeting transcription
                 if self.cfg.get("always_available_dictation", True):
                     if self._backup.is_loading:
-                        logger.debug("Backup model still loading, triggering yellow flash")
+                        logger.debug("Backup model still loading, triggering yellow flash", extra={"secondary": True})
                         self._yellow_flash()
                         return
                     self._start_overlay_dictation()
                 else:
-                    logger.info("Dictation unavailable during meeting (always_available_dictation disabled)")
+                    logger.info("Dictation unavailable during meeting (always_available_dictation disabled)", extra={"secondary": True})
                     notify("Dictation unavailable", "Enable always-available dictation in settings")
             elif self.mode == "saving":
                 logger.debug("Dictation ignored - meeting is saving")
@@ -367,12 +367,13 @@ class WhisperSync:
                         backup_device = self.cfg.get("backup_device", "cpu")
                         logger.info(
                             f"Dictation (backup, {backup_device} {backup_model}): "
-                            f"{t1 - t0:.2f}s"
+                            f"{t1 - t0:.2f}s",
+                            extra={"secondary": True},
                         )
                     except Exception as backup_err:
                         # Backup failed - fall back to queuing on the main worker
-                        logger.warning(f"Backup transcriber failed: {backup_err}")
-                        logger.info("Falling back to main worker (queued)")
+                        logger.warning(f"Backup transcriber failed: {backup_err}", extra={"secondary": True})
+                        logger.info("Falling back to main worker (queued)", extra={"secondary": True})
                         self._flash_queued()
                         timeout = 180
                         text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
@@ -450,8 +451,8 @@ class WhisperSync:
         meeting_state = "recording" if self.mode == "meeting" else "transcribing"
         backup_model = self.cfg.get("backup_model", "base")
         backup_device = self.cfg.get("backup_device", "cpu")
-        logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)")
-        logger.info(f"Backup model: {backup_model} on {backup_device}")
+        logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)", extra={"secondary": True})
+        logger.info(f"Backup model: {backup_model} on {backup_device}", extra={"secondary": True})
 
         # Create a separate recorder for dictation audio (mic only)
         self._overlay_recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
@@ -460,7 +461,7 @@ class WhisperSync:
             mic = None
         self._overlay_recorder.start(mic_device=mic)
         self._dictation_overlay = True
-        logger.info("Dictation during meeting: recording started")
+        logger.info("Dictation during meeting: recording started", extra={"secondary": True})
         self._update_icon()
 
     def _stop_overlay_dictation(self):
@@ -475,14 +476,14 @@ class WhisperSync:
         self._update_icon()
 
         if "mic" not in audio:
-            logger.debug("Overlay dictation stopped - no audio captured")
+            logger.debug("Overlay dictation stopped - no audio captured", extra={"secondary": True})
             self._overlay_recorder = None
             return
 
         overlay_audio = audio["mic"]
         self._overlay_recorder = None
 
-        logger.info("Dictation during meeting: transcribing...")
+        logger.info("Dictation during meeting: transcribing...", extra={"secondary": True})
 
         def _process_overlay():
             import time as _time
@@ -497,7 +498,8 @@ class WhisperSync:
                 backup_device = self.cfg.get("backup_device", "cpu")
                 logger.info(
                     f"Dictation during meeting: {duration:.1f}s, {char_count} chars "
-                    f"(backup {backup_device} {backup_model})"
+                    f"(backup {backup_device} {backup_model})",
+                    extra={"secondary": True},
                 )
                 if text:
                     paste(text, self.cfg["paste_method"])
@@ -521,17 +523,17 @@ class WhisperSync:
 
                 delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
                 if incognito:
-                    logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)")
+                    logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
                 else:
                     log_dictation_result(text or "", duration, delivery, char_count)
 
             except Exception as e:
-                logger.error(f"Overlay dictation error: {e}")
+                logger.error(f"Overlay dictation error: {e}", extra={"secondary": True})
                 import traceback
                 logger.debug(traceback.format_exc())
                 # Fall back to queuing on main worker if backup fails
                 try:
-                    logger.info("Falling back to main worker for overlay dictation")
+                    logger.info("Falling back to main worker for overlay dictation", extra={"secondary": True})
                     dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
                     timeout = 180
                     text = self.worker.transcribe_fast(overlay_audio, model_override=dictation_model, timeout=timeout)
@@ -540,7 +542,7 @@ class WhisperSync:
                     t1 = _time.perf_counter()
                     duration = t1 - t0
                     char_count = len(text or "")
-                    logger.info(f"Overlay dictation fallback: {duration:.2f}s, {char_count} chars")
+                    logger.info(f"Overlay dictation fallback: {duration:.2f}s, {char_count} chars", extra={"secondary": True})
 
                     # Post-dictation bookkeeping (same as the normal overlay path)
                     self._stats["dictations"] += 1
@@ -561,11 +563,11 @@ class WhisperSync:
 
                     delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
                     if incognito:
-                        logger.info(f"Overlay dictation fallback: {duration:.2f}s - {delivery} ({char_count} chars)")
+                        logger.info(f"Overlay dictation fallback: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
                     else:
                         log_dictation_result(text or "", duration, delivery, char_count)
                 except Exception as fallback_err:
-                    logger.error(f"Overlay dictation fallback also failed: {fallback_err}")
+                    logger.error(f"Overlay dictation fallback also failed: {fallback_err}", extra={"secondary": True})
 
         threading.Thread(target=_process_overlay, daemon=True).start()
 
@@ -732,7 +734,7 @@ class WhisperSync:
                 self._overlay_recorder.stop()
                 self._overlay_recorder = None
                 self._dictation_overlay = False
-                logger.info("Overlay dictation discarded (left-click)")
+                logger.info("Overlay dictation discarded (left-click)", extra={"secondary": True})
                 self._update_icon()
                 return
 
@@ -2486,7 +2488,7 @@ class WhisperSync:
         if self.cfg.get("backup_device", "auto") == device:
             return
         self.cfg["backup_device"] = device
-        logger.info(f"Backup device: {device}")
+        logger.info(f"Backup device: {device}", extra={"secondary": True})
         self._backup.stop()
         self._backup.preload()
         self._save_and_refresh()
@@ -2495,7 +2497,7 @@ class WhisperSync:
         if self.cfg.get("backup_model", "base") == model_name:
             return
         self.cfg["backup_model"] = model_name
-        logger.info(f"Backup model: {model_name}")
+        logger.info(f"Backup model: {model_name}", extra={"secondary": True})
         self._backup.stop()
         self._backup.preload()
         self._save_and_refresh()
@@ -2712,7 +2714,7 @@ class WhisperSync:
         if BackupTranscriber.is_enabled(self.cfg):
             backup_model = self.cfg.get("backup_model", "base")
             backup_device = self.cfg.get("backup_device", "cpu")
-            logger.info(f"Always Available Dictation: on (backup model: {backup_model}, device: {backup_device})")
+            logger.info(f"Always Available Dictation: on (backup model: {backup_model}, device: {backup_device})", extra={"secondary": True})
         logger.info("Right-click tray icon for menu.")
 
         # Startup toast notification

--- a/whisper_sync/backup_worker.py
+++ b/whisper_sync/backup_worker.py
@@ -61,19 +61,20 @@ class BackupTranscriber:
                 if backup_device in ("gpu", "cuda") and main_device != "cpu":
                     logger.warning(
                         "Backup model on GPU while main model also on GPU"
-                        " - may cause VRAM pressure"
+                        " - may cause VRAM pressure",
+                        extra={"secondary": True},
                     )
 
-                logger.info(f"Spawning backup worker ({backup_device}, {backup_model})...")
+                logger.info(f"Spawning backup worker ({backup_device}, {backup_model})...", extra={"secondary": True})
                 worker = TranscriptionWorker(backup_cfg, preload_model=backup_model)
                 worker.start()
 
                 if worker.wait_ready(timeout=30):
                     with self._spawn_lock:
                         self._worker = worker
-                    logger.info(f"Backup worker ready ({backup_device}, {backup_model})")
+                    logger.info(f"Backup worker ready ({backup_device}, {backup_model})", extra={"secondary": True})
                 else:
-                    logger.warning("Backup worker failed to start within 30s")
+                    logger.warning("Backup worker failed to start within 30s", extra={"secondary": True})
                     worker.stop()
             finally:
                 with self._spawn_lock:
@@ -111,7 +112,7 @@ class BackupTranscriber:
         """Shut down the backup subprocess."""
         with self._spawn_lock:
             if self._worker is not None:
-                logger.info("Stopping backup worker...")
+                logger.info("Stopping backup worker...", extra={"secondary": True})
                 self._worker.stop()
                 self._worker = None
 

--- a/whisper_sync/logger.py
+++ b/whisper_sync/logger.py
@@ -25,6 +25,7 @@ _C_YELLOW = "\033[33m"      # yellow for warnings
 _C_RED = "\033[31m"         # red for errors
 _C_MAGENTA = "\033[35m"     # magenta for transcription text
 _C_WHITE = "\033[37m"       # white for general info
+_C_SECONDARY = "\033[95m"  # light purple for backup/secondary operations
 
 # Enable ANSI on Windows
 if sys.platform == "win32":
@@ -82,6 +83,10 @@ class _ColorFormatter(logging.Formatter):
             msg_color = _C_CYAN
         else:
             msg_color = _C_WHITE
+
+        # Secondary flag overrides text color (backup/overlay operations)
+        if getattr(record, "secondary", False):
+            msg_color = _C_SECONDARY
 
         # Check if this is the verbose [WhisperSync] format
         if self._fmt and "WhisperSync" in self._fmt:

--- a/whisper_sync/logger.py
+++ b/whisper_sync/logger.py
@@ -85,7 +85,8 @@ class _ColorFormatter(logging.Formatter):
             msg_color = _C_WHITE
 
         # Secondary flag overrides text color (backup/overlay operations)
-        if getattr(record, "secondary", False):
+        # Only override INFO and DEBUG; preserve WARNING (yellow) and ERROR (red)
+        if getattr(record, "secondary", False) and record.levelno <= logging.INFO:
             msg_color = _C_SECONDARY
 
         # Check if this is the verbose [WhisperSync] format
@@ -178,18 +179,23 @@ def set_console_level(tier: str) -> None:
         _ch.setFormatter(_fmt_clean)
 
 
-def log_dictation_result(text: str, duration: float, delivery: str, chars: int) -> None:
+def log_dictation_result(text: str, duration: float, delivery: str, chars: int,
+                         secondary: bool = False) -> None:
     """Log a dictation result at appropriate tiers.
 
     Normal:   [HH:MM] Dictation: 0.67s -- pasted (97 chars)
     Detailed: adds text preview
     Verbose:  adds model info (handled by caller's own debug logs)
+
+    When *secondary* is True the log lines are tagged so the formatter
+    renders them in the secondary (light-purple) color.
     """
-    logger.info(f"Dictation: {duration:.2f}s -- {delivery} ({chars} chars)")
+    extra = {"secondary": True} if secondary else {}
+    logger.info(f"Dictation: {duration:.2f}s -- {delivery} ({chars} chars)", extra=extra)
     if text:
         # Truncate preview to 120 chars for readability
         preview = text[:120] + ("..." if len(text) > 120 else "")
-        logger.log(TRANSCRIPT, f'        "{preview}"')
+        logger.log(TRANSCRIPT, f'        "{preview}"', extra=extra)
 
 
 def log_meeting_result(name: str, duration_secs: float, words: int, speakers: int, folder: str) -> None:


### PR DESCRIPTION
## Summary
Backup/secondary operations now render in light purple in the log window, making it easy to distinguish primary vs backup subsystem activity at a glance.

Closes #62

### Changes
- `logger.py`: Added `_C_SECONDARY` ANSI color, formatter checks `record.secondary` flag
- `backup_worker.py`: All 5 logger calls marked as secondary
- `__main__.py`: 21 overlay dictation and backup-related log lines marked as secondary

### How it looks
```
[19:12] Dictation: 0.5s - pasted (42 chars)          <- white (primary)
[19:12] Dictation during meeting: 1.4s, 6 chars       <- light purple (secondary)
[19:12] Spawning backup worker (cpu, small)...         <- light purple (secondary)
```

## Test plan
- [ ] Start meeting, dictate, verify backup log lines are purple
- [ ] Normal dictation log lines stay white
- [ ] File log has no ANSI codes