### PR TITLE
feat: feature suggest mode + JSON dictation logs

### DIFF
--- a/build-dist.ps1
+++ b/build-dist.ps1
@@ -49,6 +49,8 @@ $pyFiles = @(
     "speakers.py",
     "speaker_prompt.md",
     "minutes_prompt.md",
+    "feature_log.py",
+    "feature_prompt.md",
     "split_meeting.py",
     "rebuild_index.py",
     "whisper-capture.ico"

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -38,6 +38,7 @@ from .paths import (get_install_root, get_default_output_dir, is_standalone,
 from .worker_manager import TranscriptionWorker, WorkerCrashedError
 from .backup_worker import BackupTranscriber
 from . import dictation_log
+from . import feature_log
 from .streaming_wav import fix_orphan
 from .crash_diagnostics import install_excepthook, check_previous_crash
 from .flatten import flatten as flatten_transcript
@@ -64,6 +65,13 @@ HOTKEY_OPTIONS = [
     "ctrl+alt+m",
     "ctrl+shift+t",
     "ctrl+alt+t",
+]
+
+FEATURE_HOTKEY_OPTIONS = [
+    "ctrl+shift+alt+f",
+    "ctrl+shift+alt+s",
+    "ctrl+shift+alt+r",
+    "ctrl+alt+f",
 ]
 
 PASTE_OPTIONS = ["clipboard", "keystrokes"]
@@ -104,10 +112,12 @@ class WhisperSync:
         self._github_poller = None
         self._github_prs = []
         self._dictation_history = dictation_log.load_recent(10)  # persist across restarts
+        self._feature_suggest_active = False  # routes dictation output to feature log
         # Session stats
         self._stats = {
             "dictations": 0,
             "meetings": 0,
+            "feature_suggestions": 0,
             "total_dictation_chars": 0,
             "total_dictation_time": 0.0,
             "total_meeting_seconds": 0,
@@ -275,6 +285,49 @@ class WhisperSync:
             elif self._can_record():
                 self._start_dictation()
 
+    def toggle_feature_suggest(self):
+        """Toggle feature suggestion recording (same as dictation but saves to feature log)."""
+        with self._lock:
+            current = self.state.current if self.state else None
+            mode = current.mode if current else None
+            overlay = current.dictation_overlay if current else False
+            meeting_tx = current.meeting_transcribing if current else False
+
+            # If already recording a feature suggestion, stop it
+            if overlay and self._feature_suggest_active:
+                self._stop_overlay_dictation()
+                return
+            if mode == "dictation" and self._feature_suggest_active:
+                self._stop_dictation()
+                return
+
+            # Start feature suggestion (reuses dictation pipeline)
+            if mode == "dictation" and not self._feature_suggest_active:
+                # Already recording a normal dictation - ignore
+                logger.debug("Feature suggest ignored - dictation in progress")
+                return
+
+            self._feature_suggest_active = True
+            if mode == "meeting" or (mode is None and meeting_tx):
+                if self.cfg.get("always_available_dictation", True):
+                    if self._backup.is_loading:
+                        self._feature_suggest_active = False
+                        logger.debug("Backup model still loading, triggering yellow flash", extra={"secondary": True})
+                        self._yellow_flash()
+                        return
+                    self._start_overlay_dictation()
+                else:
+                    self._feature_suggest_active = False
+                    logger.info("Feature suggest unavailable during meeting (always_available_dictation disabled)", extra={"secondary": True})
+                    notify("Feature suggest unavailable", "Enable always-available dictation in settings")
+            elif mode == "saving":
+                self._feature_suggest_active = False
+                logger.debug("Feature suggest ignored - meeting is saving")
+            elif self._can_record():
+                self._start_dictation()
+            else:
+                self._feature_suggest_active = False
+
     def _dictation_log_dir(self) -> Path:
         return get_dictation_log_dir()
 
@@ -349,33 +402,50 @@ class WhisperSync:
                     text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
                     t1 = _time.perf_counter()
                     logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
-                if text:
-                    paste(text, self.cfg["paste_method"])
+                is_feature = self._feature_suggest_active
+                self._feature_suggest_active = False
                 t2 = _time.perf_counter()
-                delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
                 char_count = len(text) if text else 0
-                if self.cfg.get("incognito"):
-                    logger.info(f"Dictation: {t2 - t0:.2f}s -- {delivery} ({char_count} chars)")
+
+                if is_feature and text:
+                    # Feature suggestion mode: save to feature log, format via Claude
+                    entry_id = feature_log.append_raw(text, t2 - t0)
+                    logger.info(f"Feature suggestion saved: {char_count} chars in {t2 - t0:.2f}s")
+                    notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
+                    self._stats["feature_suggestions"] += 1
+                    # Format asynchronously via Claude CLI
+                    threading.Thread(
+                        target=self._format_feature_async,
+                        args=(text, entry_id),
+                        daemon=True,
+                    ).start()
                 else:
-                    log_dictation_result(text or "", t2 - t0, delivery, char_count, secondary=used_backup)
-                effective_model = self.cfg.get("backup_model", "base") if used_backup else dictation_model
-                logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={effective_model}{' (backup)' if used_backup else ''}")
-                # Update session stats
-                self._stats["dictations"] += 1
-                self._stats["total_dictation_chars"] += char_count
-                self._stats["total_dictation_time"] += t2 - t0
-                incognito = self.cfg.get("incognito", False)
-                if text and not incognito:
-                    dictation_log.append(text, t2 - t0)
-                    self._dictation_history.append({
-                        "text": text,
-                        "timestamp": datetime.now().strftime("%H:%M"),
-                        "chars": len(text),
-                    })
-                    if len(self._dictation_history) > 10:
-                        self._dictation_history = self._dictation_history[-10:]
-                    self._refresh_menu()
-                # Success -- remove crash-safety WAV (text is in the .md log)
+                    # Normal dictation mode: paste + log
+                    if text:
+                        paste(text, self.cfg["paste_method"])
+                    delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
+                    if self.cfg.get("incognito"):
+                        logger.info(f"Dictation: {t2 - t0:.2f}s -- {delivery} ({char_count} chars)")
+                    else:
+                        log_dictation_result(text or "", t2 - t0, delivery, char_count, secondary=used_backup)
+                    effective_model = self.cfg.get("backup_model", "base") if used_backup else dictation_model
+                    logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={effective_model}{' (backup)' if used_backup else ''}")
+                    # Update session stats
+                    self._stats["dictations"] += 1
+                    self._stats["total_dictation_chars"] += char_count
+                    self._stats["total_dictation_time"] += t2 - t0
+                    incognito = self.cfg.get("incognito", False)
+                    if text and not incognito:
+                        dictation_log.append(text, t2 - t0)
+                        self._dictation_history.append({
+                            "text": text,
+                            "timestamp": datetime.now().strftime("%H:%M"),
+                            "chars": len(text),
+                        })
+                        if len(self._dictation_history) > 10:
+                            self._dictation_history = self._dictation_history[-10:]
+                        self._refresh_menu()
+                # Success -- remove crash-safety WAV (text is in the log)
                 self.recorder.stop_streaming()  # defensive: ensure writer closed
                 if self._dictation_wav_path:
                     self._safe_unlink(self._dictation_wav_path)
@@ -457,33 +527,48 @@ class WhisperSync:
                     f"(backup {backup_device} {backup_model})",
                     extra={"secondary": True},
                 )
-                if text:
-                    paste(text, self.cfg["paste_method"])
+                is_feature = self._feature_suggest_active
+                self._feature_suggest_active = False
 
-                # Update session stats
-                self._stats["dictations"] += 1
-                self._stats["total_dictation_chars"] += char_count
-                self._stats["total_dictation_time"] += duration
-
-                incognito = self.cfg.get("incognito", False)
-                if text and not incognito:
-                    dictation_log.append(text, duration)
-                    self._dictation_history.append({
-                        "text": text,
-                        "timestamp": datetime.now().strftime("%H:%M"),
-                        "chars": len(text),
-                    })
-                    if len(self._dictation_history) > 10:
-                        self._dictation_history = self._dictation_history[-10:]
-                    self._refresh_menu()
-
-                delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
-                if incognito:
-                    logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
+                if is_feature and text:
+                    entry_id = feature_log.append_raw(text, duration)
+                    logger.info(f"Feature suggestion (overlay) saved: {char_count} chars in {duration:.2f}s", extra={"secondary": True})
+                    notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
+                    self._stats["feature_suggestions"] += 1
+                    threading.Thread(
+                        target=self._format_feature_async,
+                        args=(text, entry_id),
+                        daemon=True,
+                    ).start()
                 else:
-                    log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
+                    if text:
+                        paste(text, self.cfg["paste_method"])
+
+                    # Update session stats
+                    self._stats["dictations"] += 1
+                    self._stats["total_dictation_chars"] += char_count
+                    self._stats["total_dictation_time"] += duration
+
+                    incognito = self.cfg.get("incognito", False)
+                    if text and not incognito:
+                        dictation_log.append(text, duration)
+                        self._dictation_history.append({
+                            "text": text,
+                            "timestamp": datetime.now().strftime("%H:%M"),
+                            "chars": len(text),
+                        })
+                        if len(self._dictation_history) > 10:
+                            self._dictation_history = self._dictation_history[-10:]
+                        self._refresh_menu()
+
+                    delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
+                    if incognito:
+                        logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
+                    else:
+                        log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
 
             except Exception as e:
+                self._feature_suggest_active = False
                 logger.error(f"Overlay dictation error: {e}", extra={"secondary": True})
                 import traceback
                 logger.debug(traceback.format_exc())
@@ -1619,6 +1704,40 @@ class WhisperSync:
         except _sp.TimeoutExpired:
             logger.warning("Claude CLI timed out generating minutes (5 min limit)")
 
+    def _format_feature_async(self, raw_text: str, entry_id: str):
+        """Format a feature suggestion via Claude CLI (background thread)."""
+        import subprocess as _sp
+
+        prompt_file = Path(__file__).parent / "feature_prompt.md"
+        if not prompt_file.exists():
+            logger.warning(f"Feature prompt template not found: {prompt_file}")
+            return
+
+        prompt_text = prompt_file.read_text(encoding="utf-8")
+        prompt_text = prompt_text.replace("{TRANSCRIPTION}", raw_text)
+
+        logger.info("Formatting feature suggestion via Claude CLI...")
+        try:
+            result = _sp.run(
+                ["claude", "-p", "--model", "haiku"],
+                input=prompt_text,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                feature_log.update_consolidated(entry_id, result.stdout.strip())
+                logger.info("Feature suggestion formatted successfully")
+                notify("Feature formatted", "Claude formatted your feature suggestion")
+            else:
+                logger.warning(f"Claude CLI returned code {result.returncode}")
+                if result.stderr:
+                    logger.debug(f"stderr: {result.stderr[:500]}")
+        except FileNotFoundError:
+            logger.warning("Claude CLI not found - raw feature saved without formatting")
+        except _sp.TimeoutExpired:
+            logger.warning("Claude CLI timed out formatting feature (60s limit)")
+
     def _meeting_temp_dir(self) -> Path:
         return Path(__file__).parent / "logs" / "data" / "meeting"
 
@@ -1754,6 +1873,15 @@ class WhisperSync:
                 radio=True,
             )
             for hk in HOTKEY_OPTIONS
+        ]
+        feature_hk_items = [
+            pystray.MenuItem(
+                hk,
+                self._cb(self._set_hotkey, "feature_suggest", hk),
+                checked=lambda item, hk=hk: self.cfg["hotkeys"].get("feature_suggest", "ctrl+shift+alt+f") == hk,
+                radio=True,
+            )
+            for hk in FEATURE_HOTKEY_OPTIONS
         ]
         paste_items = [
             pystray.MenuItem(
@@ -1915,6 +2043,8 @@ class WhisperSync:
                                  pystray.Menu(*dictation_hk_items)),
                 pystray.MenuItem(f"Meeting Hotkey\t{self.cfg['hotkeys']['meeting_toggle']}",
                                  pystray.Menu(*meeting_hk_items)),
+                pystray.MenuItem(f"Feature Suggest Hotkey\t{self.cfg['hotkeys'].get('feature_suggest', 'ctrl+shift+alt+f')}",
+                                 pystray.Menu(*feature_hk_items)),
                 pystray.MenuItem(f"Paste Method\t{self.cfg['paste_method']}",
                                  pystray.Menu(*paste_items)),
                 pystray.Menu.SEPARATOR,
@@ -2322,6 +2452,8 @@ class WhisperSync:
             pystray.MenuItem(f"Meetings: {s['meetings']}", None, enabled=False),
             pystray.MenuItem(f"Total meeting time: {s['total_meeting_seconds'] // 60}m", None, enabled=False),
             pystray.MenuItem(f"Total meeting words: {s['total_meeting_words']:,}", None, enabled=False),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(f"Feature suggestions: {s['feature_suggestions']}", None, enabled=False),
         ]
         return pystray.Menu(*items)
 
@@ -2344,7 +2476,7 @@ class WhisperSync:
         self._save_and_refresh()
 
     def _set_hotkey(self, key: str, hotkey: str):
-        old = self.cfg["hotkeys"][key]
+        old = self.cfg["hotkeys"].get(key)
         if old == hotkey:
             return
         self.cfg["hotkeys"][key] = hotkey
@@ -2645,6 +2777,13 @@ class WhisperSync:
             self.toggle_meeting,
             suppress=False,
         )
