### PR TITLE
fix: auto-merge sweep for clean PRs without synchronize events

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -41,32 +41,33 @@ jobs:
             if (context.payload.pull_request) {
               prNumbers = [context.payload.pull_request.number];
             } else if (context.payload.check_suite) {
+              // Process all associated PRs, not just the first
               const prs = context.payload.check_suite.pull_requests;
-              if (prs && prs.length > 0) prNumbers = [prs[0].number];
+              if (prs && prs.length > 0) prNumbers = prs.map(p => p.number);
             } else if (context.payload.review) {
               prNumbers = [context.payload.pull_request.number];
             }
 
-            // For workflow_run triggers (and any trigger with no PR context),
-            // sweep all open PRs. This handles clean PRs where the only
+            // For workflow_run triggers, try payload PRs first
+            if (prNumbers.length === 0 && context.payload.workflow_run) {
+              const prs = context.payload.workflow_run.pull_requests;
+              if (prs && prs.length > 0) {
+                prNumbers = prs.map(p => p.number);
+              }
+            }
+
+            // Sweep fallback: when no PR in payload (workflow_run on dev),
+            // check all open PRs. This handles clean PRs where the only
             // trigger was pull_request_review from Copilot (blocked by GitHub
             // as action_required for bot-initiated reviews).
             if (prNumbers.length === 0) {
-              if (context.payload.workflow_run) {
-                const prs = context.payload.workflow_run.pull_requests;
-                if (prs && prs.length > 0) {
-                  prNumbers = [prs[0].number];
-                }
-              }
-            }
-            if (prNumbers.length === 0) {
-              console.log('No PR in payload, sweeping all open PRs...');
+              console.log('No PR in payload, sweeping all open PRs targeting dev...');
               const { data: openPRs } = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'open',
                 base: 'dev',
-                per_page: 20
+                per_page: 100
               });
               prNumbers = openPRs.map(pr => pr.number);
               if (prNumbers.length === 0) {
@@ -75,6 +76,9 @@ jobs:
               }
               console.log(`Found ${prNumbers.length} open PRs: ${prNumbers.join(', ')}`);
             }
+
+            // Deduplicate PR numbers
+            prNumbers = [...new Set(prNumbers)];
 
             // Process each PR
             for (const prNumber of prNumbers) {
@@ -92,23 +96,30 @@ jobs:
               const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber
+                issue_number: prNumber,
+                per_page: 100
               });
               if (comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merged'))) {
                 continue;
               }
 
-              // Check if Copilot has reviewed
+              // Check if Copilot has reviewed (must not be CHANGES_REQUESTED)
               const { data: reviews } = await github.rest.pulls.listReviews({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber
               });
-              const copilotReviewed = reviews.some(
+              const copilotReviews = reviews.filter(
                 r => r.user.login === 'copilot-pull-request-reviewer[bot]'
               );
-              if (!copilotReviewed) {
+              if (copilotReviews.length === 0) {
                 console.log(`PR #${prNumber}: no Copilot review yet`);
+                continue;
+              }
+              // Check the latest Copilot review state
+              const latestReview = copilotReviews[copilotReviews.length - 1];
+              if (latestReview.state === 'CHANGES_REQUESTED') {
+                console.log(`PR #${prNumber}: Copilot requested changes, skipping`);
                 continue;
               }
 
@@ -116,7 +127,8 @@ jobs:
               const { data: reviewComments } = await github.rest.pulls.listReviewComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: prNumber
+                pull_number: prNumber,
+                per_page: 100
               });
               // Only count comments on the latest commit - old comments from
               // previous pushes should not permanently block auto-merge.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -35,108 +35,136 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Determine PR number from different event types
-            let prNumber;
+            // Collect PR numbers to process (may be one or many)
+            let prNumbers = [];
+
             if (context.payload.pull_request) {
-              prNumber = context.payload.pull_request.number;
+              prNumbers = [context.payload.pull_request.number];
             } else if (context.payload.check_suite) {
               const prs = context.payload.check_suite.pull_requests;
-              if (!prs || prs.length === 0) return;
-              prNumber = prs[0].number;
-            } else if (context.payload.workflow_run) {
-              const prs = context.payload.workflow_run.pull_requests;
-              if (!prs || prs.length === 0) return;
-              prNumber = prs[0].number;
+              if (prs && prs.length > 0) prNumbers = [prs[0].number];
             } else if (context.payload.review) {
-              prNumber = context.payload.pull_request.number;
-            } else {
-              return;
+              prNumbers = [context.payload.pull_request.number];
             }
 
