### PR TITLE
feat: stateful concurrent meeting icons, non-blocking rename

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1104,15 +1104,21 @@ class WhisperSync:
         meaningful = [w for w in words if w not in stopwords and len(w) > 2][:4]
         return ["-".join(meaningful)] if meaningful else [current_name]
 
-    def _ask_rename_suggestion(self, current_name: str, summary: str):
-        """Show a popup suggesting a better meeting name based on minutes summary.
+    def _ask_rename_suggestion(self, current_name: str, summary: str,
+                               meeting_dir=None, date_time_str: str | None = None):
+        """Show a non-blocking popup suggesting a better meeting name.
 
-        Returns the chosen name string, or None to skip rename.
+        When meeting_dir and date_time_str are provided, the rename is
+        performed inside the dialog thread so the caller is never blocked.
+        Returns immediately (None). The dialog handles the rename on accept.
+
+        When meeting_dir is None, falls back to blocking mode and returns the
+        chosen name string (or None to skip).
         """
         suggestions = self._generate_name_suggestions(summary, current_name)
 
         result = [None]
-        event = threading.Event()
+        event = threading.Event() if meeting_dir is None else None
 
         def _show():
             import tkinter as tk
@@ -1143,7 +1149,6 @@ class WhisperSync:
             # --- Summary card ---
             summary_card = tk.Frame(root, bg=card_bg)
             summary_card.pack(fill="x", padx=24, pady=(12, 0))
-            # Rounded corners not possible in tk, but border color helps
             summary_card.configure(highlightbackground="#313244", highlightthickness=1)
             summary_text = summary[:140] + ("..." if len(summary) > 140 else "")
             tk.Label(summary_card, text=summary_text, wraplength=420,
@@ -1206,13 +1211,32 @@ class WhisperSync:
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _skip)
             root.mainloop()
-            event.set()
+
+            # Perform rename in this thread (non-blocking for caller)
+            if meeting_dir is not None and date_time_str is not None:
+                new_name = result[0]
+                if new_name and new_name != current_name:
+                    import shutil
+                    new_folder_name = f"{date_time_str}_{new_name}"
+                    new_meeting_dir = meeting_dir.parent / new_folder_name
+                    if not new_meeting_dir.exists():
+                        shutil.move(str(meeting_dir), str(new_meeting_dir))
+                        logger.info(f"Renamed: {meeting_dir.name} -> {new_folder_name}")
+                    else:
+                        logger.warning(f"Rename skipped - folder already exists: {new_folder_name}")
+
+            if event is not None:
+                event.set()
 
         t = threading.Thread(target=_show, daemon=True)
         t.start()
-        event.wait(timeout=120)
 
-        return result[0]
+        # Only block when in legacy (no meeting_dir) mode
+        if event is not None:
+            event.wait(timeout=120)
+            return result[0]
+
+        return None
 
     def _show_llm_unavailable(self):
         """Show a dialog when Claude CLI is not available. Returns True if user checked 'don't show again'."""
@@ -1670,21 +1694,14 @@ class WhisperSync:
                                         summary = line[len("> Summary:"):].strip()
                                         break
                                 if summary:
-                                    new_name = self._ask_rename_suggestion(meeting_name or "meeting", summary)
-                                    if new_name and new_name != meeting_name:
-                                        new_folder_name = f"{date_time_str}_{new_name}"
-                                        new_meeting_dir = meeting_dir.parent / new_folder_name
-                                        if not new_meeting_dir.exists():
-                                            import shutil
-                                            shutil.move(str(meeting_dir), str(new_meeting_dir))
-                                            logger.info(f"Renamed: {folder_name} -> {new_folder_name}")
-                                            meeting_dir = new_meeting_dir
-                                        else:
-                                            logger.warning(f"Rename skipped — folder already exists: {new_folder_name}")
+                                    # Non-blocking: dialog + rename run in their own thread
+                                    self._ask_rename_suggestion(
+                                        meeting_name or "meeting", summary,
+                                        meeting_dir=meeting_dir, date_time_str=date_time_str)
                                 else:
-                                    logger.info("No > Summary: line found in minutes — rename skipped")
+                                    logger.info("No > Summary: line found in minutes - rename skipped")
                             else:
-                                logger.info("No minutes.md found — rename skipped")
+                                logger.info("No minutes.md found - rename skipped")
                         except Exception as e:
                             logger.warning(f"Rename suggestion failed (non-fatal): {e}")
                 # Rebuild week + root INDEX.md
@@ -1841,14 +1858,10 @@ class WhisperSync:
                                     summary = line[len("> Summary:"):].strip()
                                     break
                             if summary:
