### PR TITLE
fix: increase overlay dot size and outer ring gap

### DIFF
--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -91,7 +91,7 @@ def build_icon(spec: IconSpec, progress: float | None = None,
 
     margin = 2
     ring_width = 3
-    gap = 2
+    gap = 3
     outer_r = size - margin
 
     # Outer ring (full, partial arc, or absent)
@@ -125,7 +125,7 @@ def build_icon(spec: IconSpec, progress: float | None = None,
 
     # Inner dot (overlay dictation indicator)
     if spec.inner is not None:
-        dot_radius = 4
+        dot_radius = 7
         cx, cy = size // 2, size // 2
         draw.ellipse(
             [cx - dot_radius, cy - dot_radius,


### PR DESCRIPTION
## Summary
- Increased overlay dictation dot radius from 4 to 7 pixels (8x8 to 14x14), making it visible during meetings
- Widened gap between outer ring and middle circle from 2px to 3px, eliminating anti-aliasing artifacts that looked like rendering glitches

## Test plan
- [ ] Launch WhisperSync and verify tray icon renders cleanly at rest
- [ ] Start a meeting and confirm the blue overlay dot is clearly visible
- [ ] Check that the outer ring and middle circle have clean separation with no aliasing artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)