### PR TITLE
fix: use RLock to prevent deadlock on feature suggest/dictation toggle

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -101,7 +101,7 @@ class WhisperSync:
         self.recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
         self.tray = None
         self.state = None  # Initialized after tray creation in run()
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._api_filter = "Windows WASAPI"  # None = show all
         self._dictation_wav_path: Path | None = None
         self._meeting_start_time: datetime | None = None


### PR DESCRIPTION
## Summary
- `toggle_feature_suggest()` and `toggle_dictation()` acquire `self._lock`, then call `_stop_dictation()` / `_stop_overlay_dictation()` which also acquire `self._lock` (lines 369, 524)
- With `threading.Lock()`, the same thread deadlocks on itself - the tray icon stays orange permanently
- Fix: `threading.Lock()` -> `threading.RLock()` (reentrant lock allows same-thread re-entry)

## Root cause
Introduced in #66 (feature suggest mode) which added `with self._lock:` blocks at lines 369 and 524 to safely capture `_feature_suggest_active`. These are called from within `toggle_*` methods that already hold the lock.

## Test plan
- [ ] Start WhisperSync, trigger feature suggest hotkey (ctrl+shift+alt+f), speak, release - should transcribe and return to idle
- [ ] During a meeting, trigger feature suggest overlay - should transcribe and return
- [ ] Normal dictation toggle still works (same code path affected)
- [ ] Verify tray icon returns to idle after all operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)