### PR TITLE
fix: speaker confirmation dialog too short for 4+ speakers

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1413,8 +1413,8 @@ class WhisperSync:
             conf_colors = {"high": green, "medium": yellow, "low": red}
 
             num_speakers = len(speaker_map)
-            # Each speaker row ~40px + reasoning line ~16px
-            height = min(170 + (num_speakers * 58), 550)
+            # Each speaker row ~44px + reasoning line ~22px + padding
+            height = min(180 + (num_speakers * 70), 700)
             root.geometry(f"500x{height}")
 
             # Header

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1414,7 +1414,9 @@ class WhisperSync:
 
             num_speakers = len(speaker_map)
             # Each speaker row ~44px + reasoning line ~22px + padding
-            height = min(180 + (num_speakers * 70), 700)
+            screen_h = root.winfo_screenheight()
+            max_h = min(700, int(screen_h * 0.8))
+            height = min(180 + (num_speakers * 70), max_h)
             root.geometry(f"500x{height}")
 
             # Header


### PR DESCRIPTION
## Summary
Increase speaker confirmation dialog height calculation so Confirm/Skip buttons are not cut off with 4+ speakers.

- Per-speaker estimate: 58px -> 70px
- Base height: 170px -> 180px
- Max cap: 550px -> 700px

## Context
With 4 speakers, the old formula produced 402px which was too short when reasoning text wrapped. The buttons were below the visible area and could not be clicked.

## Test plan
- [ ] Trigger speaker ID with 2 speakers, verify dialog fits
- [ ] Trigger speaker ID with 4 speakers, verify Confirm/Skip visible
- [ ] Verify dialog does not exceed screen height with 8+ speakers (700px cap)

Generated with [Claude Code](https://claude.com/claude-code)