### PR TITLE
feat: add model field to dictation log entries

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -476,7 +476,7 @@ class WhisperSync:
                     weekly_stats.record_dictation(char_count, t2 - t0)
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
-                        dictation_log.append(text, t2 - t0)
+                        dictation_log.append(text, t2 - t0, model=effective_model)
                         self._dictation_history.append({
                             "text": text,
                             "timestamp": datetime.now().strftime("%H:%M"),
@@ -602,7 +602,7 @@ class WhisperSync:
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
-                        dictation_log.append(text, duration)
+                        dictation_log.append(text, duration, model=backup_model)
                         self._dictation_history.append({
                             "text": text,
                             "timestamp": datetime.now().strftime("%H:%M"),
@@ -643,7 +643,7 @@ class WhisperSync:
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
-                        dictation_log.append(text, duration)
+                        dictation_log.append(text, duration, model=dictation_model)
                         self._dictation_history.append({
                             "text": text,
                             "timestamp": datetime.now().strftime("%H:%M"),
@@ -682,7 +682,7 @@ class WhisperSync:
             text = self.worker.transcribe_fast(audio_np, model_override=dictation_model)
             if text:
                 pyperclip.copy(text)
-                dictation_log.append(text, 0)
+                dictation_log.append(text, 0, model=dictation_model)
                 logger.info(f"Crash-recovered dictation copied to clipboard: {text[:80]}...")
                 # #38: Toast with recovered text info and Copy button
                 try:

--- a/whisper_sync/dictation_log.py
+++ b/whisper_sync/dictation_log.py
@@ -29,12 +29,13 @@ def _log_dir() -> Path:
     return get_dictation_log_dir()
 
 
-def append(text: str, duration: float) -> None:
+def append(text: str, duration: float, model: str = "") -> None:
     """Append a dictation entry to today's JSON log file.
 
     Args:
         text: The transcribed text (exactly as pasted).
         duration: Total pipeline time in seconds (stop -> paste).
+        model: Whisper model name used for transcription.
     """
     if not text or not text.strip():
         return
@@ -48,6 +49,7 @@ def append(text: str, duration: float) -> None:
         "timestamp": now.isoformat(timespec="seconds"),
         "duration": round(duration, 2),
         "chars": len(text),
+        "model": model,
         "text": text,
     }
 


### PR DESCRIPTION
## Summary
- Adds a `model` parameter to `dictation_log.append()` (defaults to empty string for backwards compatibility)
- Includes the `model` field in each JSON log entry, between `chars` and `text`
- Updates all 4 call sites in `__main__.py` to pass the correct model name:
  - Normal dictation: `effective_model` (primary or backup depending on fallback)
  - Overlay dictation (backup worker): `backup_model`
  - Overlay dictation (fallback to main worker): `dictation_model`
  - Crash recovery: `dictation_model`

## Test plan
- [ ] Run a normal dictation, verify the daily JSON log includes the correct `model` value
- [ ] Trigger overlay dictation during a meeting, verify backup model name is logged
- [ ] Confirm existing log files without `model` field still load correctly via `load_recent()`

Generated with [Claude Code](https://claude.com/claude-code)