+        feature_hk = self.cfg["hotkeys"].get("feature_suggest", "ctrl+shift+alt+f")
+        if feature_hk:
+            keyboard.add_hotkey(
+                feature_hk,
+                self.toggle_feature_suggest,
+                suppress=False,
+            )
 
         self.tray = pystray.Icon(
             "whisper-sync",
@@ -2682,6 +2821,7 @@ class WhisperSync:
         logger.info("WhisperSync running. Hotkeys:")
         logger.info(f"  Dictation: {self.cfg['hotkeys']['dictation_toggle']} (model: {dictation_model})")
         logger.info(f"  Meeting:   {self.cfg['hotkeys']['meeting_toggle']} (model: {self.cfg['model']})")
+        logger.info(f"  Feature:   {self.cfg['hotkeys'].get('feature_suggest', 'ctrl+shift+alt+f')}")
         logger.info(f"  Left-click: {self.cfg.get('left_click', 'meeting')}")
         logger.info(f"  Middle-click: {self.cfg.get('middle_click', 'dictation')}")
         logger.info(f"Log file: {get_log_path()}")

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -335,6 +335,7 @@ class WhisperSync:
         _meeting_tx = self.state.current.meeting_transcribing if self.state else False
         if not self.worker.is_ready() and not (_meeting_tx and BackupTranscriber.is_enabled(self.cfg)):
             logger.warning("Worker not ready yet - ignoring dictation request")
+            self._feature_suggest_active = False
             return
         self.state.emit(DICTATION_STARTED, mode="dictation")
         mic = self.cfg.get("mic_device")
@@ -356,6 +357,7 @@ class WhisperSync:
         self.recorder.stop_streaming()
 
         if "mic" not in audio:
+            self._feature_suggest_active = False
             self.state.emit(IDLE, mode=None)
             return
 
@@ -363,6 +365,10 @@ class WhisperSync:
 
         dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
         use_backup = self.state.current.meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)
