### PR TITLE
fix: remove standalone mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Local speech-to-text for Windows. GPU-accelerated transcription with speaker dia
 | `capture.py` | Mic + WASAPI loopback recording via sounddevice/PyAudioWPatch |
 | `channel_merge.py` | Per-channel diarization with confidence fusion for stereo recordings |
 | `config.py` | Config load/save. Merges defaults with user overrides. Only `_VALID_KEYS` persisted. Includes `toast_events` for notification config. |
-| `paths.py` | Data directory resolution. Standalone vs repo mode. All `.whispersync/` accessors |
+| `paths.py` | Data directory resolution. Repo mode path accessors. All `.whispersync/` accessors |
 | `logger.py` | Tiered logging (off/normal/detailed/verbose). File handler always DEBUG |
 | `icons.py` | Declarative icon registry (ICON_REGISTRY + IconSpec). build_icon() with progress-ring arc. IconAnimator for flash animations. Backward-compat wrappers for migration. |
 | `notifications.py` | Windows toast notifications with button callbacks. ToastListener (state event subscriber), TOAST_REGISTRY (configurable templates), notify_update() for in-place toasts via Tag/Group. |
@@ -70,7 +70,7 @@ output_dir/
       minutes.md
 ```
 
-`paths.py` modes: **Standalone** (`.standalone` marker) outputs to `~/Documents/WhisperSync/transcriptions`. **Repo mode** outputs to `<repo>/meetings/local-transcriptions`.
+`paths.py` resolves all paths relative to the repo root. Output defaults to `<repo>/meetings/local-transcriptions`.
 
 ## Conventions
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -17,7 +17,7 @@ Everything below is for developers modifying this app or for an AI assistant (li
 | `worker_manager.py` | **Subprocess lifecycle.** Spawns/kills/restarts worker process. IPC via multiprocessing.Queue. Crash detection + respawn. | `TranscriptionWorker` class --`start()`, `wait_ready()`, `transcribe_fast()`, `transcribe()`, `reload_model()`, `restart()`, `is_alive()` |
 | `streaming_wav.py` | **Crash-safe WAV writer.** Writes audio incrementally during recording. Can recover orphaned files after crash. | `StreamingWavWriter` class --`write()`, `close()`, `_write_header()`; `fix_orphan(path)` -- validates + rewrites header; `cleanup_temp_files(dir)` |
 | `config.py` | **Config manager.** Loads `config.defaults.json`, deep-merges with user `config.json` overrides. | `load()` returns merged dict; `save(overrides)` writes config.json |
-| `paths.py` | **Path resolver.** Standalone vs repo mode detection, model cache dir, output dir. | `is_standalone()` -- checks `.standalone` marker; `get_install_root()`, `get_model_cache()`, `get_default_output_dir()` |
+| `paths.py` | **Path resolver.** Repo mode path resolution, model cache dir, output dir. | `get_install_root()`, `get_model_cache()`, `get_default_output_dir()` |
 | `model_status.py` | **Model management.** Download, cache validation, bootstrap (auto-download tiny+base, prompt for larger). | `get_model_status(name)` returns bool; `download_model(name)` downloads to HF cache; `bootstrap_models(config)` -- first-run setup |
 | `icons.py` | **Tray icon generator.** Creates colored 64x64 PNG circles with labels. No external assets needed. | `_circle_icon(color, label)` returns PIL Image |
 | `paste.py` | **Text output.** Routes transcribed text to clipboard+Ctrl+V or simulated keystrokes. | `paste(text, method)`, `paste_clipboard(text)`, `paste_keystrokes(text)` |
@@ -36,7 +36,6 @@ Everything below is for developers modifying this app or for an AI assistant (li
 | `config.defaults.json` | `whisper_sync/` | Default configuration. Merged under user overrides. |
 | `config.json` | `<output_dir>/.whispersync/` (primary), `whisper_sync/` (legacy fallback) | User overrides. Created on first settings change. |
 | `whisper-capture.ico` | `whisper_sync/` | Application icon (64x64). Used in Windows shortcuts. |
-| `.standalone` | `whisper_sync/` | Marker file. If present, standalone mode. If absent, repo mode. Created by installer. |
 | `requirements.txt` | Top level | Pip dependencies. |
 | `install.ps1` | Top level | CLI installer. |
 | `start.ps1` | Top level | Launcher script. |
@@ -347,7 +346,7 @@ To also clear models: `Remove-Item -Recurse -Force ".\whisper_sync\models\*"`
 2. **Streaming WAV**: Audio written to disk incrementally; crash recovery can salvage partial recordings
 3. **PyTorch override**: whisperX pulls CPU-only torch; installer forces CUDA torch
 4. **Config merge**: Defaults + user overrides, deep merged; user config.json only contains changed keys
-5. **Standalone marker**: `.standalone` file determines path resolution mode
+5. **Path resolution**: All paths resolve relative to the repo root (two levels up from `whisper_sync/`)
 
 ### Important Constants
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ powershell -ExecutionPolicy Bypass -File start.ps1
 powershell -ExecutionPolicy Bypass -File start.ps1 -Watchdog
 ```
 
