### PR TITLE
fix: add thread safety lock for tray icon updates

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -134,6 +134,7 @@ class WhisperSync:
         self.tray = None
         self.state = None  # Initialized after tray creation in run()
         self._lock = threading.RLock()
+        self._tray_lock = threading.Lock()  # Serialize all tray icon/title updates (pystray not thread-safe)
         self._api_filter = "Windows WASAPI"  # None = show all
         self._dictation_wav_path: Path | None = None
         self._meeting_start_time: datetime | None = None
@@ -198,12 +199,22 @@ class WhisperSync:
                             shutil.copy2(f, dest)
                 logger.info(f"Migrated dictation logs -> {new_dict_dir}")
 
+    def _update_tray(self, icon=None, title=None):
+        """Thread-safe tray icon/title update. Serializes all pystray mutations."""
+        with self._tray_lock:
+            if self.tray is None:
+                return
+            if icon is not None:
+                self.tray.icon = icon
+            if title is not None:
+                self.tray.title = title
+
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
         if getattr(self, '_flashing', False):
             return
         self._flashing = True
-        animator = IconAnimator(self.tray)
+        animator = IconAnimator(self.tray, lock=self._tray_lock)
         animator.flash(count=2, interval_ms=150)
         # Reset flag after animation completes (~600ms)
         import time
@@ -282,7 +293,7 @@ class WhisperSync:
 
     def _flash_queued(self):
         """Rapid amber flash to indicate dictation is queued behind a meeting stage."""
-        animator = IconAnimator(self.tray)
+        animator = IconAnimator(self.tray, lock=self._tray_lock)
         animator.flash_between("queued", "transcribing", count=2, interval_ms=150)
 
     def _can_record(self) -> bool:
@@ -3250,8 +3261,7 @@ class WhisperSync:
             spec = ICON_REGISTRY[key]
             progress = s.progress
             icon = build_icon(spec, progress=progress)
-            self.tray.icon = icon
-            self.tray.title = f"WhisperSync: {spec.tooltip}"
+            self._update_tray(icon=icon, title=f"WhisperSync: {spec.tooltip}")
         self.state.on_any(_on_state_change)
 
         # Register toast notification listener

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -187,9 +187,24 @@ def resolve_icon_key(mode: str | None = None,
 class IconAnimator:
     """Frame-by-frame icon animations in background threads."""
 
-    def __init__(self, tray):
+    def __init__(self, tray, lock=None):
         self._tray = tray
+        self._lock = lock  # Optional threading.Lock for thread-safe tray updates
         self._cancel = threading.Event()
+
+    def _set_tray(self, icon=None, title=None):
+        """Set tray icon/title, using the lock if one was provided."""
+        if self._lock is not None:
+            with self._lock:
+                if icon is not None:
+                    self._tray.icon = icon
+                if title is not None:
+                    self._tray.title = title
+        else:
+            if icon is not None:
+                self._tray.icon = icon
+            if title is not None:
+                self._tray.title = title
 
     def flash(self, count: int = 2, interval_ms: int = 150):
         """Yellow double-flash (universal loading/queuing signal)."""
@@ -203,9 +218,9 @@ class IconAnimator:
             for _ in range(count):
                 if self._cancel.is_set():
                     break
-                self._tray.icon = flash_img
+                self._set_tray(icon=flash_img)
                 time.sleep(interval_ms / 1000)
-                self._tray.icon = original
+                self._set_tray(icon=original)
                 time.sleep(interval_ms / 1000)
 
         threading.Thread(target=_run, daemon=True).start()
@@ -223,11 +238,9 @@ class IconAnimator:
             for _ in range(count):
                 if self._cancel.is_set():
                     break
-                self._tray.icon = img_a
-                self._tray.title = f"WhisperSync: {ICON_REGISTRY[key_a].tooltip}"
+                self._set_tray(icon=img_a, title=f"WhisperSync: {ICON_REGISTRY[key_a].tooltip}")
                 time.sleep(interval_ms / 1000)
-                self._tray.icon = img_b
-                self._tray.title = f"WhisperSync: {ICON_REGISTRY[key_b].tooltip}"
+                self._set_tray(icon=img_b, title=f"WhisperSync: {ICON_REGISTRY[key_b].tooltip}")
                 time.sleep(interval_ms / 1000)
 
         threading.Thread(target=_run, daemon=True).start()


### PR DESCRIPTION
## Summary
- Adds a `threading.Lock` (`_tray_lock`) that serializes all pystray icon and title mutations, preventing concurrent access violations on Windows
- Introduces `_update_tray()` helper in `__main__.py` that acquires the lock before setting `self.tray.icon` or `self.tray.title`
- Introduces `_set_tray()` helper in `IconAnimator` that uses the same lock (passed via constructor) for animation thread updates

## Context
Concurrent threads (e.g., dictation completion + state change after meeting transcription) calling `self.tray.icon = ...` simultaneously caused `Windows fatal exception: access violation` crashes. pystray's icon property setter is not thread-safe on Windows.

Closes #103

## Test plan
- [ ] Start a meeting recording, then trigger dictation while recording. Verify no crash on icon transition
- [ ] Queue a dictation while a meeting is transcribing. Verify the queued flash animation completes without crash
- [ ] Rapid-fire dictation start/stop while a state change is in progress. Verify stability
- [ ] Confirm yellow flash animation still renders correctly (not frozen or skipped)

Generated with [Claude Code](https://claude.com/claude-code)