### PR TITLE
fix: increase overlay dot size and outer ring gap for clarity

### DIFF
--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -91,7 +91,7 @@ def build_icon(spec: IconSpec, progress: float | None = None,
 
     margin = 2
     ring_width = 3
-    gap = 2
+    gap = 3
     outer_r = size - margin
 
     # Outer ring (full, partial arc, or absent)
@@ -125,7 +125,7 @@ def build_icon(spec: IconSpec, progress: float | None = None,
 
     # Inner dot (overlay dictation indicator)
     if spec.inner is not None:
-        dot_radius = 4
+        dot_radius = 7
         cx, cy = size // 2, size // 2
         draw.ellipse(
             [cx - dot_radius, cy - dot_radius,


### PR DESCRIPTION
Increases dot_radius from 4 to 7 and gap from 2 to 3 for better visual clarity.