+        # Capture feature flag under lock before spawning background thread
+        with self._lock:
+            is_feature = self._feature_suggest_active
+            self._feature_suggest_active = False
 
         def _process():
             import time as _time
@@ -402,23 +408,27 @@ class WhisperSync:
                     text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
                     t1 = _time.perf_counter()
                     logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
-                is_feature = self._feature_suggest_active
-                self._feature_suggest_active = False
                 t2 = _time.perf_counter()
                 char_count = len(text) if text else 0
 
-                if is_feature and text:
-                    # Feature suggestion mode: save to feature log, format via Claude
-                    entry_id = feature_log.append_raw(text, t2 - t0)
-                    logger.info(f"Feature suggestion saved: {char_count} chars in {t2 - t0:.2f}s")
-                    notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
-                    self._stats["feature_suggestions"] += 1
-                    # Format asynchronously via Claude CLI
-                    threading.Thread(
-                        target=self._format_feature_async,
-                        args=(text, entry_id),
-                        daemon=True,
-                    ).start()
+                if is_feature:
+                    # Feature suggestion mode
+                    if not text:
+                        logger.info("Feature suggestion discarded (no speech detected)")
+                    elif self.cfg.get("incognito", False):
+                        logger.info("Feature suggestion skipped: incognito mode enabled")
+                        notify("Feature not saved", "Incognito mode is on; suggestions are not stored on disk")
+                    else:
+                        entry_id = feature_log.append_raw(text, t2 - t0)
+                        logger.info(f"Feature suggestion saved: {char_count} chars in {t2 - t0:.2f}s")
+                        notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
+                        self._stats["feature_suggestions"] += 1
+                        # Format asynchronously via Claude CLI
+                        threading.Thread(
+                            target=self._format_feature_async,
+                            args=(text, entry_id),
+                            daemon=True,
+                        ).start()
                 else:
                     # Normal dictation mode: paste + log
                     if text:
