### PR TITLE
fix: suppress torchcodec warnings in subprocesses, force-exit on restart

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2,11 +2,20 @@
 
 import faulthandler
 import logging
+import os
 import sys
 import threading
 import warnings
 
-# Suppress known harmless warnings before any imports trigger them
+# Set PYTHONWARNINGS env var so spawned subprocesses (multiprocessing "spawn"
+# context) also suppress these warnings. The warnings module filters only
+# apply to the current process; subprocesses start fresh Python interpreters.
+os.environ["PYTHONWARNINGS"] = (
+    "ignore::UserWarning:pyannote.audio.core.io,"
+    "ignore::UserWarning:pyannote.audio.utils.reproducibility"
+)
+
+# Suppress known harmless warnings in the main process too
 warnings.filterwarnings("ignore", message="torchcodec is not installed correctly",
                         category=UserWarning, module=r"pyannote\.audio\.core\.io")
 warnings.filterwarnings("ignore", message="TensorFloat-32.*has been disabled",
@@ -3093,14 +3102,18 @@ class WhisperSync:
             import time
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
-            try:
-                if self.tray:
-                    self.tray.stop()
-            finally:
-                subprocess.Popen(
-                    [sys.executable, "-m", "whisper_sync"],
-                    cwd=str(Path(__file__).parent.parent),
-                )
+            # Spawn new process first so it starts loading immediately
+            subprocess.Popen(
+                [sys.executable, "-m", "whisper_sync"],
+                cwd=str(Path(__file__).parent.parent),
+            )
+            # Stop tray icon, then force-exit. os._exit() is needed because
+            # daemon threads (worker subprocesses, keyboard listener, etc.)
+            # can keep the process alive after tray.stop() returns.
+            if self.tray:
+                self.tray.stop()
+            time.sleep(0.2)
+            os._exit(0)
 
         threading.Thread(target=_do_restart, daemon=True).start()
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -476,7 +476,7 @@ class WhisperSync:
                     weekly_stats.record_dictation(char_count, t2 - t0)
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
-                        dictation_log.append(text, t2 - t0)
+                        dictation_log.append(text, t2 - t0, model=effective_model)
                         self._dictation_history.append({
                             "text": text,
                             "timestamp": datetime.now().strftime("%H:%M"),
@@ -602,7 +602,7 @@ class WhisperSync:
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
-                        dictation_log.append(text, duration)
+                        dictation_log.append(text, duration, model=backup_model)
                         self._dictation_history.append({
                             "text": text,
                             "timestamp": datetime.now().strftime("%H:%M"),
@@ -643,7 +643,7 @@ class WhisperSync:
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
-                        dictation_log.append(text, duration)
+                        dictation_log.append(text, duration, model=dictation_model)
                         self._dictation_history.append({
                             "text": text,
                             "timestamp": datetime.now().strftime("%H:%M"),
@@ -682,7 +682,7 @@ class WhisperSync:
             text = self.worker.transcribe_fast(audio_np, model_override=dictation_model)
             if text:
                 pyperclip.copy(text)
-                dictation_log.append(text, 0)
+                dictation_log.append(text, 0, model=dictation_model)
                 logger.info(f"Crash-recovered dictation copied to clipboard: {text[:80]}...")
                 # #38: Toast with recovered text info and Copy button
                 try:

--- a/whisper_sync/dictation_log.py
+++ b/whisper_sync/dictation_log.py
@@ -29,12 +29,13 @@ def _log_dir() -> Path:
     return get_dictation_log_dir()
 
 
-def append(text: str, duration: float) -> None:
+def append(text: str, duration: float, model: str = "") -> None:
     """Append a dictation entry to today's JSON log file.
 
     Args:
         text: The transcribed text (exactly as pasted).
         duration: Total pipeline time in seconds (stop -> paste).
+        model: Whisper model name used for transcription.
     """
     if not text or not text.strip():
         return
@@ -48,6 +49,7 @@ def append(text: str, duration: float) -> None:
         "timestamp": now.isoformat(timespec="seconds"),
         "duration": round(duration, 2),
         "chars": len(text),
+        "model": model,
         "text": text,
     }
 


### PR DESCRIPTION
Sets PYTHONWARNINGS env var for subprocess inheritance (matches start.ps1 approach). Adds os._exit(0) after restart spawn to kill lingering daemon threads.