### PR TITLE
feat: preserve clipboard contents during dictation

### DIFF
--- a/whisper_sync/paste.py
+++ b/whisper_sync/paste.py
@@ -1,18 +1,55 @@
 """Paste transcription results into the focused field."""
 
+import threading
 import time
 
 import pyperclip
 
 from .logger import logger
 
+# Delay (seconds) before restoring previous clipboard contents.
+# Must be long enough for the paste keystroke to land.
+_RESTORE_DELAY: float = 0.5
 
-def paste_clipboard(text: str) -> None:
+
+def _save_clipboard() -> str | None:
+    """Read the current clipboard contents, returning None on failure."""
+    try:
+        return pyperclip.paste()
+    except Exception:
+        return None
+
+
+def _schedule_clipboard_restore(previous: str | None) -> None:
+    """Restore *previous* clipboard contents after a short delay.
+
+    Runs in a daemon thread so it never blocks the caller.
+    """
+    if previous is None:
+        return
+
+    def _restore():
+        time.sleep(_RESTORE_DELAY)
+        try:
+            pyperclip.copy(previous)
+            logger.debug("Clipboard restored to previous contents")
+        except Exception:
+            pass
+
+    threading.Thread(target=_restore, daemon=True).start()
+
+
+def paste_clipboard(text: str, *, restore: bool = True) -> None:
     """Copy text to clipboard and attempt to paste into focused window.
 
     ALWAYS puts text in clipboard first, then tries Ctrl+V.
     Text is guaranteed to be in clipboard regardless of outcome.
+
+    When *restore* is True the previous clipboard contents are put back
+    after the paste keystroke has had time to land.
     """
+    previous = _save_clipboard() if restore else None
+
     pyperclip.copy(text)
     logger.info(f"Text in clipboard ({len(text)} chars)")
     try:
@@ -27,21 +64,28 @@ def paste_clipboard(text: str) -> None:
         except Exception:
             pass
         logger.warning(f"Auto-paste failed (text still in clipboard): {e}")
+        # Don't restore - user needs clipboard contents to paste manually
+        return
+
+    _schedule_clipboard_restore(previous)
 
 
-def paste_keystrokes(text: str) -> None:
+def paste_keystrokes(text: str, *, restore: bool = True) -> None:
     """Type text via simulated keystrokes. Falls back to clipboard if it fails."""
+    previous = _save_clipboard() if restore else None
+
     try:
         import keyboard
         keyboard.write(text, delay=0.01)
+        _schedule_clipboard_restore(previous)
     except Exception:
         pyperclip.copy(text)
         logger.warning("Keystroke paste failed, text copied to clipboard")
+        # Don't restore - user needs clipboard contents to paste manually
 
 
 def paste(text: str, method: str = "clipboard") -> None:
-    # Always ensure clipboard has the text as absolute fallback
-    pyperclip.copy(text)
+    # Save clipboard before any writes so we can restore afterwards
     if method == "clipboard":
         paste_clipboard(text)
     elif method == "keystrokes":


### PR DESCRIPTION
## Summary
- Before dictation text is written to clipboard, the current clipboard contents are cached in RAM
- After auto-paste completes (0.5s delay for the keystroke to land), previous contents are restored via a daemon thread
- If auto-paste fails, clipboard is NOT restored so the user can still manually Ctrl+V the dictation text
- Crash recovery and manual copy-from-history paths are unchanged (they intentionally leave text on clipboard)

## Design decisions
- Restoration runs in a daemon thread so it never blocks the main dictation flow
- The `paste_clipboard` and `paste_keystrokes` functions accept a `restore` keyword arg (default True) for callers that want to opt out
- The redundant `pyperclip.copy(text)` in `paste()` before dispatching to method-specific functions was removed since each function already handles clipboard writes
- `_save_clipboard()` returns None on any exception (e.g., empty clipboard, access error), and restoration is skipped when previous is None

## Test plan
- [ ] Normal dictation: verify text pastes correctly, then check clipboard after ~1s to confirm previous contents are restored
- [ ] Keystroke paste method: same verification
- [ ] Auto-paste failure (e.g., no focused window): verify dictation text stays on clipboard (no restore)
- [ ] Crash recovery: verify text is on clipboard and stays there (no restore, no auto-paste)
- [ ] Copy from dictation history menu: verify text stays on clipboard (unchanged path)

Closes #91

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>