### PR TITLE
feat: persistent weekly stats

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -39,6 +39,7 @@ from .worker_manager import TranscriptionWorker, WorkerCrashedError
 from .backup_worker import BackupTranscriber
 from . import dictation_log
 from . import feature_log
+from . import weekly_stats
 from .streaming_wav import fix_orphan
 from .crash_diagnostics import install_excepthook, check_previous_crash
 from .flatten import flatten as flatten_transcript
@@ -423,6 +424,7 @@ class WhisperSync:
                         logger.info(f"Feature suggestion saved: {char_count} chars in {t2 - t0:.2f}s")
                         notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
                         self._stats["feature_suggestions"] += 1
+                        weekly_stats.record_feature_suggestion()
                         # Format asynchronously via Claude CLI
                         threading.Thread(
                             target=self._format_feature_async,
@@ -444,6 +446,7 @@ class WhisperSync:
                     self._stats["dictations"] += 1
                     self._stats["total_dictation_chars"] += char_count
                     self._stats["total_dictation_time"] += t2 - t0
+                    weekly_stats.record_dictation(char_count, t2 - t0)
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
                         dictation_log.append(text, t2 - t0)
@@ -554,6 +557,7 @@ class WhisperSync:
                         logger.info(f"Feature suggestion (overlay) saved: {char_count} chars in {duration:.2f}s", extra={"secondary": True})
                         notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
                         self._stats["feature_suggestions"] += 1
+                        weekly_stats.record_feature_suggestion()
                         threading.Thread(
                             target=self._format_feature_async,
                             args=(text, entry_id),
@@ -567,6 +571,7 @@ class WhisperSync:
                     self._stats["dictations"] += 1
                     self._stats["total_dictation_chars"] += char_count
                     self._stats["total_dictation_time"] += duration
+                    weekly_stats.record_dictation(char_count, duration)
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
@@ -607,6 +612,7 @@ class WhisperSync:
                     self._stats["dictations"] += 1
                     self._stats["total_dictation_chars"] += char_count
                     self._stats["total_dictation_time"] += duration
+                    weekly_stats.record_dictation(char_count, duration)
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
@@ -1483,6 +1489,7 @@ class WhisperSync:
                 self._stats["meetings"] += 1
                 self._stats["total_meeting_seconds"] += int(_meet_duration)
                 self._stats["total_meeting_words"] += _meet_words
+                weekly_stats.record_meeting(int(_meet_duration), _meet_words)
 
                 # Log speaker previews at TRANSCRIPT level (detailed tier)
                 _meet_segments = result.get("speaker_segments")
@@ -2453,25 +2460,32 @@ class WhisperSync:
         logger.info(f"Output folder changed to: {new_path}")
 
     def _build_session_stats_menu(self):
-        """Build session stats submenu items."""
+        """Build session stats submenu items with weekly and lifetime context."""
         s = self._stats
         uptime = datetime.now() - s["session_start"]
         hours, remainder = divmod(int(uptime.total_seconds()), 3600)
         minutes = remainder // 60
         avg_dict_time = s["total_dictation_time"] / s["dictations"] if s["dictations"] else 0
 
+        week = weekly_stats.get_current_week()
+        lifetime = weekly_stats.get_lifetime()
+        weekly_avg = weekly_stats.get_weekly_average("total_dictation_time")
+
         items = [
             pystray.MenuItem(f"Session uptime: {hours}h {minutes}m", None, enabled=False),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(f"Dictations: {s['dictations']}", None, enabled=False),
-            pystray.MenuItem(f"Avg dictation time: {avg_dict_time:.2f}s", None, enabled=False),
-            pystray.MenuItem(f"Total chars dictated: {s['total_dictation_chars']:,}", None, enabled=False),
+            pystray.MenuItem(f"Dictations: {s['dictations']} today | {week.get('dictations', 0)} this week", None, enabled=False),
+            pystray.MenuItem(f"Avg dictation: {avg_dict_time:.2f}s | {weekly_avg:.2f}s weekly", None, enabled=False),
+            pystray.MenuItem(f"Chars dictated: {s['total_dictation_chars']:,} today | {week.get('total_dictation_chars', 0):,} this week", None, enabled=False),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(f"Meetings: {s['meetings']}", None, enabled=False),
-            pystray.MenuItem(f"Total meeting time: {s['total_meeting_seconds'] // 60}m", None, enabled=False),
-            pystray.MenuItem(f"Total meeting words: {s['total_meeting_words']:,}", None, enabled=False),
+            pystray.MenuItem(f"Meetings: {s['meetings']} today | {week.get('meetings', 0)} this week", None, enabled=False),
+            pystray.MenuItem(f"Meeting time: {s['total_meeting_seconds'] // 60}m today | {week.get('total_meeting_seconds', 0) // 60}m this week", None, enabled=False),
+            pystray.MenuItem(f"Meeting words: {s['total_meeting_words']:,} today | {week.get('total_meeting_words', 0):,} this week", None, enabled=False),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(f"Feature suggestions: {s['feature_suggestions']}", None, enabled=False),
+            pystray.MenuItem(f"Features: {s['feature_suggestions']} today | {week.get('feature_suggestions', 0)} this week", None, enabled=False),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(f"Lifetime dictations: {lifetime.get('dictations', 0):,}", None, enabled=False),
+            pystray.MenuItem(f"Lifetime meetings: {lifetime.get('meetings', 0):,}", None, enabled=False),
         ]
         return pystray.Menu(*items)
 
@@ -2696,6 +2710,7 @@ class WhisperSync:
 
     def _restart(self):
         import subprocess
+        weekly_stats.flush()
         if self.recorder.is_recording:
             self.recorder.stop()
         self.worker.stop()
@@ -2709,6 +2724,7 @@ class WhisperSync:
             self.tray.stop()
 
     def quit(self):
+        weekly_stats.flush()
         if self.recorder.is_recording:
             self.recorder.stop()
         self.worker.stop()
@@ -2879,9 +2895,25 @@ class WhisperSync:
         # Start GitHub PR status polling if configured
         self._start_github_poller()
 
+        # Periodic flush for persistent weekly stats
+        self._stats_flush_stop = threading.Event()
+        def _stats_flush_loop():
+            while not self._stats_flush_stop.wait(weekly_stats._flush_interval):
+                try:
+                    weekly_stats.flush()
+                except Exception:
+                    pass
+        threading.Thread(target=_stats_flush_loop, daemon=True).start()
+
         try:
             self.tray.run()
         finally:
+            # Flush persistent stats before shutdown
+            try:
+                self._stats_flush_stop.set()
+                weekly_stats.flush()
+            except Exception:
+                pass
             # Always release keyboard hooks to prevent stuck modifier keys
             keyboard.unhook_all()
             self.worker.stop()

--- a/whisper_sync/paths.py
+++ b/whisper_sync/paths.py
@@ -124,6 +124,11 @@ def get_dictation_log_dir() -> Path:
     return get_data_dir() / "dictation-logs"
 
 
+def get_stats_dir() -> Path:
+    """Return the directory for persistent stats."""
+    return get_data_dir() / "stats"
+
+
 def get_feature_log_dir() -> Path:
     """Return the directory for feature suggestion logs."""
     return get_data_dir() / "feature-suggestions"

--- a/whisper_sync/weekly_stats.py
+++ b/whisper_sync/weekly_stats.py
@@ -1,0 +1,176 @@
+"""Persistent weekly stats with RAM buffering and lifetime tracking.
+
+Stats accumulate in memory and flush to disk every 60 seconds and on
+shutdown.  The on-disk format is a single JSON file at
+``{data_dir}/stats/weekly-stats.json`` containing per-week buckets and a
+lifetime aggregate.
+"""
+
+import json
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+from .logger import logger
+from .paths import get_stats_dir
+
+_lock = threading.Lock()
+
+# Buffered deltas since last flush
+_buffer: dict = {}
+
+_flush_interval = 60  # seconds
+_last_flush: float = 0.0
+
+_EMPTY_BUCKET = {
+    "dictations": 0,
+    "total_dictation_chars": 0,
+    "total_dictation_time": 0.0,
+    "meetings": 0,
+    "total_meeting_seconds": 0,
+    "total_meeting_words": 0,
+    "feature_suggestions": 0,
+}
+
+
+def _stats_file() -> Path:
+    return get_stats_dir() / "weekly-stats.json"
+
+
+def _current_week() -> str:
+    return datetime.now().strftime("%G-W%V")
+
+
+def _read() -> dict:
+    """Read stats from disk. Returns empty structure if file missing."""
+    path = _stats_file()
+    if not path.exists():
+        return {"weeks": {}, "lifetime": {}}
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(f"Could not read weekly stats: {exc}")
+        return {"weeks": {}, "lifetime": {}}
+
+
+def _write(data: dict) -> None:
+    """Write stats to disk (atomic via temp file)."""
+    path = _stats_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        tmp.replace(path)
+    except OSError as exc:
+        logger.warning(f"Could not write weekly stats: {exc}")
+
+
+def _add_to_bucket(bucket: dict, key: str, value) -> None:
+    bucket[key] = bucket.get(key, 0) + value
+
+
+def _buffer_event(**kwargs) -> None:
+    """Add deltas to the in-memory buffer, flushing if interval elapsed."""
+    global _last_flush
+    with _lock:
+        for k, v in kwargs.items():
+            _buffer[k] = _buffer.get(k, 0) + v
+        now = time.monotonic()
+        if now - _last_flush >= _flush_interval:
+            _flush_locked()
+            _last_flush = now
+
+
+def _flush_locked() -> None:
+    """Flush buffer to disk. Caller must hold _lock."""
+    global _buffer
+    if not _buffer:
+        return
+    buf = _buffer.copy()
+    _buffer = {}
+
+    data = _read()
+    week = _current_week()
+
+    # Update weekly bucket
+    if week not in data["weeks"]:
+        data["weeks"][week] = dict(_EMPTY_BUCKET)
+    for k, v in buf.items():
+        _add_to_bucket(data["weeks"][week], k, v)
+
+    # Update lifetime bucket
+    lt = data.get("lifetime", {})
+    if "first_session" not in lt:
+        lt["first_session"] = datetime.now().isoformat()
+    for k, v in buf.items():
+        _add_to_bucket(lt, k, v)
+    data["lifetime"] = lt
+
+    _write(data)
+
+
+# ---- Public API ---------------------------------------------------------
+
+def record_dictation(chars: int, duration: float) -> None:
+    """Record a dictation event. Buffered in RAM."""
+    _buffer_event(dictations=1, total_dictation_chars=chars, total_dictation_time=duration)
+
+
+def record_meeting(seconds: int, words: int) -> None:
+    """Record a meeting event. Buffered in RAM."""
+    _buffer_event(meetings=1, total_meeting_seconds=seconds, total_meeting_words=words)
+
+
+def record_feature_suggestion() -> None:
+    """Record a feature suggestion event. Buffered in RAM."""
+    _buffer_event(feature_suggestions=1)
+
+
+def flush() -> None:
+    """Flush buffered stats to disk. Called periodically and on shutdown."""
+    global _last_flush
+    with _lock:
+        _flush_locked()
+        _last_flush = time.monotonic()
+
+
+def get_current_week() -> dict:
+    """Get this week's stats (disk + buffer merged)."""
+    with _lock:
+        data = _read()
+        week = _current_week()
+        result = dict(data.get("weeks", {}).get(week, _EMPTY_BUCKET))
+        for k, v in _buffer.items():
+            result[k] = result.get(k, 0) + v
+        return result
+
+
+def get_lifetime() -> dict:
+    """Get lifetime stats (disk + buffer merged)."""
+    with _lock:
+        data = _read()
+        result = dict(data.get("lifetime", {}))
+        for k, v in _buffer.items():
+            result[k] = result.get(k, 0) + v
+        return result
+
+
+def get_weekly_average(metric: str, weeks: int = 4) -> float:
+    """Compute rolling average for a metric over the last N completed weeks.
+
+    The current (partial) week is excluded from the average so results
+    are stable throughout the week.
+    """
+    with _lock:
+        data = _read()
+        all_weeks = sorted(data.get("weeks", {}).keys())
+        current = _current_week()
+        completed = [w for w in all_weeks if w != current]
+        recent = completed[-weeks:] if len(completed) >= weeks else completed
+        if not recent:
+            return 0.0
+        total = sum(data["weeks"][w].get(metric, 0) for w in recent)
+        return total / len(recent)


### PR DESCRIPTION
## Summary
- Add `weekly_stats.py` module that persists dictation, meeting, and feature suggestion counts to `{data_dir}/stats/weekly-stats.json` with ISO week keys (`YYYY-WNN`)
- RAM buffer with thread-safe `threading.Lock()` flushes to disk every 60 seconds and on all shutdown/restart paths
- Tray "Session Stats" submenu now shows session, weekly, and lifetime stats side by side
- Rolling weekly averages computed on read from completed weeks (current partial week excluded)
- Added `get_stats_dir()` to `paths.py` for the new stats directory

## Test plan
- [ ] Start WhisperSync, do a few dictations, verify stats file appears at `.whispersync/stats/weekly-stats.json`
- [ ] Check tray menu shows "today | this week" format for all metrics
- [ ] Verify lifetime counters persist across restarts
- [ ] Verify flush occurs on quit, restart, and periodic timer
- [ ] Verify no data loss on abrupt process kill (at most 60s of buffered events lost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)