@@ -504,10 +514,16 @@ class WhisperSync:
         if "mic" not in audio:
             logger.debug("Overlay dictation stopped - no audio captured", extra={"secondary": True})
             self._overlay_recorder = None
+            self._feature_suggest_active = False
             return
 
         overlay_audio = audio["mic"]
         self._overlay_recorder = None
+
+        # Capture feature flag before spawning background thread
+        with self._lock:
+            is_feature = self._feature_suggest_active
+            self._feature_suggest_active = False
 
         logger.info("Dictation during meeting: transcribing...", extra={"secondary": True})
 
@@ -527,19 +543,22 @@ class WhisperSync:
                     f"(backup {backup_device} {backup_model})",
                     extra={"secondary": True},
                 )
-                is_feature = self._feature_suggest_active
-                self._feature_suggest_active = False
-
-                if is_feature and text:
-                    entry_id = feature_log.append_raw(text, duration)
-                    logger.info(f"Feature suggestion (overlay) saved: {char_count} chars in {duration:.2f}s", extra={"secondary": True})
-                    notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
-                    self._stats["feature_suggestions"] += 1
-                    threading.Thread(
-                        target=self._format_feature_async,
-                        args=(text, entry_id),
-                        daemon=True,
-                    ).start()
+                if is_feature:
+                    if not text:
+                        logger.info("Feature suggestion (overlay) discarded (no speech detected)", extra={"secondary": True})
+                    elif self.cfg.get("incognito", False):
+                        logger.info("Feature suggestion skipped: incognito mode enabled", extra={"secondary": True})
+                        notify("Feature not saved", "Incognito mode is on; suggestions are not stored on disk")
+                    else:
+                        entry_id = feature_log.append_raw(text, duration)
+                        logger.info(f"Feature suggestion (overlay) saved: {char_count} chars in {duration:.2f}s", extra={"secondary": True})
+                        notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
+                        self._stats["feature_suggestions"] += 1
+                        threading.Thread(
+                            target=self._format_feature_async,
+                            args=(text, entry_id),
+                            daemon=True,
+                        ).start()
                 else:
                     if text:
                         paste(text, self.cfg["paste_method"])