-            const { data: prData } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-
-            if (prData.state !== 'open' || prData.merged) return;
-
-            // Check if we already auto-merged (dedup)
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
-            if (comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merged'))) {
-              return;
+            // For workflow_run triggers (and any trigger with no PR context),
+            // sweep all open PRs. This handles clean PRs where the only
+            // trigger was pull_request_review from Copilot (blocked by GitHub
+            // as action_required for bot-initiated reviews).
+            if (prNumbers.length === 0) {
+              if (context.payload.workflow_run) {
+                const prs = context.payload.workflow_run.pull_requests;
+                if (prs && prs.length > 0) {
+                  prNumbers = [prs[0].number];
+                }
+              }
+            }
+            if (prNumbers.length === 0) {
+              console.log('No PR in payload, sweeping all open PRs...');
+              const { data: openPRs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                base: 'dev',
+                per_page: 20
+              });
+              prNumbers = openPRs.map(pr => pr.number);
+              if (prNumbers.length === 0) {
+                console.log('No open PRs found');
+                return;
+              }
+              console.log(`Found ${prNumbers.length} open PRs: ${prNumbers.join(', ')}`);
             }
 
-            // Check if Copilot has reviewed
-            const { data: reviews } = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            const copilotReviewed = reviews.some(
-              r => r.user.login === 'copilot-pull-request-reviewer[bot]'
-            );
-            if (!copilotReviewed) {
-              console.log(`PR #${prNumber}: no Copilot review yet`);
-              return;
-            }
+            // Process each PR
+            for (const prNumber of prNumbers) {
+              console.log(`Checking PR #${prNumber}...`);
 
-            // Check for unresolved inline suggestions
-            const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            // Only count comments on the latest commit -- old comments from
-            // previous pushes should not permanently block auto-merge.
-            const suggestions = reviewComments.filter(
-              c => c.user.login === 'copilot-pull-request-reviewer[bot]'
-                && c.commit_id === prData.head.sha
-            );
+              const { data: prData } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
 
-            if (suggestions.length > 0) {
-              // Only comment once
-              if (!comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merge skipped'))) {
+              if (prData.state !== 'open' || prData.merged) continue;
+
+              // Check if we already auto-merged (dedup)
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+              });
+              if (comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merged'))) {
+                continue;
+              }
+
+              // Check if Copilot has reviewed
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              const copilotReviewed = reviews.some(
+                r => r.user.login === 'copilot-pull-request-reviewer[bot]'
+              );
+              if (!copilotReviewed) {
+                console.log(`PR #${prNumber}: no Copilot review yet`);
+                continue;
+              }
+
+              // Check for unresolved inline suggestions
+              const { data: reviewComments } = await github.rest.pulls.listReviewComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              // Only count comments on the latest commit - old comments from
+              // previous pushes should not permanently block auto-merge.
+              const suggestions = reviewComments.filter(
+                c => c.user.login === 'copilot-pull-request-reviewer[bot]'
+                  && c.commit_id === prData.head.sha
+              );
+
+              if (suggestions.length > 0) {
+                // Only comment once
+                if (!comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merge skipped'))) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `## Auto-merge skipped\n\nCopilot found ${suggestions.length} suggestion(s). Push fixes and auto-merge will re-check.`
+                  });
+                }
+                continue;
+              }
+
+              // All clear - merge
+              const labels = prData.labels.map(l => l.name);
+              const complexity = labels.find(l => l.startsWith('complexity:')) || 'unknown';
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100
+              });
+              const changedLines = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+              const fileList = files.map(f => f.filename).join(', ');
+
+              try {
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  merge_method: 'squash'
+                });
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  body: `## Auto-merge skipped\n\nCopilot found ${suggestions.length} suggestion(s). Push fixes and auto-merge will re-check.`
+                  body: `## Auto-merged\n\nCopilot reviewed (${complexity}), no suggestions. Merged automatically.\n\n**${changedLines} lines** across: ${fileList}`
                 });
+                console.log(`PR #${prNumber} auto-merged`);
+              } catch (err) {
+                console.log(`PR #${prNumber} merge failed: ${err.message}`);
               }
-              return;
-            }
-
-            // All clear — merge
-            const labels = prData.labels.map(l => l.name);
-            const complexity = labels.find(l => l.startsWith('complexity:')) || 'unknown';
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100
-            });
-            const changedLines = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
-            const fileList = files.map(f => f.filename).join(', ');
-
-            try {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                merge_method: 'squash'
-              });
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: `## Auto-merged\n\nCopilot reviewed (${complexity}), no suggestions. Merged automatically.\n\n**${changedLines} lines** across: ${fileList}`
-              });
-              console.log(`PR #${prNumber} auto-merged`);
-            } catch (err) {
-              console.log(`PR #${prNumber} merge failed: ${err.message}`);
             }


### PR DESCRIPTION
## Summary
- Auto-merge only worked when fix commits were pushed after Copilot review (synchronize event)
- Clean PRs with no suggestions never merged because the bot review event is blocked by GitHub
- Now workflow_run triggers sweep all open PRs targeting dev, processing any that are reviewed and ready

## Test plan
- [ ] This PR itself should auto-merge once Copilot reviews it (it will trigger a synchronize or workflow_run)
- [ ] PRs #75-81 should auto-merge after this lands (next workflow_run trigger will sweep them)