-When running without the `.standalone` marker file, WhisperSync operates in **repo mode**: transcription output goes to `<repo-root>/meetings/local-transcriptions/` instead of `~/Documents/WhisperSync/transcriptions/`.
+WhisperSync operates in **repo mode**: transcription output goes to `<repo-root>/meetings/local-transcriptions/`. All paths resolve relative to the repo root.
 
 ## Configuration
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -30,7 +30,7 @@ from .icons import (idle_icon, build_icon, resolve_icon_key, ICON_REGISTRY,
 from .logger import logger, get_log_path, set_console_level, log_dictation_result, log_meeting_result, log_transcript_preview
 from .model_status import get_model_status, download_model, bootstrap_models
 from .paste import paste
-from .paths import (get_install_root, get_default_output_dir, is_standalone,
+from .paths import (get_install_root, get_default_output_dir,
                      get_data_dir, get_dictation_log_dir,
                      get_legacy_config_path, get_legacy_speaker_config_path,
                      get_legacy_dictation_log_dir, get_config_path as get_data_config_path,
@@ -1709,12 +1709,8 @@ class WhisperSync:
     def _output_dir(self) -> Path:
         p = Path(self.cfg["output_dir"])
         if not p.is_absolute():
-            if is_standalone():
-                # Standalone: relative paths resolve under ~/Documents/WhisperSync/
-                p = get_default_output_dir().parent / p
-            else:
-                # Repo mode: relative paths resolve from repo root
-                p = get_install_root() / p
+            # Relative paths resolve from repo root
+            p = get_install_root() / p
         return p
 
     def _generate_minutes(self, meeting_dir: Path, readable_file: Path, minutes_file: Path):
@@ -2183,10 +2179,10 @@ class WhisperSync:
                 pystray.Menu.SEPARATOR,
                 *incognito_items,
                 pystray.Menu.SEPARATOR,
-                *([] if is_standalone() else [pystray.MenuItem("Update", pystray.Menu(
+                pystray.MenuItem("Update", pystray.Menu(
                     pystray.MenuItem("Stable\tmain", self._cb(self._update, "main")),
                     pystray.MenuItem("Labs\tdev", self._cb(self._update, "dev")),
-                ))]),
+                )),
                 pystray.MenuItem("Restart", lambda: self._restart()),
                 pystray.MenuItem("Quit", lambda: self.quit()),
             )),

--- a/whisper_sync/installer_gui.py
+++ b/whisper_sync/installer_gui.py
@@ -986,11 +986,6 @@ class InstallerApp:
             n = advance("Downloading models")
             self._log_step(n, "Downloading models...")
 
-            # Standalone marker
-            marker = self.pkg_dir / ".standalone"
-            if not marker.exists():
-                marker.write_text("")
-
             fd, bootstrap_path = tempfile.mkstemp(
                 suffix=".py", prefix="ws-bootstrap-",
             )

--- a/whisper_sync/paths.py
+++ b/whisper_sync/paths.py
@@ -1,25 +1,16 @@
-"""Central path resolution -- standalone vs repo mode detection."""
+"""Central path resolution for repo mode."""
 
 import json
 from pathlib import Path
 
 _PKG_DIR = Path(__file__).parent
-_STANDALONE = (_PKG_DIR / ".standalone").exists()
-
-
-def is_standalone() -> bool:
-    """True when running from a distributed zip (not inside the git repo)."""
-    return _STANDALONE
 
 
 def get_install_root() -> Path:
     """Root directory for resolving relative paths.
 
-    Repo mode:  two levels up (scripts/whisper_sync/ -> repo root).
-    Standalone: the package directory itself.
+    Two levels up from whisper_sync/ package to repo root.
     """
-    if _STANDALONE:
-        return _PKG_DIR
     return _PKG_DIR.parent.parent
 
 
@@ -36,11 +27,8 @@ def get_model_cache() -> Path:
 def get_default_output_dir() -> Path:
     """Sensible default when output_dir is relative.
 
-    Repo mode:  <repo_root>/meetings/local-transcriptions
-    Standalone: ~/Documents/WhisperSync/transcriptions
+    Returns <repo_root>/meetings/local-transcriptions.
     """
-    if _STANDALONE:
-        return Path.home() / "Documents" / "WhisperSync" / "transcriptions"
     return get_install_root() / "meetings" / "local-transcriptions"
 
 
@@ -66,8 +54,6 @@ def _resolve_output_dir() -> Path:
         p = Path(raw)
         if p.is_absolute():
             return p
-        if _STANDALONE:
-            return Path.home() / "Documents" / "WhisperSync" / p
         return get_install_root() / p
 
     # Phase 1: Check if we already know the output_dir from legacy config

--- a/whisper_sync/transcribe.py
+++ b/whisper_sync/transcribe.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from . import config
 from .logger import logger
-from .paths import get_model_cache, is_standalone
+from .paths import get_model_cache
 
 # Local model cache — keeps models offline
 _MODEL_CACHE = get_model_cache()
@@ -205,7 +205,7 @@ def _load_diarize_pipeline():
         from whisperx.diarize import DiarizationPipeline
         hf_token_path = Path.home() / ".huggingface" / "token"
         if not hf_token_path.exists():
-            hint = "See README.md for setup instructions." if is_standalone() else "Run: pm-get-secret hugging-face_read"
+            hint = "Run: pm-get-secret hugging-face_read"
             raise FileNotFoundError(
                 f"HF token not found at {hf_token_path}. {hint}"
             )


### PR DESCRIPTION
## Summary
- Remove `.standalone` marker detection, `is_standalone()`, and `_STANDALONE` flag from `paths.py`
- Remove all standalone code paths from `__main__.py`, `transcribe.py`, and `installer_gui.py`
- Update menu is now always visible (was hidden when standalone mode was active)
- Updated CLAUDE.md, TECHNICAL.md, and development.md to remove standalone references

## Context
Standalone mode was dead code that caused the Update menu to be hidden in the system tray. The `.standalone` marker file no longer exists, but the detection code remained and defaulted to non-standalone behavior. This cleanup removes the branching entirely so only repo-mode paths remain.

**Note**: `build-dist.ps1` and `install.ps1` still contain standalone marker creation logic. These are build/install scripts and were left as-is since they are part of the distribution pipeline (now effectively dead code in those scripts too).

## Test plan
- [ ] Verify WhisperSync starts without errors
- [ ] Verify Update menu appears in the system tray
- [ ] Verify transcription output still goes to the correct directory
- [ ] Verify relative output_dir paths resolve correctly from repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)