@@ -568,7 +587,6 @@ class WhisperSync:
                         log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
 
             except Exception as e:
-                self._feature_suggest_active = False
                 logger.error(f"Overlay dictation error: {e}", extra={"secondary": True})
                 import traceback
                 logger.debug(traceback.format_exc())

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -1,7 +1,8 @@
 {
   "hotkeys": {
     "dictation_toggle": "ctrl+shift+space",
-    "meeting_toggle": "ctrl+shift+m"
+    "meeting_toggle": "ctrl+shift+m",
+    "feature_suggest": "ctrl+shift+alt+f"
   },
   "paste_method": "clipboard",
   "language": "en",

--- a/whisper_sync/dictation_log.py
+++ b/whisper_sync/dictation_log.py
@@ -18,11 +18,15 @@ from .paths import get_dictation_log_dir
 
 logger = logging.getLogger("whisper_sync")
 
-_LOG_DIR = get_dictation_log_dir()
 _lock = threading.Lock()
 
 # Legacy markdown header regex for backwards-compatible reading
 _HEADER_RE = re.compile(r"^## (\d{2}:\d{2}):(\d{2}) \|.*?\| (\d+) chars$")
+
+
+def _log_dir() -> Path:
+    """Resolve dictation log directory at call time (respects runtime output_dir changes)."""
+    return get_dictation_log_dir()
 
 
 def append(text: str, duration: float) -> None:
@@ -35,9 +39,10 @@ def append(text: str, duration: float) -> None:
     if not text or not text.strip():
         return
 
-    _LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_dir = _log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
     now = datetime.now()
-    log_file = _LOG_DIR / f"{now:%Y-%m-%d}.json"
+    log_file = log_dir / f"{now:%Y-%m-%d}.json"
 
     entry = {
         "timestamp": now.isoformat(timespec="seconds"),
@@ -51,8 +56,18 @@ def append(text: str, duration: float) -> None:
         if log_file.exists():
             try:
                 entries = json.loads(log_file.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                logger.debug(f"Could not read existing log {log_file}, starting fresh")
+            except (json.JSONDecodeError, OSError) as e:
+                # Preserve corrupt file to avoid silent data loss
+                logger.warning(f"Could not read existing log {log_file}: {e}")
+                backup_name = f"{log_file.name}.corrupt-{now:%H%M%S}"
+                backup_path = log_file.with_name(backup_name)
+                try:
+                    log_file.rename(backup_path)
+                    logger.warning(f"Renamed corrupt log to {backup_path}")
+                except OSError as rename_err:
+                    logger.error(f"Failed to rename corrupt log: {rename_err}. Aborting append to avoid data loss.")
+                    return
+                entries = []
         entries.append(entry)
         log_file.write_text(json.dumps(entries, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
@@ -70,12 +85,13 @@ def load_recent(count: int = 10) -> List[Dict]:
         List of dicts: ``{"text": str, "timestamp": str, "chars": int}``.
         Oldest first (same order as the in-memory list).
     """
-    if not _LOG_DIR.exists():
+    log_dir = _log_dir()
+    if not log_dir.exists():
         return []
 
     # Gather all log files (json + legacy md), sorted newest-first by stem
-    json_files = {f.stem: f for f in _LOG_DIR.glob("*.json")}
-    md_files = {f.stem: f for f in _LOG_DIR.glob("*.md")}
+    json_files = {f.stem: f for f in log_dir.glob("*.json")}
+    md_files = {f.stem: f for f in log_dir.glob("*.md")}
 
     # Merge: prefer .json over .md for the same date
     all_dates = sorted(set(json_files) | set(md_files), reverse=True)

--- a/whisper_sync/dictation_log.py
+++ b/whisper_sync/dictation_log.py
@@ -1,5 +1,12 @@
-"""Daily dictation history -- append-only markdown log per day."""
+"""Daily dictation history -- append-only JSON log per day.
 
+Each daily file (YYYY-MM-DD.json) contains a JSON array of entries:
+    [{"timestamp": "2026-03-25T11:30:45", "duration": 1.28, "chars": 9, "text": "..."}]
+
+Backwards compatible: load_recent() reads both .json (new) and .md (legacy) files.
+"""
+
+import json
 import logging
 import re
 import threading
@@ -14,11 +21,12 @@ logger = logging.getLogger("whisper_sync")
 _LOG_DIR = get_dictation_log_dir()
 _lock = threading.Lock()
 
-_HEADER_RE = re.compile(r"^## (\d{2}:\d{2}):\d{2} \|.*?\| (\d+) chars$")
+# Legacy markdown header regex for backwards-compatible reading
+_HEADER_RE = re.compile(r"^## (\d{2}:\d{2}):(\d{2}) \|.*?\| (\d+) chars$")
 
 
 def append(text: str, duration: float) -> None:
-    """Append a dictation entry to today's log file.
+    """Append a dictation entry to today's JSON log file.
 
     Args:
         text: The transcribed text (exactly as pasted).
@@ -29,48 +37,65 @@ def append(text: str, duration: float) -> None:
 
     _LOG_DIR.mkdir(parents=True, exist_ok=True)
     now = datetime.now()
-    log_file = _LOG_DIR / f"{now:%Y-%m-%d}.md"
+    log_file = _LOG_DIR / f"{now:%Y-%m-%d}.json"
 
-    entry = f"\n## {now:%H:%M:%S} | {duration:.2f}s | {len(text)} chars\n{text}\n"
+    entry = {
+        "timestamp": now.isoformat(timespec="seconds"),
+        "duration": round(duration, 2),
+        "chars": len(text),
+        "text": text,
+    }
 
     with _lock:
-        with open(log_file, "a", encoding="utf-8") as f:
-            f.write(entry)
+        entries = []
+        if log_file.exists():
+            try:
+                entries = json.loads(log_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                logger.debug(f"Could not read existing log {log_file}, starting fresh")
+        entries.append(entry)
+        log_file.write_text(json.dumps(entries, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def load_recent(count: int = 10) -> List[Dict]:
     """Load the most recent dictation entries from log files on disk.
 
-    Reads daily log files in reverse chronological order and parses
-    entries until *count* entries are collected.
+    Reads daily log files (JSON and legacy markdown) in reverse chronological
+    order and collects entries until *count* entries are gathered.
 
     Args:
         count: Maximum number of entries to return.
 
     Returns:
-        List of dicts matching the in-memory history format:
-        ``{"text": str, "timestamp": str, "chars": int}``.
+        List of dicts: ``{"text": str, "timestamp": str, "chars": int}``.
         Oldest first (same order as the in-memory list).
     """
     if not _LOG_DIR.exists():
         return []
 
-    # Gather log files sorted newest-first
-    log_files = sorted(_LOG_DIR.glob("*.md"), reverse=True)
-    if not log_files:
+    # Gather all log files (json + legacy md), sorted newest-first by stem
+    json_files = {f.stem: f for f in _LOG_DIR.glob("*.json")}
+    md_files = {f.stem: f for f in _LOG_DIR.glob("*.md")}
+
+    # Merge: prefer .json over .md for the same date
+    all_dates = sorted(set(json_files) | set(md_files), reverse=True)
+    if not all_dates:
         return []
 
     results: List[Dict] = []
 
-    for log_file in log_files:
+    for date_stem in all_dates:
         if len(results) >= count:
             break
         try:
-            entries = _parse_log_file(log_file)
+            if date_stem in json_files:
+                entries = _parse_json_file(json_files[date_stem])
+            else:
+                entries = _parse_md_file(md_files[date_stem])
             results.extend(entries)
         except Exception as e:
-            logger.debug(f"Failed to parse dictation log {log_file}: {e}")
-            continue  # skip corrupt files
+            logger.debug(f"Failed to parse dictation log {date_stem}: {e}")
+            continue
 
     # Keep only the most recent *count*, oldest-first
     results = results[:count]
@@ -78,8 +103,29 @@ def load_recent(count: int = 10) -> List[Dict]:
     return results
 
 
-def _parse_log_file(path: Path) -> List[Dict]:
-    """Parse a single daily log file into entry dicts (newest-first)."""
+def _parse_json_file(path: Path) -> List[Dict]:
+    """Parse a JSON daily log file into entry dicts (newest-first)."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    entries = []
+    for item in data:
+        ts_raw = item.get("timestamp", "")
+        # Extract HH:MM for display (matches legacy format)
+        try:
+            ts_display = datetime.fromisoformat(ts_raw).strftime("%H:%M")
+        except (ValueError, TypeError):
+            ts_display = ts_raw[:5] if len(ts_raw) >= 5 else ts_raw
+        entries.append({
+            "text": item.get("text", ""),
+            "timestamp": ts_display,
+            "chars": item.get("chars", 0),
+        })
+    # Return newest-first
+    entries.reverse()
+    return entries
+
+
+def _parse_md_file(path: Path) -> List[Dict]:
+    """Parse a legacy markdown daily log file into entry dicts (newest-first)."""
     text = path.read_text(encoding="utf-8")
     entries: List[Dict] = []
     current_timestamp = None
@@ -89,7 +135,6 @@ def _parse_log_file(path: Path) -> List[Dict]:
     for line in text.splitlines():
         m = _HEADER_RE.match(line)
         if m:
-            # Flush previous entry
             if current_timestamp is not None:
                 body = "\n".join(body_lines).strip()
                 if body:
@@ -99,12 +144,11 @@ def _parse_log_file(path: Path) -> List[Dict]:
                         "chars": current_chars,
                     })
             current_timestamp = m.group(1)
-            current_chars = int(m.group(2))
+            current_chars = int(m.group(3))
             body_lines = []
         else:
             body_lines.append(line)
 
-    # Flush last entry
     if current_timestamp is not None:
         body = "\n".join(body_lines).strip()
         if body:
@@ -114,6 +158,6 @@ def _parse_log_file(path: Path) -> List[Dict]:
                 "chars": current_chars,
             })
 
-    # Return newest-first so the outer loop collects most-recent across files
+    # Return newest-first
     entries.reverse()
     return entries

--- a/whisper_sync/feature_log.py
+++ b/whisper_sync/feature_log.py
@@ -1,0 +1,134 @@
+"""Feature suggestion log -- JSON-based with status tracking.
+
+Single rolling file (features.json) containing all feature suggestions.
+Each entry tracks raw voice transcription, Claude-formatted version,
+and lifecycle status (pending -> in-progress -> completed).
+"""
+
+import json
+import logging
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+
+from .paths import get_feature_log_dir
+
+logger = logging.getLogger("whisper_sync")
+
+_LOG_DIR = get_feature_log_dir()
+_LOG_FILE = _LOG_DIR / "features.json"
+_lock = threading.Lock()
+
+
+def _read() -> List[Dict]:
+    """Read the feature log from disk."""
+    if not _LOG_FILE.exists():
+        return []
+    try:
+        return json.loads(_LOG_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        logger.debug(f"Could not read feature log: {e}")
+        return []
+
+
+def _write(entries: List[Dict]) -> None:
+    """Write the feature log to disk."""
+    _LOG_DIR.mkdir(parents=True, exist_ok=True)
+    _LOG_FILE.write_text(
+        json.dumps(entries, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def append_raw(text: str, duration: float) -> str:
+    """Append a raw feature suggestion entry.
+
+    Args:
+        text: The raw voice transcription.
+        duration: Pipeline time in seconds (stop -> transcribe).
+
+    Returns:
+        The entry ID (ISO timestamp string) for later updates.
+    """
+    now = datetime.now()
+    entry_id = now.isoformat(timespec="seconds")
+
+    entry = {
+        "id": entry_id,
+        "timestamp": entry_id,
+        "duration": round(duration, 2),
+        "chars": len(text),
+        "raw": text,
+        "consolidated": None,
+        "status": "pending",
+        "pr": None,
+    }
+
+    with _lock:
+        entries = _read()
+        entries.append(entry)
+        _write(entries)
+
+    return entry_id
+
+
+def update_consolidated(entry_id: str, consolidated: str) -> bool:
+    """Set the Claude-formatted consolidated text for an entry.
+
+    Args:
+        entry_id: The ID returned by append_raw().
+        consolidated: The formatted feature request text.
+
+    Returns:
+        True if the entry was found and updated.
+    """
+    with _lock:
+        entries = _read()
+        for entry in entries:
+            if entry.get("id") == entry_id:
+                entry["consolidated"] = consolidated
+                _write(entries)
+                return True
+    logger.warning(f"Feature entry not found for consolidation: {entry_id}")
+    return False
+
+
+def update_status(entry_id: str, status: str, pr: Optional[str] = None) -> bool:
+    """Update the status (and optional PR link) for an entry.
+
+    Args:
+        entry_id: The ID returned by append_raw().
+        status: One of "pending", "in-progress", "completed".
+        pr: Optional PR URL or branch name.
+
+    Returns:
+        True if the entry was found and updated.
+    """
+    with _lock:
+        entries = _read()
+        for entry in entries:
+            if entry.get("id") == entry_id:
+                entry["status"] = status
+                if pr is not None:
+                    entry["pr"] = pr
+                _write(entries)
+                return True
+    logger.warning(f"Feature entry not found for status update: {entry_id}")
+    return False
+
+
+def load_all() -> List[Dict]:
+    """Return all feature suggestion entries."""
+    return _read()
+
+
+def load_pending() -> List[Dict]:
+    """Return entries with status 'pending'."""
+    return [e for e in _read() if e.get("status") == "pending"]
+
+
+def load_recent(count: int = 10) -> List[Dict]:
+    """Return the most recent N entries (newest first)."""
+    entries = _read()
+    return list(reversed(entries[-count:]))

--- a/whisper_sync/feature_log.py
+++ b/whisper_sync/feature_log.py
@@ -16,26 +16,43 @@ from .paths import get_feature_log_dir
 
 logger = logging.getLogger("whisper_sync")
 
-_LOG_DIR = get_feature_log_dir()
-_LOG_FILE = _LOG_DIR / "features.json"
 _lock = threading.Lock()
+
+
+def _log_dir() -> Path:
+    """Resolve feature log directory at call time (respects runtime output_dir changes)."""
+    return get_feature_log_dir()
+
+
+def _log_file() -> Path:
+    return _log_dir() / "features.json"
 
 
 def _read() -> List[Dict]:
     """Read the feature log from disk."""
-    if not _LOG_FILE.exists():
+    path = _log_file()
+    if not path.exists():
         return []
     try:
-        return json.loads(_LOG_FILE.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
-        logger.debug(f"Could not read feature log: {e}")
+        # Preserve corrupt file to avoid silent data loss
+        logger.warning(f"Could not read feature log {path}: {e}")
+        try:
+            timestamp = datetime.now().strftime("%H%M%S")
+            corrupt_path = path.with_suffix(f".json.corrupt-{timestamp}")
+            path.rename(corrupt_path)
+            logger.warning(f"Renamed corrupt feature log to {corrupt_path}")
+        except OSError as rename_err:
+            logger.error(f"Failed to preserve corrupt feature log: {rename_err}")
         return []
 
 
 def _write(entries: List[Dict]) -> None:
     """Write the feature log to disk."""
-    _LOG_DIR.mkdir(parents=True, exist_ok=True)
-    _LOG_FILE.write_text(
+    log_dir = _log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    _log_file().write_text(
         json.dumps(entries, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
@@ -52,7 +69,7 @@ def append_raw(text: str, duration: float) -> str:
         The entry ID (ISO timestamp string) for later updates.
     """
     now = datetime.now()
-    entry_id = now.isoformat(timespec="seconds")
+    entry_id = now.isoformat(timespec="microseconds")
 
     entry = {
         "id": entry_id,

--- a/whisper_sync/feature_prompt.md
+++ b/whisper_sync/feature_prompt.md
@@ -1,0 +1,22 @@
+You are formatting a raw voice transcription into a clean feature request.
+The user dictated this feature idea via voice. Clean it up, structure it,
+and make it actionable. Keep the user's intent and specifics intact.
+
+Output EXACTLY this format:
+
+**Feature**: [concise title]
+
+**What**: [1-2 sentence description of what the feature does]
+
+**Why**: [what problem it solves or what it enables]
+
+**Details**:
+- [key points extracted from the transcription]
+
+**Component**: [best guess: ui, api, transcription, dictation, meeting, general]
+
+---
+
+Raw transcription:
+
+{TRANSCRIPTION}

--- a/whisper_sync/paths.py
+++ b/whisper_sync/paths.py
@@ -124,6 +124,11 @@ def get_dictation_log_dir() -> Path:
     return get_data_dir() / "dictation-logs"
 
 
+def get_feature_log_dir() -> Path:
+    """Return the directory for feature suggestion logs."""
+    return get_data_dir() / "feature-suggestions"
+
+
 def get_legacy_config_path() -> Path:
     """Return the legacy config.json path (inside code repo)."""
     return _PKG_DIR / "config.json"


### PR DESCRIPTION
## Summary
- Add **Feature Suggest** recording mode (`Ctrl+Shift+Alt+F`) - voice-driven feature request capture using the existing dictation pipeline
- Raw transcription saved immediately to `feature-suggestions/features.json`, then Claude CLI formats it asynchronously in the background
- Each feature entry tracks lifecycle: `status` (pending/in-progress/completed) and `pr` link for later implementation tracking
- Migrate dictation logs from markdown to JSON format (daily `.json` files), with backwards-compatible reading of legacy `.md` files
- New configurable hotkey in Settings tray menu + session stats tracking

## Files changed
- `feature_log.py` (new) - JSON feature log with status tracking
- `feature_prompt.md` (new) - Claude CLI prompt template
- `dictation_log.py` - rewritten for JSON format with legacy .md compat
- `config.defaults.json` - `feature_suggest` hotkey added
- `paths.py` - `get_feature_log_dir()` added
- `__main__.py` - hotkey registration, toggle/start/stop, tray menu, stats, Claude CLI formatting

## Test plan
- [ ] Start WhisperSync, verify `Ctrl+Shift+Alt+F` registers (check log output)
- [ ] Press hotkey, speak a feature idea, press again to stop
- [ ] Check `.whispersync/feature-suggestions/features.json` for entry with `status: "pending"`
- [ ] Verify toast notification fires ("Feature saved")
- [ ] Wait for Claude CLI background thread - entry should get `consolidated` field
- [ ] If Claude CLI unavailable - verify raw is still saved, warning logged, no crash
- [ ] Do a normal dictation - verify `.whispersync/dictation-logs/YYYY-MM-DD.json` created
- [ ] Verify old `.md` dictation logs still appear in Recent Dictations menu
- [ ] Verify Settings menu shows "Feature Suggest Hotkey" with configurable options
- [ ] Test during meeting recording (backup transcriber path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)