### PR TITLE
Address Copilot review comments from PR #64

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,18 @@ Local speech-to-text for Windows. GPU-accelerated transcription with speaker dia
 
 | Module | Purpose |
 |--------|---------|
-| `__main__.py` | Entry point. Tray icon, hotkeys, mode state machine, recording flows, GitHub status, incognito, session stats |
+| `__main__.py` | Entry point. Tray icon, hotkeys, recording flows, GitHub status, incognito, session stats. Uses StateManager for all state transitions. |
+| `state_manager.py` | Observable state machine. AppState dataclass, typed StateEvent, event constants, thread-safe emit(), listener subscriptions (on/on_any), event log ringbuffer. All icon/toast updates flow through here. |
 | `transcribe.py` | WhisperX with persistent model cache. Fast path (dictation) and staged pipeline (meeting) |
 | `worker.py` | Multiprocessing transcription worker. CUDA isolation via spawn context |
 | `worker_manager.py` | Spawns/manages worker subprocess. Crash detection and auto-respawn |
 | `capture.py` | Mic + WASAPI loopback recording via sounddevice/PyAudioWPatch |
 | `channel_merge.py` | Per-channel diarization with confidence fusion for stereo recordings |
-| `config.py` | Config load/save. Merges defaults with user overrides. Only `_VALID_KEYS` persisted |
+| `config.py` | Config load/save. Merges defaults with user overrides. Only `_VALID_KEYS` persisted. Includes `toast_events` for notification config. |
 | `paths.py` | Data directory resolution. Standalone vs repo mode. All `.whispersync/` accessors |
 | `logger.py` | Tiered logging (off/normal/detailed/verbose). File handler always DEBUG |
-| `icons.py` | Dual-ring tray icon generation via PIL. No external image assets |
-| `notifications.py` | Windows toast notifications with button callbacks |
+| `icons.py` | Declarative icon registry (ICON_REGISTRY + IconSpec). build_icon() with progress-ring arc. IconAnimator for flash animations. Backward-compat wrappers for migration. |
+| `notifications.py` | Windows toast notifications with button callbacks. ToastListener (state event subscriber), TOAST_REGISTRY (configurable templates), notify_update() for in-place toasts via Tag/Group. |
 | `github_status.py` | Background PR polling via `gh` CLI. Copilot review state tracking |
 | `speakers.py` | AI speaker identification via Claude CLI |
 | `dictation_log.py` | Append-only daily markdown logs in `.whispersync/dictation-logs/` |
@@ -48,7 +49,7 @@ Two-phase bootstrap:
 
 Load order: defaults -> real config -> legacy config (fallback).
 
-Key settings: `model`, `dictation_model`, `output_dir`, `device` (auto/cpu/cuda), `hotkeys`, `paste_method`, `log_window`, `incognito`, `github_repo`, `left_click`, `middle_click`.
+Key settings: `model`, `dictation_model`, `output_dir`, `device` (auto/cpu/cuda), `hotkeys`, `paste_method`, `log_window`, `incognito`, `github_repo`, `left_click`, `middle_click`, `toast_events` (list of event types that trigger Windows toasts).
 
 ## Data Directory
 
@@ -77,7 +78,8 @@ output_dir/
 - **Config changes**: `config.save(cfg)` only. Never write config files directly.
 - **Worker comms**: Request/response queues with `request_id`. No shared state.
 - **Worker errors**: Catch exceptions, send `{type: "error", ...}`. Never let exceptions kill silently.
-- **Icons**: Generated in `icons.py`. No external image/font assets.
+- **Icons**: Generated via `icons.py` ICON_REGISTRY. No external image/font assets. Add new states by adding an IconSpec to the registry.
+- **State changes**: Always via `self.state.emit(EVENT, mode=..., data=...)`. Never set `self.mode` directly.
 - **Warning suppression**: Scoped only. Must specify `message=`, `category=`, and/or `module=`.
 - **Commits**: `fix(whisper-sync):`, `feat(whisper-sync):`, `ci:`, `docs:` prefixes.
 - **Text style**: No em dash characters. Use single hyphens for asides.

--- a/docs/specs/2026-03-24-state-manager-design.md
+++ b/docs/specs/2026-03-24-state-manager-design.md
@@ -2,7 +2,7 @@
 
 > **Date**: 2026-03-24
 > **Status**: Design
-> **Repo**: `N:/Github/repos/pendentive/whisper-sync/`
+> **Repo**: `https://github.com/Pendentive/whisper-sync`
 > **Approach**: A (Python-Native Refactor) with B/C evolution paths documented
 
 ## Context

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -91,8 +91,6 @@ class WhisperSync:
         self.cfg = config.load()
         set_console_level(self.cfg.get("log_window", "normal"))
         self.recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
