### PR TITLE
fix: yellow flash when dictating before models loaded

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -336,6 +336,7 @@ class WhisperSync:
         if not self.worker.is_ready() and not (_meeting_tx and BackupTranscriber.is_enabled(self.cfg)):
             logger.warning("Worker not ready yet - ignoring dictation request")
             self._feature_suggest_active = False
+            self._yellow_flash()
             return
         self.state.emit(DICTATION_STARTED, mode="dictation")
         mic = self.cfg.get("mic_device")


### PR DESCRIPTION
## Summary
- Adds a yellow flash (two quick 150ms pulses) when the user presses the dictation hotkey before models have finished loading
- Previously the hotkey was silently ignored with only a log message, giving no visual feedback
- Reuses the existing `_yellow_flash()` method, the universal loading/queuing signal

## Test plan
- [ ] Start WhisperSync and immediately press the dictation hotkey before models load
- [ ] Verify the tray icon flashes yellow twice
- [ ] Verify dictation still works normally after models finish loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)