### PR TITLE
feat: add Update menu item to tray

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2185,7 +2185,10 @@ class WhisperSync:
                 pystray.Menu.SEPARATOR,
                 *incognito_items,
                 pystray.Menu.SEPARATOR,
-                pystray.MenuItem("Update", lambda: self._update()),
+                pystray.MenuItem("Update", pystray.Menu(
+                    pystray.MenuItem("Stable\tmain", lambda: self._update("main")),
+                    pystray.MenuItem("Labs\tdev", lambda: self._update("dev")),
+                )),
                 pystray.MenuItem("Restart", lambda: self._restart()),
                 pystray.MenuItem("Quit", lambda: self.quit()),
             )),
@@ -2785,13 +2788,13 @@ class WhisperSync:
 
         threading.Thread(target=_do_download, daemon=True).start()
 
-    def _update(self):
-        """Pull latest code from dev and restart if updated."""
+    def _update(self, branch="dev"):
+        """Pull latest code from a branch and restart if updated."""
         def _do_update():
             import subprocess as _sp
             repo_root = str(Path(__file__).parent.parent)
 
-            notify("Updating WhisperSync...", "Pulling latest from dev")
+            notify("Updating WhisperSync...", f"Pulling latest from {branch}")
 
             # Check for uncommitted changes
             status = _sp.run(
@@ -2803,7 +2806,7 @@ class WhisperSync:
 
             # Fetch
             fetch = _sp.run(
-                ["git", "fetch", "origin", "dev"],
+                ["git", "fetch", "origin", branch],
                 cwd=repo_root, capture_output=True, text=True, timeout=30
             )
             if fetch.returncode != 0:
@@ -2813,17 +2816,32 @@ class WhisperSync:
 
             # Check if there are updates
             diff = _sp.run(
-                ["git", "rev-list", "HEAD..origin/dev", "--count"],
+                ["git", "rev-list", f"HEAD..origin/{branch}", "--count"],
                 cwd=repo_root, capture_output=True, text=True, timeout=10
             )
             commit_count = int(diff.stdout.strip()) if diff.stdout.strip() else 0
 
             if commit_count == 0:
-                notify("Already up to date", "No new changes on dev")
+                notify("Already up to date", f"No new changes on {branch}")
                 return
 
+            # Checkout the target branch if not already on it
+            current = _sp.run(
+                ["git", "branch", "--show-current"],
+                cwd=repo_root, capture_output=True, text=True, timeout=10
+            )
+            if current.stdout.strip() != branch:
+                checkout = _sp.run(
+                    ["git", "checkout", branch],
+                    cwd=repo_root, capture_output=True, text=True, timeout=15
+                )
+                if checkout.returncode != 0:
+                    logger.error(f"git checkout {branch} failed: {checkout.stderr}")
+                    notify("Update failed", f"Could not switch to {branch}")
+                    return
+
             pull = _sp.run(
-                ["git", "pull", "origin", "dev"],
+                ["git", "pull", "origin", branch],
                 cwd=repo_root, capture_output=True, text=True, timeout=60
             )
             if pull.returncode != 0:
@@ -2831,8 +2849,8 @@ class WhisperSync:
                 notify("Update failed", "git pull failed, check console")
                 return
 
-            logger.info(f"Updated: {commit_count} new commit(s)")
-            notify("Updated!", f"{commit_count} new commit(s). Restarting...")
+            logger.info(f"Updated from {branch}: {commit_count} new commit(s)")
+            notify("Updated!", f"{commit_count} commit(s) from {branch}. Restarting...")
 
             import time
             time.sleep(2)  # Let the notification display

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2185,10 +2185,10 @@ class WhisperSync:
                 pystray.Menu.SEPARATOR,
                 *incognito_items,
                 pystray.Menu.SEPARATOR,
-                pystray.MenuItem("Update", pystray.Menu(
-                    pystray.MenuItem("Stable\tmain", lambda: self._update("main")),
-                    pystray.MenuItem("Labs\tdev", lambda: self._update("dev")),
-                )),
+                *([] if is_standalone() else [pystray.MenuItem("Update", pystray.Menu(
+                    pystray.MenuItem("Stable\tmain", self._cb(self._update, "main")),
+                    pystray.MenuItem("Labs\tdev", self._cb(self._update, "dev")),
+                ))]),
                 pystray.MenuItem("Restart", lambda: self._restart()),
                 pystray.MenuItem("Quit", lambda: self.quit()),
             )),
@@ -2788,73 +2788,93 @@ class WhisperSync:
 
         threading.Thread(target=_do_download, daemon=True).start()
 