-        self.mode = None  # None, "dictation", "meeting", "saving", "transcribing", "done", "error"
-        self._meeting_transcribing = False  # True while meeting transcription runs in background
         self.tray = None
         self.state = None  # Initialized after tray creation in run()
         self._lock = threading.Lock()
@@ -102,7 +100,6 @@ class WhisperSync:
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
         self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
         self._backup = BackupTranscriber(self.cfg)
-        self._dictation_overlay = False  # True while dictation runs during a meeting
         self._overlay_recorder = None    # Separate AudioRecorder for dictation during meetings
         self._github_poller = None
         self._github_prs = []
@@ -156,28 +153,6 @@ class WhisperSync:
                             shutil.copy2(f, dest)
                 logger.info(f"Migrated dictation logs -> {new_dict_dir}")
 
-    def _update_icon(self):
-        """Render tray icon from current state via the declarative icon registry.
-
-        This is a shim that reads old-style state (self.mode, self._meeting_transcribing,
-        self._dictation_overlay) and delegates rendering to the new icon system.
-        Once all call sites migrate to StateManager.emit(), this method will be removed.
-        """
-        if self.tray is None:
-            return
-        speaker_ok = getattr(self.recorder, "speaker_loopback_active", True) if hasattr(self, "recorder") else True
-        key = resolve_icon_key(
-            mode=self.mode,
-            meeting_transcribing=self._meeting_transcribing,
-            dictation_overlay=self._dictation_overlay,
-            speaker_ok=speaker_ok,
-        )
-        spec = ICON_REGISTRY[key]
-        progress = getattr(self, "_progress", None)
-        icon = build_icon(spec, progress=progress)
-        self.tray.icon = icon
-        self.tray.title = f"WhisperSync: {spec.tooltip}"
-
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
         if getattr(self, '_flashing', False):
@@ -203,8 +178,8 @@ class WhisperSync:
     def _on_left_click(self):
         # Left-click while dictating = discard (stop recording, throw away audio)
         current = self.state.current if self.state else None
-        mode = current.mode if current else self.mode
-        overlay = current.dictation_overlay if current else self._dictation_overlay
+        mode = current.mode if current else None
+        overlay = current.dictation_overlay if current else False
         if mode == "dictation" or overlay:
             self._discard_dictation()
             return
@@ -267,15 +242,15 @@ class WhisperSync:
 
     def _can_record(self) -> bool:
         """Can we start a new recording? Allowed if idle or just transcribing in background."""
-        mode = self.state.current.mode if self.state else self.mode
+        mode = self.state.current.mode if self.state else None
         return mode is None or mode in ("transcribing", "done", "error")
 
     def toggle_dictation(self):
         with self._lock:
             current = self.state.current if self.state else None
-            mode = current.mode if current else self.mode
-            overlay = current.dictation_overlay if current else self._dictation_overlay
-            meeting_tx = current.meeting_transcribing if current else self._meeting_transcribing
+            mode = current.mode if current else None
+            overlay = current.dictation_overlay if current else False
+            meeting_tx = current.meeting_transcribing if current else False
 
             # Handle overlay dictation during meetings
             if overlay:
@@ -304,7 +279,7 @@ class WhisperSync:
         return get_dictation_log_dir()
 
     def _start_dictation(self):
-        _meeting_tx = self.state.current.meeting_transcribing if self.state else self._meeting_transcribing
+        _meeting_tx = self.state.current.meeting_transcribing if self.state else False
         if not self.worker.is_ready() and not (_meeting_tx and BackupTranscriber.is_enabled(self.cfg)):
             logger.warning("Worker not ready yet - ignoring dictation request")
             return
@@ -432,7 +407,7 @@ class WhisperSync:
         # Note: always_available_dictation config flag already gates the call to
         # this method in toggle_dictation(), so no need to re-check is_enabled() here.
 
-        meeting_state = "recording" if (self.state.current.mode if self.state else self.mode) == "meeting" else "transcribing"
+        meeting_state = "recording" if (self.state.current.mode if self.state else None) == "meeting" else "transcribing"
         backup_model = self.cfg.get("backup_model", "base")
         backup_device = self.cfg.get("backup_device", "cpu")
         logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)", extra={"secondary": True})
@@ -444,19 +419,16 @@ class WhisperSync:
         if self.cfg.get("use_system_devices", True):
             mic = None
         self._overlay_recorder.start(mic_device=mic)
-        self._dictation_overlay = True
         logger.info("Dictation during meeting: recording started", extra={"secondary": True})
         self.state.emit(DICTATION_STARTED, dictation_overlay=True)
 
     def _stop_overlay_dictation(self):
         """Stop overlay dictation, transcribe with backup model, paste result."""
         if not self._overlay_recorder:
-            self._dictation_overlay = False
             self.state.emit(IDLE, dictation_overlay=False)
             return
 
         audio = self._overlay_recorder.stop()