-                                new_name = self._ask_rename_suggestion(meeting_name or "meeting", summary)
-                                if new_name and new_name != meeting_name:
-                                    new_folder_name = f"{date_time_str}_{new_name}"
-                                    new_meeting_dir = meeting_dir.parent / new_folder_name
-                                    if not new_meeting_dir.exists():
-                                        import shutil
-                                        shutil.move(str(meeting_dir), str(new_meeting_dir))
-                                        logger.info(f"Renamed: {folder_name} -> {new_folder_name}")
+                                # Non-blocking: dialog + rename run in their own thread
+                                self._ask_rename_suggestion(
+                                    meeting_name or "meeting", summary,
+                                    meeting_dir=meeting_dir, date_time_str=date_time_str)
                     except Exception as e:
                         logger.warning(f"Rename suggestion failed (non-fatal): {e}")
 

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -50,11 +50,19 @@ ICON_REGISTRY: dict[str, IconSpec] = {
     "recording.meeting":              IconSpec("#CC3333", "#FF4444", tooltip="Recording meeting..."),
     "recording.meeting.speaker_fail": IconSpec("#FFAA00", "#FF4444", tooltip="Recording (speaker issue)"),
 
+    # Recording meeting while background transcription runs
+    "recording.meeting.bg_transcribing":              IconSpec("#CC8800", "#FF4444", tooltip="Recording (bg transcribing)..."),
+    "recording.meeting.bg_transcribing.speaker_fail": IconSpec("#FFAA00", "#FF4444", tooltip="Recording (bg transcribing, speaker issue)..."),
+
     # Dictation states
     "dictation":                              IconSpec("#CCCCCC", "#4488FF", tooltip="Dictating..."),
     "dictation.overlay.meeting":              IconSpec("#CC3333", "#FF4444", "#4488FF", tooltip="Dictating (meeting)..."),
     "dictation.overlay.meeting.speaker_fail": IconSpec("#FFAA00", "#FF4444", "#4488FF", tooltip="Dictating (meeting, speaker issue)..."),
     "dictation.overlay.transcribing":         IconSpec("#CC8800", "#FFAA00", "#4488FF", tooltip="Dictating (transcribing)..."),
+
+    # Dictation during recording while background transcription runs
+    "dictation.overlay.meeting.bg_transcribing":              IconSpec("#CC8800", "#FF4444", "#4488FF", tooltip="Dictating (meeting + bg transcribing)..."),
+    "dictation.overlay.meeting.bg_transcribing.speaker_fail": IconSpec("#FFAA00", "#FF4444", "#4488FF", tooltip="Dictating (meeting + bg transcribing, speaker issue)..."),
 
     # Pipeline states
     "saving":        IconSpec("#CC8800", "#FFAA00", tooltip="Saving audio..."),
@@ -151,6 +159,9 @@ def resolve_icon_key(mode: str | None = None,
     """
     if dictation_overlay:
         if mode == "meeting":
+            if meeting_transcribing:
+                return ("dictation.overlay.meeting.bg_transcribing.speaker_fail"
+                        if not speaker_ok else "dictation.overlay.meeting.bg_transcribing")
             return ("dictation.overlay.meeting.speaker_fail"
                     if not speaker_ok else "dictation.overlay.meeting")
         if meeting_transcribing:
@@ -158,6 +169,9 @@ def resolve_icon_key(mode: str | None = None,
         return "dictation"
 
     if mode == "meeting":
+        if meeting_transcribing:
+            return ("recording.meeting.bg_transcribing.speaker_fail"
+                    if not speaker_ok else "recording.meeting.bg_transcribing")
         return "recording.meeting" if speaker_ok else "recording.meeting.speaker_fail"
     if mode:
         return mode  # "dictation", "saving", "transcribing", "done", "error"


### PR DESCRIPTION
## Summary
- Add 4 compound icon states for recording + background transcription (orange outer ring signals bg transcription is active during a new recording)
- Update `resolve_icon_key` to check `meeting_transcribing` flag when `mode == "meeting"`, covering both plain recording and dictation overlay
- Refactor `_ask_rename_suggestion` to perform the rename inside the dialog thread when `meeting_dir` is provided, so the meeting save pipeline returns immediately instead of blocking up to 120s

Fixes #99

## Test plan
- [ ] Start a meeting, stop it, start a second meeting while the first transcribes. Verify orange outer ring appears instead of red.
- [ ] During the above state, trigger dictation overlay. Verify the icon shows orange ring + red middle + blue dot.
- [ ] After transcription completes during recording, verify icon returns to red (recording.meeting).
- [ ] Save & Summarize a meeting. Verify the rename dialog appears without blocking the transcription pipeline.
- [ ] Dismiss the rename dialog. Verify no rename occurs and logs show skip.
- [ ] Accept a rename. Verify the folder is renamed correctly.

Generated with [Claude Code](https://claude.com/claude-code)