+    _updating = False  # Guard against concurrent update clicks
+
     def _update(self, branch="dev"):
         """Pull latest code from a branch and restart if updated."""
+        if self._updating:
+            logger.debug("Update already in progress, ignoring")
+            return
+        self._updating = True
+
         def _do_update():
             import subprocess as _sp
-            repo_root = str(Path(__file__).parent.parent)
+            repo_root = str(get_install_root())
 
-            notify("Updating WhisperSync...", f"Pulling latest from {branch}")
+            try:
+                notify("Updating WhisperSync...", f"Pulling latest from {branch}")
 
-            # Check for uncommitted changes
-            status = _sp.run(
-                ["git", "status", "--porcelain"],
-                cwd=repo_root, capture_output=True, text=True, timeout=10
-            )
-            if status.stdout.strip():
-                logger.warning(f"Uncommitted changes detected:\n{status.stdout.strip()}")
-
-            # Fetch
-            fetch = _sp.run(
-                ["git", "fetch", "origin", branch],
-                cwd=repo_root, capture_output=True, text=True, timeout=30
-            )
-            if fetch.returncode != 0:
-                logger.error(f"git fetch failed: {fetch.stderr}")
-                notify("Update failed", "git fetch failed, check console")
-                return
-
-            # Check if there are updates
-            diff = _sp.run(
-                ["git", "rev-list", f"HEAD..origin/{branch}", "--count"],
-                cwd=repo_root, capture_output=True, text=True, timeout=10
-            )
-            commit_count = int(diff.stdout.strip()) if diff.stdout.strip() else 0
-
-            if commit_count == 0:
-                notify("Already up to date", f"No new changes on {branch}")
-                return
-
-            # Checkout the target branch if not already on it
-            current = _sp.run(
-                ["git", "branch", "--show-current"],
-                cwd=repo_root, capture_output=True, text=True, timeout=10
-            )
-            if current.stdout.strip() != branch:
-                checkout = _sp.run(
-                    ["git", "checkout", branch],
-                    cwd=repo_root, capture_output=True, text=True, timeout=15
+                # Check for uncommitted changes
+                status = _sp.run(
+                    ["git", "status", "--porcelain"],
+                    cwd=repo_root, capture_output=True, text=True, timeout=10
                 )
-                if checkout.returncode != 0:
-                    logger.error(f"git checkout {branch} failed: {checkout.stderr}")
-                    notify("Update failed", f"Could not switch to {branch}")
+                if status.stdout.strip():
+                    logger.warning(f"Uncommitted changes detected:\n{status.stdout.strip()}")
+
+                # Fetch
+                fetch = _sp.run(
+                    ["git", "fetch", "origin", branch],
+                    cwd=repo_root, capture_output=True, text=True, timeout=30
+                )
+                if fetch.returncode != 0:
+                    logger.error(f"git fetch failed: {fetch.stderr}")
+                    notify("Update failed", "git fetch failed, check console")
                     return
 
-            pull = _sp.run(
-                ["git", "pull", "origin", branch],
-                cwd=repo_root, capture_output=True, text=True, timeout=60
-            )
-            if pull.returncode != 0:
-                logger.error(f"git pull failed: {pull.stderr}")
-                notify("Update failed", "git pull failed, check console")
-                return
+                # Check if there are updates
+                diff = _sp.run(
+                    ["git", "rev-list", f"HEAD..origin/{branch}", "--count"],
+                    cwd=repo_root, capture_output=True, text=True, timeout=10
+                )
+                count_str = (diff.stdout or "").strip()
+                commit_count = int(count_str) if count_str.isdigit() else 0
 
-            logger.info(f"Updated from {branch}: {commit_count} new commit(s)")
-            notify("Updated!", f"{commit_count} commit(s) from {branch}. Restarting...")
+                if commit_count == 0:
+                    notify("Already up to date", f"No new changes on {branch}")
+                    return
 
-            import time
-            time.sleep(2)  # Let the notification display
-            self._restart()
+                # Checkout the target branch if not already on it
+                current = _sp.run(
+                    ["git", "branch", "--show-current"],
+                    cwd=repo_root, capture_output=True, text=True, timeout=10
+                )
+                if current.stdout.strip() != branch:
+                    checkout = _sp.run(
+                        ["git", "checkout", branch],
+                        cwd=repo_root, capture_output=True, text=True, timeout=15
+                    )
+                    if checkout.returncode != 0:
+                        logger.error(f"git checkout {branch} failed: {checkout.stderr}")
+                        notify("Update failed", f"Could not switch to {branch}")
+                        return
+
+                pull = _sp.run(
+                    ["git", "pull", "origin", branch],
+                    cwd=repo_root, capture_output=True, text=True, timeout=60
+                )
+                if pull.returncode != 0:
+                    logger.error(f"git pull failed: {pull.stderr}")
+                    notify("Update failed", "git pull failed, check console")
+                    return
+
+                logger.info(f"Updated from {branch}: {commit_count} new commit(s)")
+                notify("Updated!", f"{commit_count} commit(s) from {branch}. Restarting...")
+
+                import time
+                time.sleep(2)  # Let the notification display
+                self._restart()
+            except FileNotFoundError:
+                logger.error("git not found on PATH")
+                notify("Update failed", "git not found, check installation")
+            except _sp.TimeoutExpired:
+                logger.error("git command timed out during update")
+                notify("Update failed", "git timed out, check network")
+            except Exception as e:
+                logger.error(f"Update failed: {e}")
+                notify("Update failed", "Unexpected error, check console")
+            finally:
+                self._updating = False
 
         threading.Thread(target=_do_update, daemon=True).start()
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2185,6 +2185,7 @@ class WhisperSync:
                 pystray.Menu.SEPARATOR,
                 *incognito_items,
                 pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Update", lambda: self._update()),
                 pystray.MenuItem("Restart", lambda: self._restart()),
                 pystray.MenuItem("Quit", lambda: self.quit()),
             )),