-        self._dictation_overlay = False
         self.state.emit(DICTATION_COMPLETED, dictation_overlay=False)
 
         if "mic" not in audio:
@@ -711,16 +683,15 @@ class WhisperSync:
         """Discard current dictation - stop recording, throw away audio, return to idle."""
         with self._lock:
             # Handle overlay dictation discard
-            _overlay = self.state.current.dictation_overlay if self.state else self._dictation_overlay
+            _overlay = self.state.current.dictation_overlay if self.state else False
             if _overlay and self._overlay_recorder:
                 self._overlay_recorder.stop()
                 self._overlay_recorder = None
-                self._dictation_overlay = False
                 logger.info("Overlay dictation discarded (left-click)", extra={"secondary": True})
                 self.state.emit(DICTATION_DISCARDED, dictation_overlay=False)
                 return
 
-            if (self.state.current.mode if self.state else self.mode) != "dictation":
+            if (self.state.current.mode if self.state else None) != "dictation":
                 return
             self.recorder.stop()  # stop recording, discard the audio
             self.recorder.stop_streaming()
@@ -731,7 +702,7 @@ class WhisperSync:
 
     def toggle_meeting(self):
         with self._lock:
-            mode = self.state.current.mode if self.state else self.mode
+            mode = self.state.current.mode if self.state else None
             if mode == "meeting":
                 self._stop_meeting()
             elif self._can_record():
@@ -2701,10 +2672,6 @@ class WhisperSync:
             icon = build_icon(spec, progress=progress)
             self.tray.icon = icon
             self.tray.title = f"WhisperSync: {spec.tooltip}"
-            # Keep old vars in sync for any code paths not yet migrated
-            self.mode = s.mode
-            self._meeting_transcribing = s.meeting_transcribing
-            self._dictation_overlay = s.dictation_overlay
         self.state.on_any(_on_state_change)
 
         # Register toast notification listener

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -25,11 +25,8 @@ import pystray
 
 from . import config
 from .capture import AudioRecorder, get_default_devices, get_host_apis, list_devices, save_wav, save_stereo_wav
-from .icons import (idle_icon, recording_icon, dictation_icon, saving_icon,
-                     transcribing_icon, done_icon, queued_icon, error_icon,
-                     dictation_during_recording_icon, dictation_during_transcription_icon,
-                     build_icon, resolve_icon_key, ICON_REGISTRY, IconAnimator,
-                     yellow_flash_icon)
+from .icons import (idle_icon, build_icon, resolve_icon_key, ICON_REGISTRY,
+                     IconAnimator)
 from .logger import logger, get_log_path, set_console_level, log_dictation_result, log_meeting_result, log_transcript_preview
 from .model_status import get_model_status, download_model, bootstrap_models
 from .paste import paste
@@ -186,7 +183,6 @@ class WhisperSync:
         if getattr(self, '_flashing', False):
             return
         self._flashing = True
-        from .icons import IconAnimator
         animator = IconAnimator(self.tray)
         animator.flash(count=2, interval_ms=150)
         # Reset flag after animation completes (~600ms)
@@ -266,7 +262,6 @@ class WhisperSync:
 
     def _flash_queued(self):
         """Rapid amber flash to indicate dictation is queued behind a meeting stage."""
