### PR TITLE
fix: speaker ID timeout recovery with manual fallback and Meetings menu (#109)

### DIFF
--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -38,6 +38,12 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 - Default backup_model is `base`. The installer can override to `small` or `tiny` based on detected VRAM during installation. No runtime auto-selection.
 - Model merging: dictation and meeting share the primary model instance. The backup model is always a separate instance.
 
+## Speaker Identification Recovery
+
+`identify_speakers()` calls `claude -p --model haiku` with a 90s timeout and 1 retry. If both attempts fail, `step_speaker_id` in `meeting_job.py` builds a stub with empty names and still shows `_ask_speaker_confirmation()` so the user can enter names manually. A toast notification fires before the dialog to explain the timeout.
+
+The **Meetings** tray menu (above Recent Dictations) shows the 10 most recent meetings with their speaker status. Clicking any meeting re-enters the speaker ID flow: `identify_speakers()` -> `_ask_speaker_confirmation()` -> `write_speaker_map()` -> `flatten()` -> optionally regenerate minutes. This handles recovery from timeouts, accidental skips, and retroactive speaker assignment.
+
 ## Critical Rules
 
 - **Never change the multiprocessing context from "spawn"** - required for CUDA isolation.

--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -40,7 +40,7 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 
 ## Speaker Identification Recovery
 
-`identify_speakers()` calls `claude -p --model haiku` with a 90s timeout and 1 retry. If both attempts fail, `step_speaker_id` in `meeting_job.py` builds a stub with empty names and still shows `_ask_speaker_confirmation()` so the user can enter names manually. A toast notification fires before the dialog to explain the timeout.
+`identify_speakers()` calls `claude -p --model haiku` with a 90s timeout and 1 retry. If both attempts fail, `step_speaker_id` in `meeting_job.py` builds a stub with empty names and still shows `_ask_speaker_confirmation()` so the user can enter names manually. A toast notification fires before the dialog to indicate that automatic speaker identification failed and that names can be entered manually.
 
 The **Meetings** tray menu (above Recent Dictations) shows the 10 most recent meetings with their speaker status. Clicking any meeting re-enters the speaker ID flow: `identify_speakers()` -> `_ask_speaker_confirmation()` -> `write_speaker_map()` -> `flatten()` -> optionally regenerate minutes. This handles recovery from timeouts, accidental skips, and retroactive speaker assignment.
 

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -55,6 +55,10 @@ The menu is rebuilt on every open via `_refresh_menu()`. Structure:
 
 ```
 ┌─────────────────────────────────────────┐
+│ Meetings ►                              │  → _build_meetings_menu()
+│   ├── 0401_Abhi-11       No speakers    │  → _recover_meeting_speakers(dir)
+│   ├── 0401_retro         Colby, Vinod   │  → _recover_meeting_speakers(dir)
+│   └── ...  (10 most recent)             │
 │ Dictation              Ctrl+Shift+Space │  → toggle_dictation()
 │ Meeting                Ctrl+Shift+M     │  → toggle_meeting()
 │ ─────────────────────────────────────── │

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -842,7 +842,7 @@ class WhisperSync:
     def _recover_meeting_speakers(self, meeting_dir: Path):
         """Re-enter the speaker ID flow for a past meeting."""
         import json as _json
-        from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
+        from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path, build_manual_stub
         from .flatten import flatten as flatten_transcript
 
         json_path = meeting_dir / "transcript.json"
@@ -865,22 +865,8 @@ class WhisperSync:
 
             # Fall back to manual stub
             if not id_result or not id_result.get("speaker_map"):
-                try:
-                    with open(json_path) as f:
-                        data = _json.load(f)
-                    unique_speakers = sorted(set(
-                        s.get("speaker", "UNKNOWN")
-                        for s in data.get("segments", [])
-                        if s.get("speaker")
-                    ))
-                    if unique_speakers:
-                        id_result = {
-                            "speaker_map": {spk: "" for spk in unique_speakers},
-                            "confidence": {spk: "low" for spk in unique_speakers},
-                            "reasoning": {spk: "Enter name manually" for spk in unique_speakers},
-                        }
-                except Exception as e:
-                    logger.warning(f"Could not build speaker stub: {e}")
+                id_result = build_manual_stub(str(json_path))
+                if not id_result:
                     return
 
             if not id_result or not id_result.get("speaker_map"):
@@ -904,7 +890,7 @@ class WhisperSync:
             except Exception as e:
                 logger.warning(f"Recovery: flatten failed: {e}")
 
-            # Offer to regenerate minutes
+            # Regenerate minutes with updated speaker names
             readable_file = meeting_dir / "transcript-readable.txt"
             minutes_file = meeting_dir / "minutes.md"
             if readable_file.exists() and self._is_claude_cli_available():
@@ -1921,8 +1907,9 @@ class WhisperSync:
                         with open(json_path) as f:
                             data = _json.load(f)
                         smap = data.get("speaker_map", {})
-                        if smap:
-                            status = ", ".join(sorted(set(smap.values())))
+                        names = [str(v).strip() for v in smap.values() if str(v).strip()]
+                        if names:
+                            status = ", ".join(sorted(set(names)))
                         else:
                             status = "No speakers"
                     except Exception:

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -839,6 +839,93 @@ class WhisperSync:
             threading.Thread(target=_transcribe, daemon=True).start()
         self._recovered_meeting_paths = []
 
+    def _recover_meeting_speakers(self, meeting_dir: Path):
+        """Re-enter the speaker ID flow for a past meeting."""
+        import json as _json
+        from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
+        from .flatten import flatten as flatten_transcript
+
+        json_path = meeting_dir / "transcript.json"
+        if not json_path.exists():
+            logger.warning(f"No transcript.json in {meeting_dir}")
+            return
+
+        def _run():
+            cfg_path = get_config_path()
+
+            # Try Claude identification first
+            id_result = None
+            if self._is_claude_cli_available():
+                try:
+                    id_result = identify_speakers(
+                        str(json_path), cfg_path, meeting_dir.name
+                    )
+                except Exception as e:
+                    logger.warning(f"Speaker ID failed for recovery: {e}")
+
+            # Fall back to manual stub
+            if not id_result or not id_result.get("speaker_map"):
+                try:
+                    with open(json_path) as f:
+                        data = _json.load(f)
+                    unique_speakers = sorted(set(
+                        s.get("speaker", "UNKNOWN")
+                        for s in data.get("segments", [])
+                        if s.get("speaker")
+                    ))
+                    if unique_speakers:
+                        id_result = {
+                            "speaker_map": {spk: "" for spk in unique_speakers},
+                            "confidence": {spk: "low" for spk in unique_speakers},
+                            "reasoning": {spk: "Enter name manually" for spk in unique_speakers},
+                        }
+                except Exception as e:
+                    logger.warning(f"Could not build speaker stub: {e}")
+                    return
+
+            if not id_result or not id_result.get("speaker_map"):
+                logger.warning("No speakers to identify")
+                return
+
+            confirmed_map = self._ask_speaker_confirmation(id_result)
+            if not confirmed_map:
+                logger.info("Recovery: speaker identification skipped by user")
+                return
+
+            # Write speaker map
+            write_speaker_map(str(json_path), confirmed_map)
+            update_config(cfg_path, confirmed_map, id_result.get("config_updates"))
+            logger.info(f"Recovery: speakers confirmed for {meeting_dir.name}: {confirmed_map}")
+
+            # Re-flatten
+            try:
+                flatten_transcript(str(json_path))
+                logger.info(f"Recovery: re-flattened {meeting_dir.name}")
+            except Exception as e:
+                logger.warning(f"Recovery: flatten failed: {e}")
+
+            # Offer to regenerate minutes
+            readable_file = meeting_dir / "transcript-readable.txt"
+            minutes_file = meeting_dir / "minutes.md"
+            if readable_file.exists() and self._is_claude_cli_available():
+                try:
+                    from .notifications import notify
+                    notify(
+                        f"Speakers updated: {meeting_dir.name}",
+                        "Regenerating minutes with updated speaker names.",
+                    )
+                except Exception:
+                    pass
+                try:
+                    self._generate_minutes(meeting_dir, readable_file, minutes_file)
+                    logger.info(f"Recovery: minutes regenerated for {meeting_dir.name}")
+                except Exception as e:
+                    logger.warning(f"Recovery: minutes generation failed: {e}")
+
+            self._refresh_menu()
+
+        threading.Thread(target=_run, daemon=True).start()
+
     def _ask_recovery_name(self, wav_path: str, duration_str: str):
         """Show a dialog to name a recovered meeting. Returns name string or _ABORT."""
         result = [self._ABORT]
@@ -1813,6 +1900,55 @@ class WhisperSync:
         )
         return pystray.Menu(*items)
 
+    def _build_meetings_menu(self):
+        """Build the Meetings submenu showing recent meetings with speaker status."""
+        import json as _json
+
+        output_dir = self._output_dir()
+        meeting_folders = []
+
+        # Scan all week folders for meeting directories with transcript.json
+        for week_dir in sorted(output_dir.iterdir(), reverse=True):
+            if not week_dir.is_dir() or week_dir.name.startswith("."):
+                continue
+            for meeting_dir in sorted(week_dir.iterdir(), reverse=True):
+                if not meeting_dir.is_dir():
+                    continue
+                json_path = meeting_dir / "transcript.json"
+                if json_path.exists():
+                    # Check speaker_map status
+                    try:
+                        with open(json_path) as f:
+                            data = _json.load(f)
+                        smap = data.get("speaker_map", {})
+                        if smap:
+                            status = ", ".join(sorted(set(smap.values())))
+                        else:
+                            status = "No speakers"
+                    except Exception:
+                        status = "Error"
+                    meeting_folders.append((meeting_dir, status))
+                    if len(meeting_folders) >= 10:
+                        break
+            if len(meeting_folders) >= 10:
+                break
+
+        if not meeting_folders:
+            return pystray.Menu(
+                pystray.MenuItem("No meetings found", None, enabled=False),
+            )
+
+        items = []
+        for meeting_dir, status in meeting_folders:
+            label = f"{meeting_dir.name}\t{status}"
+            items.append(
+                pystray.MenuItem(
+                    label,
+                    self._cb(self._recover_meeting_speakers, meeting_dir),
+                )
+            )
+        return pystray.Menu(*items)
+
     def _build_menu(self):
         devices = list_devices(api_filter=self._api_filter)
         dict_hk = self._fmt_hotkey(self.cfg["hotkeys"]["dictation_toggle"])
@@ -2024,6 +2160,7 @@ class WhisperSync:
         # Left-click fires the default menu item
         left_action = self.cfg.get("left_click", "meeting")
         return pystray.Menu(
+            pystray.MenuItem("Meetings", self._build_meetings_menu()),
             pystray.MenuItem("Recent Dictations", self._build_recent_dictations_menu()),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem(f"Dictation\t{dict_hk}", lambda: self._on_left_click() if left_action == "dictation" else self.toggle_dictation(),

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -137,23 +137,58 @@ class MeetingJob:
         self.llm_ok = self.app._is_claude_cli_available()
 
     def step_speaker_id(self):
-        """Identify and confirm speakers via Claude CLI + tkinter dialog."""
+        """Identify and confirm speakers via Claude CLI + tkinter dialog.
+
+        If Claude times out or fails, still shows the dialog with empty names
+        so the user can manually enter speaker names.
+        """
         from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
 
-        if not self.llm_ok:
-            logger.info("Claude CLI not available, speaker identification skipped")
-            return
+        json_path = self.transcript_result.get(
+            "json_path", str(self.meeting_dir / "transcript.json")
+        )
 
-        try:
-            cfg_path = get_config_path()
-            json_path = self.transcript_result.get(
-                "json_path", str(self.meeting_dir / "transcript.json")
-            )
-            id_result = identify_speakers(json_path, cfg_path, self.folder_name)
-            if id_result and id_result.get("speaker_map"):
+        id_result = None
+        if self.llm_ok:
+            try:
+                cfg_path = get_config_path()
+                id_result = identify_speakers(json_path, cfg_path, self.folder_name)
+            except Exception as e:
+                logger.warning("Speaker identification failed (non-fatal): %s", e)
+
+        if not id_result or not id_result.get("speaker_map"):
+            # Build stub with empty names so the dialog still appears
+            try:
+                import json as _json
+                with open(json_path) as f:
+                    data = _json.load(f)
+                unique_speakers = sorted(set(
+                    s.get("speaker", "UNKNOWN")
+                    for s in data.get("segments", [])
+                    if s.get("speaker")
+                ))
+                if unique_speakers:
+                    id_result = {
+                        "speaker_map": {spk: "" for spk in unique_speakers},
+                        "confidence": {spk: "low" for spk in unique_speakers},
+                        "reasoning": {spk: "Auto-identification failed - enter name manually" for spk in unique_speakers},
+                    }
+                    # Notify user
+                    try:
+                        from .notifications import notify
+                        notify("Speaker ID Failed", "Enter speaker names manually in the dialog.")
+                    except Exception:
+                        pass
+                    logger.warning("Speaker ID failed, showing manual entry dialog")
+            except Exception as e:
+                logger.warning("Could not build manual speaker stub: %s", e)
+
+        if id_result and id_result.get("speaker_map"):
+            try:
                 confirmed_map = self.app._ask_speaker_confirmation(id_result)
                 if confirmed_map:
                     write_speaker_map(json_path, confirmed_map)
+                    cfg_path = get_config_path()
                     update_config(
                         cfg_path, confirmed_map, id_result.get("config_updates")
                     )
@@ -161,10 +196,10 @@ class MeetingJob:
                     self.speakers_confirmed = confirmed_map
                 else:
                     logger.info("Speaker identification skipped by user")
-            else:
-                logger.info("No speakers identified from transcript")
-        except Exception as e:
-            logger.warning("Speaker identification failed (non-fatal): %s", e)
+            except Exception as e:
+                logger.warning("Speaker confirmation dialog failed: %s", e)
+        else:
+            logger.info("No speakers found in transcript")
 
     def step_flatten(self):
         """Flatten transcript JSON to readable text."""

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -142,7 +142,7 @@ class MeetingJob:
         If Claude times out or fails, still shows the dialog with empty names
         so the user can manually enter speaker names.
         """
-        from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
+        from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path, build_manual_stub
 
         json_path = self.transcript_result.get(
             "json_path", str(self.meeting_dir / "transcript.json")
@@ -157,31 +157,24 @@ class MeetingJob:
                 logger.warning("Speaker identification failed (non-fatal): %s", e)
 
         if not id_result or not id_result.get("speaker_map"):
-            # Build stub with empty names so the dialog still appears
-            try:
-                import json as _json
-                with open(json_path) as f:
-                    data = _json.load(f)
-                unique_speakers = sorted(set(
-                    s.get("speaker", "UNKNOWN")
-                    for s in data.get("segments", [])
-                    if s.get("speaker")
-                ))
-                if unique_speakers:
-                    id_result = {
-                        "speaker_map": {spk: "" for spk in unique_speakers},
-                        "confidence": {spk: "low" for spk in unique_speakers},
-                        "reasoning": {spk: "Auto-identification failed - enter name manually" for spk in unique_speakers},
-                    }
-                    # Notify user
-                    try:
-                        from .notifications import notify
-                        notify("Speaker ID Failed", "Enter speaker names manually in the dialog.")
-                    except Exception:
-                        pass
-                    logger.warning("Speaker ID failed, showing manual entry dialog")
-            except Exception as e:
-                logger.warning("Could not build manual speaker stub: %s", e)
+            # Tailor reasoning and notification based on cause
+            if self.llm_ok:
+                reason = "Auto-identification failed - enter name manually"
+                toast_title = "Speaker ID Failed"
+                toast_body = "Automatic speaker identification failed; enter names manually in the dialog."
+            else:
+                reason = "Auto-identification unavailable (Claude CLI not available) - enter name manually"
+                toast_title = "Speaker ID Unavailable"
+                toast_body = "Speaker identification requires Claude CLI, which is not available. Enter speaker names manually in the dialog."
+
+            id_result = build_manual_stub(json_path, reason)
+            if id_result:
+                try:
+                    from .notifications import notify
+                    notify(toast_title, toast_body)
+                except Exception:
+                    pass
+                logger.warning("Speaker ID not applied, showing manual entry dialog")
 
         if id_result and id_result.get("speaker_map"):
             try:

--- a/whisper_sync/speakers.py
+++ b/whisper_sync/speakers.py
@@ -84,6 +84,8 @@ def identify_speakers(
             )
             if result.returncode != 0:
                 logger.warning(f"Speaker identification CLI failed: {result.returncode}")
+                if result.stderr:
+                    logger.debug(f"Claude CLI stderr (truncated): {result.stderr[:500]}")
                 return None
 
             # Robust JSON extraction: find first { to last }
@@ -114,6 +116,33 @@ def identify_speakers(
         except Exception as e:
             logger.warning(f"Speaker identification failed: {e}")
             return None
+
+
+def build_manual_stub(json_path: str, reason: str = "Enter name manually") -> dict | None:
+    """Build a stub identification result with empty names for manual entry.
+
+    Reads unique SPEAKER_XX labels from transcript.json and returns a dict
+    compatible with _ask_speaker_confirmation().
+    """
+    import json as _json
+    try:
+        with open(json_path) as f:
+            data = _json.load(f)
+        unique_speakers = sorted(set(
+            s.get("speaker", "UNKNOWN")
+            for s in data.get("segments", [])
+            if s.get("speaker")
+        ))
+        if not unique_speakers:
+            return None
+        return {
+            "speaker_map": {spk: "" for spk in unique_speakers},
+            "confidence": {spk: "low" for spk in unique_speakers},
+            "reasoning": {spk: reason for spk in unique_speakers},
+        }
+    except Exception as e:
+        logger.warning(f"Could not build manual speaker stub: {e}")
+        return None
 
 
 def write_speaker_map(transcript_json_path: str, speaker_map: dict) -> None:

--- a/whisper_sync/speakers.py
+++ b/whisper_sync/speakers.py
@@ -69,44 +69,51 @@ def identify_speakers(
         f"Transcript (first 30 segments):\n{seg_text}"
     )
 
-    try:
-        result = subprocess.run(
-            ["claude", "-p", "--model", "haiku"],
-            input=full_prompt,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=str(Path(__file__).parent.parent.parent),
-        )
-        if result.returncode != 0:
-            logger.warning(f"Speaker identification CLI failed: {result.returncode}")
+    max_attempts = 2
+    timeout_s = 90
+
+    for attempt in range(max_attempts):
+        try:
+            result = subprocess.run(
+                ["claude", "-p", "--model", "haiku"],
+                input=full_prompt,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                cwd=str(Path(__file__).parent.parent.parent),
+            )
+            if result.returncode != 0:
+                logger.warning(f"Speaker identification CLI failed: {result.returncode}")
+                return None
+
+            # Robust JSON extraction: find first { to last }
+            response = result.stdout.strip()
+            first_brace = response.find("{")
+            last_brace = response.rfind("}")
+            if first_brace == -1 or last_brace == -1 or last_brace <= first_brace:
+                logger.warning("Speaker identification response contains no valid JSON object")
+                logger.debug(f"Raw response: {response[:500]}")
+                return None
+
+            json_str = response[first_brace:last_brace + 1]
+            return json.loads(json_str)
+
+        except json.JSONDecodeError as e:
+            logger.warning(f"Speaker identification returned invalid JSON: {e}")
+            logger.debug(f"Raw response: {result.stdout[:500]}")
             return None
-
-        # Robust JSON extraction: find first { to last }
-        response = result.stdout.strip()
-        first_brace = response.find("{")
-        last_brace = response.rfind("}")
-        if first_brace == -1 or last_brace == -1 or last_brace <= first_brace:
-            logger.warning("Speaker identification response contains no valid JSON object")
-            logger.debug(f"Raw response: {response[:500]}")
+        except FileNotFoundError:
+            logger.warning("Claude CLI not found - speaker identification skipped")
             return None
-
-        json_str = response[first_brace:last_brace + 1]
-        return json.loads(json_str)
-
-    except json.JSONDecodeError as e:
-        logger.warning(f"Speaker identification returned invalid JSON: {e}")
-        logger.debug(f"Raw response: {result.stdout[:500]}")
-        return None
-    except FileNotFoundError:
-        logger.warning("Claude CLI not found — speaker identification skipped")
-        return None
-    except subprocess.TimeoutExpired:
-        logger.warning("Speaker identification timed out (30s)")
-        return None
-    except Exception as e:
-        logger.warning(f"Speaker identification failed: {e}")
-        return None
+        except subprocess.TimeoutExpired:
+            if attempt < max_attempts - 1:
+                logger.warning(f"Speaker identification timed out ({timeout_s}s), retrying...")
+                continue
+            logger.warning(f"Speaker identification timed out after {max_attempts} attempts ({timeout_s}s each)")
+            return None
+        except Exception as e:
+            logger.warning(f"Speaker identification failed: {e}")
+            return None
 
 
 def write_speaker_map(transcript_json_path: str, speaker_map: dict) -> None:


### PR DESCRIPTION
## Summary
- Increase speaker identification CLI timeout from 30s to 90s with 1 retry
- Show manual speaker entry dialog when auto-identification fails (dialog always appears)
- Add Meetings tray menu showing 10 most recent meetings with speaker status
- Clicking any meeting re-enters the full speaker ID -> flatten -> minutes flow

## Context
Speaker identification has been silently failing due to 30s CLI timeout since March 30. 4 of the last 6 meetings had no speaker_map, causing transcript-readable.txt to show SPEAKER_XX labels instead of real names. Closes #109.

## Test plan
- [ ] Record a short meeting, verify speaker dialog appears
- [ ] Kill Claude CLI process during speaker ID, verify manual dialog appears with toast
- [ ] Check Meetings menu shows recent meetings with correct status
- [ ] Click a meeting with "No speakers" in Meetings menu, confirm dialog + re-flatten
- [ ] Verify transcript-readable.txt shows real names after recovery

Generated with [Claude Code](https://claude.com/claude-code)