@@ -2783,6 +2784,61 @@ class WhisperSync:
             self._refresh_menu()
 
         threading.Thread(target=_do_download, daemon=True).start()
+
+    def _update(self):
+        """Pull latest code from dev and restart if updated."""
+        def _do_update():
+            import subprocess as _sp
+            repo_root = str(Path(__file__).parent.parent)
+
+            notify("Updating WhisperSync...", "Pulling latest from dev")
+
+            # Check for uncommitted changes
+            status = _sp.run(
+                ["git", "status", "--porcelain"],
+                cwd=repo_root, capture_output=True, text=True, timeout=10
+            )
+            if status.stdout.strip():
+                logger.warning(f"Uncommitted changes detected:\n{status.stdout.strip()}")
+
+            # Fetch
+            fetch = _sp.run(
+                ["git", "fetch", "origin", "dev"],
+                cwd=repo_root, capture_output=True, text=True, timeout=30
+            )
+            if fetch.returncode != 0:
+                logger.error(f"git fetch failed: {fetch.stderr}")
+                notify("Update failed", "git fetch failed, check console")
+                return
+
+            # Check if there are updates
+            diff = _sp.run(
+                ["git", "rev-list", "HEAD..origin/dev", "--count"],
+                cwd=repo_root, capture_output=True, text=True, timeout=10
+            )
+            commit_count = int(diff.stdout.strip()) if diff.stdout.strip() else 0
+
+            if commit_count == 0:
+                notify("Already up to date", "No new changes on dev")
+                return
+
+            pull = _sp.run(
+                ["git", "pull", "origin", "dev"],
+                cwd=repo_root, capture_output=True, text=True, timeout=60
+            )
+            if pull.returncode != 0:
+                logger.error(f"git pull failed: {pull.stderr}")
+                notify("Update failed", "git pull failed, check console")
+                return
+
+            logger.info(f"Updated: {commit_count} new commit(s)")
+            notify("Updated!", f"{commit_count} new commit(s). Restarting...")
+
+            import time
+            time.sleep(2)  # Let the notification display
+            self._restart()
+
+        threading.Thread(target=_do_update, daemon=True).start()
 
     def _restart(self):
         import subprocess


### PR DESCRIPTION
## Summary
- Adds an "Update" menu item to the system tray, placed just above "Restart"
- Clicking it runs `git fetch origin dev` + `git pull origin dev` in a background thread
- Shows toast notifications for progress (updating, success with commit count, already up to date, or failure)
- Automatically restarts after a successful pull with new commits
- Warns in console log if uncommitted changes are detected (does not abort)

## Test plan
- [ ] Verify "Update" appears in the tray menu above "Restart"
- [ ] Click "Update" when already on latest: should show "Already up to date" notification
- [ ] Click "Update" when behind origin/dev: should pull, notify with commit count, and restart
- [ ] Click "Update" with dirty working tree: should warn in logs but still attempt the pull
- [ ] Verify the tray menu remains responsive while the update runs in the background

Generated with [Claude Code](https://claude.com/claude-code)