-        from .icons import IconAnimator
         animator = IconAnimator(self.tray)
         animator.flash_between("queued", "transcribing", count=2, interval_ms=150)
 

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -64,7 +64,7 @@ ICON_REGISTRY: dict[str, IconSpec] = {
 
     # Terminal states
     "done":  IconSpec("#44CC44", "#66FF66", tooltip="Done!"),
-    "error": IconSpec("#CC44CC", "#FF66FF", tooltip="Error"),
+    "error": IconSpec("#CC44CC", "#FF66FF", tooltip="Error - check console"),
 
     # Animation frames
     "flash": IconSpec("#FFCC00", "#FFCC00", tooltip="Loading..."),
@@ -96,7 +96,10 @@ def build_icon(spec: IconSpec, progress: float | None = None,
 
     # Outer ring (full, partial arc, or absent)
     if progress is not None and 0.0 < progress < 1.0:
-        start_angle = -90  # 12 o'clock in PIL coordinates
+        # PIL angles: 0=3 o'clock, increasing counterclockwise in math coords.
+        # On screen (Y-down), increasing angles render clockwise visually.
+        # -90 = 12 o'clock. Adding sweep fills clockwise on screen.
+        start_angle = -90
         sweep = 360 * progress
         draw.arc(
             [margin, margin, outer_r - 1, outer_r - 1],

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -157,7 +157,7 @@ def notify_update(tag: str, title: str, body: str, *, progress=None):
         toast.tag = tag
         toast.group = "whispersync"
         if progress is not None and _has_progress_bar:
-            toast.progress_bar = ToastProgressBar("", "", progress=progress)
+            toast.progress_bar = ToastProgressBar(title, body, progress=progress)
         _toaster.show_toast(toast)
     except Exception as exc:
         _logger.debug(f"Toast update failed: {exc}")
@@ -210,7 +210,14 @@ class ToastListener:
         self._config = config
 
     def __call__(self, event) -> None:
-        enabled = set(self._config.get("toast_events", DEFAULT_TOAST_EVENTS))
+        raw_events = self._config.get("toast_events", DEFAULT_TOAST_EVENTS)
+        if not isinstance(raw_events, (list, tuple, set)):
+            _logger.debug(
+                "Invalid toast_events config (%r); falling back to defaults",
+                raw_events,
+            )
+            raw_events = DEFAULT_TOAST_EVENTS
+        enabled = set(raw_events)
         if event.type not in enabled:
             return
 

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -118,13 +118,21 @@ class StateManager:
     def emit(self, event_type: str, *, data: dict | None = None, **state_changes):
         """Emit a typed event, update state, notify all listeners.
 
-        Thread-safe.  Listeners are called outside the lock.  Listeners
-        MUST NOT call emit() recursively (would deadlock).  If a listener
-        needs to trigger a follow-up state change, schedule it on a
-        background thread.
+        Thread-safe. Listeners are called outside the lock so they can read
+        state.current without blocking. While emit() may be called from
+        within a listener, doing so can create unbounded re-entrancy or event
+        loops if not carefully controlled. If a listener needs to trigger a
+        follow-up state change, prefer scheduling it on a background thread.
         """
         with self._lock:
             old = replace(self._state)
+            # Warn on unknown state fields (catches typos at call sites)
+            unknown_keys = [k for k in state_changes if not hasattr(self._state, k)]
+            if unknown_keys:
+                _logger.warning(
+                    "StateManager.emit received unknown state field(s): %s",
+                    ", ".join(sorted(unknown_keys)),
+                )
             for k, v in state_changes.items():
                 if hasattr(self._state, k):
                     setattr(self._state, k, v)
@@ -133,29 +141,34 @@ class StateManager:
                 timestamp=time.time(),
                 old_state=old,
                 new_state=replace(self._state),
-                data=data or {},
+                data=dict(data) if data is not None else {},
             )
             self._event_log.append(event)
+            # Snapshot listener lists under lock to avoid racey iteration
+            typed_cbs = list(self._typed_listeners.get(event_type, []))
+            global_cbs = list(self._global_listeners)
 
         # Notify outside lock
-        for cb in self._typed_listeners.get(event_type, []):
+        for cb in typed_cbs:
             try:
                 cb(event)
             except Exception:
                 _logger.exception("Typed listener error for %s", event_type)
-        for cb in self._global_listeners:
+        for cb in global_cbs:
             try:
                 cb(event)
             except Exception:
                 _logger.exception("Global listener error for %s", event_type)
 
     def on(self, event_type: str, callback: Callable[[StateEvent], None]):
-        """Subscribe to a specific event type."""
-        self._typed_listeners[event_type].append(callback)
+        """Subscribe to a specific event type. Thread-safe."""
+        with self._lock:
+            self._typed_listeners[event_type].append(callback)
 
     def on_any(self, callback: Callable[[StateEvent], None]):
-        """Subscribe to all events (for API server, dashboard, etc.)."""
-        self._global_listeners.append(callback)
+        """Subscribe to all events (for API server, dashboard, etc.). Thread-safe."""
+        with self._lock:
+            self._global_listeners.append(callback)
 
     # -- Properties --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Addresses all 10 Copilot review comments from #64 plus the docs freshness reminder.

**Fixes applied:**
- `notifications.py`: Progress bar uses title/caption (not empty strings); ToastListener validates `toast_events` config type with fallback
- `state_manager.py`: Copy `data` dict at emit time (prevents mutation); warn on unknown state fields (catches typos); snapshot listener lists under lock (thread-safe iteration); protect on()/on_any() with lock; clarify docstring on re-entrancy
- `icons.py`: Clarify PIL arc direction comment; restore "Error - check console" tooltip for parity with old code
- `__main__.py`: Remove unused icon imports and redundant local IconAnimator imports
- `docs/specs/`: Replace local Windows path with GitHub URL
- `CLAUDE.md`: Add state_manager.py to module map, update icons/notifications descriptions, document toast_events config key and state change convention

## Test plan
- [ ] Verify all imports resolve (no unused imports, no missing imports)
- [ ] Verify toast notifications still work with valid config
- [ ] Verify toast notifications degrade gracefully with invalid config (string instead of list)
- [ ] Verify state.emit() with typo key logs warning instead of silent ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)