### PR TITLE
feat: deep speaker identification with full-transcript analysis (#114)

### DIFF
--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -44,11 +44,21 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 - Default backup_model is `base`. The installer can override to `small` or `tiny` based on detected VRAM during installation. No runtime auto-selection.
 - Model merging: dictation and meeting share the primary model instance. The backup model is always a separate instance.
 
-## Speaker Identification Recovery
+## Speaker Identification
 
-`identify_speakers()` calls `claude -p --model haiku` with a 90s timeout and 1 retry. If both attempts fail, `step_speaker_id` in `meeting_job.py` builds a stub with empty names and still shows `_ask_speaker_confirmation()` so the user can enter names manually. A toast notification fires before the dialog to indicate that automatic speaker identification failed and that names can be entered manually.
+Two-tier system, both using sonnet:
 
-The **Meetings** tray menu (above Recent Dictations) shows the 10 most recent meetings with their speaker status. Clicking any meeting re-enters the speaker ID flow: `identify_speakers()` -> `_ask_speaker_confirmation()` -> `write_speaker_map()` -> `flatten()` -> optionally regenerate minutes. This handles recovery from timeouts, accidental skips, and retroactive speaker assignment.
+**Light mode** (automatic after every transcription): `distill_transcript()` in `speakers.py` pre-processes the full transcript into a compact per-speaker summary (first/last appearances, name callouts, longest segments). Sonnet reads this summary + the full readable transcript for boundary detection. Produces speaker_map + meeting_boundaries. ~20-40 lines of input regardless of meeting length.
+
+**Deep mode** (manual via "Deep Identify" button in speaker confirmation dialog): Sends the full transcript with timestamps to sonnet for thorough analysis. Includes topic ownership tracking, timestamp evidence for every name callout, and meeting boundary detection. Progress bar shows analysis phases. More expensive but catches nuances light mode misses.
+
+Both modes detect meeting boundaries (farewell exchanges, pauses, new greetings). When boundaries are detected, the dialog offers to split the recording after speaker confirmation.
+
+Speaker identification timeout is 90s with 1 retry for light mode, 180s for deep mode. If identification fails, a manual entry dialog appears with empty fields and known speakers in autocomplete.
+
+The **Meetings** tray menu shows the 10 most recent meetings with speaker status. Clicking any meeting re-enters the speaker ID flow.
+
+IMPORTANT: Accent notes in transcription-config.md are human-authored reference. The LLM analyzes text only, not audio. Prompts explicitly instruct against using accent as a speaker attribution signal.
 
 ## Critical Rules
 

--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -48,7 +48,7 @@ WhisperSync captures stereo audio: microphone on channel 0, system loopback (spe
 
 Two-tier system, both using sonnet:
 
-**Light mode** (automatic after every transcription): `distill_transcript()` in `speakers.py` pre-processes the full transcript into a compact per-speaker summary (first/last appearances, name callouts, longest segments). Sonnet reads this summary + the full readable transcript for boundary detection. Produces speaker_map + meeting_boundaries. ~20-40 lines of input regardless of meeting length.
+**Light mode** (automatic after every transcription): `distill_transcript()` in `speakers.py` pre-processes the full transcript into a compact per-speaker summary (first/last appearances, name callouts, longest segments). Sonnet reads this summary + the full readable transcript for boundary detection. Produces speaker_map + meeting_boundaries. Summary size is compact and bounded per speaker, so total input scales with speaker count rather than meeting length alone.
 
 **Deep mode** (manual via "Deep Identify" button in speaker confirmation dialog): Sends the full transcript with timestamps to sonnet for thorough analysis. Includes topic ownership tracking, timestamp evidence for every name callout, and meeting boundary detection. Progress bar shows analysis phases. More expensive but catches nuances light mode misses.
 

--- a/build-dist.ps1
+++ b/build-dist.ps1
@@ -48,6 +48,7 @@ $pyFiles = @(
     "github_status.py",
     "speakers.py",
     "speaker_prompt.md",
+    "speaker_prompt_deep.md",
     "minutes_prompt.md",
     "feature_log.py",
     "feature_prompt.md",

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -895,6 +895,7 @@ class WhisperSync:
                     logger.warning("No speakers to identify")
                     return
 
+                self._current_meeting_json_path = str(json_path)
                 confirmed_map = self._ask_speaker_confirmation(id_result)
                 if not confirmed_map:
                     logger.info("Recovery: speaker identification skipped by user")
@@ -1377,6 +1378,9 @@ class WhisperSync:
         result = [None]
         event = threading.Event()
 
+        # Store json_path for deep identify button access
+        self._deep_id_json_path = getattr(self, '_current_meeting_json_path', None)
+
         # Load known speaker names from Known Speakers table ONLY (not Meeting Map)
         config_path = Path(get_config_path())
         known_names = []
@@ -1554,18 +1558,117 @@ class WhisperSync:
                     tk.Label(reason_frame, text=f"\u2514 {reason}", font=("Segoe UI", 7, "italic"),
                              bg=bg, fg=fg_dim, anchor="w", wraplength=400).pack(anchor="w")
 
+            # Progress bar (hidden initially)
+            progress_frame = tk.Frame(root, bg=bg)
+            progress_frame.pack(fill="x", padx=24, pady=(4, 0))
+            progress_canvas = tk.Canvas(progress_frame, height=4, bg="#313244",
+                                         highlightthickness=0)
+            progress_canvas.pack(fill="x")
+            progress_bar = progress_canvas.create_rectangle(0, 0, 0, 4, fill=accent, width=0)
+            progress_label = tk.Label(progress_frame, text="", font=("Segoe UI", 7),
+                                       bg=bg, fg=fg_dim)
+            progress_label.pack(anchor="w")
+            progress_frame.pack_forget()  # hidden until needed
+
+            # Boundary notice (hidden initially)
+            boundary_frame = tk.Frame(root, bg=bg)
+            boundary_label = tk.Label(boundary_frame, text="", font=("Segoe UI", 8),
+                                       bg=bg, fg=yellow, wraplength=440)
+            boundary_label.pack(side=tk.LEFT, padx=(24, 8))
+            boundary_frame.pack_forget()  # hidden until boundaries detected
+
+            _boundaries = [None]
+
             # Buttons
             btn_frame = tk.Frame(root, bg=bg)
             btn_frame.pack(pady=(14, 12))
 
             _closing = [False]
+            _deep_running = [False]
+
+            def _update_progress(phase, pct):
+                def _do():
+                    if _closing[0]:
+                        return
+                    progress_label.configure(text=phase)
+                    canvas_width = progress_canvas.winfo_width() or 440
+                    progress_canvas.coords(progress_bar, 0, 0, canvas_width * pct, 4)
+                root.after(0, _do)
+
+            def _deep_identify():
+                if _closing[0] or _deep_running[0]:
+                    return
+                _deep_running[0] = True
+
+                progress_frame.pack(fill="x", padx=24, pady=(4, 0))
+                for child in btn_frame.winfo_children():
+                    try:
+                        child.unbind("<Button-1>")
+                    except Exception:
+                        pass
+
+                def _run_deep():
+                    from .speakers import deep_identify_speakers, get_config_path
+                    try:
+                        cfg_path = get_config_path()
+                        json_path = self._deep_id_json_path
+                        if not json_path:
+                            raise ValueError("No transcript path available for deep identification")
+                        deep_result = deep_identify_speakers(
+                            json_path, cfg_path,
+                            Path(json_path).parent.name,
+                            progress_callback=_update_progress,
+                        )
+                        if deep_result and deep_result.get("speaker_map"):
+                            def _apply():
+                                for spk_id, var in dropdowns.items():
+                                    new_name = deep_result["speaker_map"].get(spk_id, "")
+                                    if new_name:
+                                        var.set(new_name)
+
+                                bounds = deep_result.get("meeting_boundaries", [])
+                                if bounds:
+                                    _boundaries[0] = bounds
+                                    pts = ", ".join(
+                                        f"{int(b['split_seconds']) // 60}:{int(b['split_seconds']) % 60:02d}"
+                                        for b in bounds
+                                    )
+                                    boundary_label.configure(
+                                        text=f"Detected {len(bounds) + 1} meetings. Split at {pts}?"
+                                    )
+                                    boundary_frame.pack(fill="x", pady=(4, 0))
+
+                                _rebind_buttons()
+                                _deep_running[0] = False
+
+                            root.after(0, _apply)
+                        else:
+                            def _fail():
+                                progress_label.configure(text="Deep identification returned no results")
+                                _rebind_buttons()
+                                _deep_running[0] = False
+                            root.after(0, _fail)
+
+                    except Exception as e:
+                        logger.warning(f"Deep identify failed: {e}")
+                        def _err():
+                            progress_label.configure(text=f"Failed: {str(e)[:60]}")
+                            _rebind_buttons()
+                            _deep_running[0] = False
+                        root.after(0, _err)
+
+                threading.Thread(target=_run_deep, daemon=True).start()
 
             def _confirm():
                 if _closing[0]:
                     return
                 _closing[0] = True
                 try:
-                    result[0] = {spk_id: var.get() for spk_id, var in dropdowns.items()}
+                    confirmed = {spk_id: var.get() for spk_id, var in dropdowns.items()}
+                    if _boundaries[0]:
+                        result[0] = (confirmed, _boundaries[0])
+                    else:
+                        result[0] = confirmed
                 except Exception:
                     pass
                 try:
@@ -1583,9 +1686,21 @@ class WhisperSync:
                 except Exception as e:
                     logger.debug(f"Speaker dialog close: {e}")
 
-            self._flat_button(btn_frame, "Confirm", _confirm,
-                              bg=accent, fg="#1e1e2e", hover_bg="#74c7ec", bold=True).pack(side=tk.RIGHT, padx=8)
-            self._flat_button(btn_frame, "Skip", _skip, fg=fg_muted).pack(side=tk.RIGHT, padx=8)
+            # Create buttons - store references for rebinding
+            _confirm_btn = self._flat_button(btn_frame, "Confirm", _confirm,
+                              bg=accent, fg="#1e1e2e", hover_bg="#74c7ec", bold=True)
+            _confirm_btn.pack(side=tk.RIGHT, padx=8)
+            _skip_btn = self._flat_button(btn_frame, "Skip", _skip, fg=fg_muted)
+            _skip_btn.pack(side=tk.RIGHT, padx=8)
+            _deep_btn = self._flat_button(btn_frame, "Deep Identify", _deep_identify,
+                              bg="#45475a", fg=fg, hover_bg="#585b70")
+            _deep_btn.pack(side=tk.RIGHT, padx=8)
+
+            def _rebind_buttons():
+                """Re-bind button clicks after deep identify completes."""
+                _confirm_btn.bind("<Button-1>", lambda e: _confirm())
+                _skip_btn.bind("<Button-1>", lambda e: _skip())
+                _deep_btn.bind("<Button-1>", lambda e: _deep_identify())
 
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _skip)

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1360,7 +1360,13 @@ class WhisperSync:
         return result[0]
 
     def _ask_speaker_confirmation(self, identification_result: dict) -> dict | None:
-        """Show speaker confirmation dialog. Returns confirmed speaker_map or None to skip."""
+        """Show speaker confirmation dialog.
+
+        Returns:
+            None: user skipped
+            dict: confirmed speaker_map (no boundaries detected)
+            tuple[dict, list]: (speaker_map, boundaries) when deep identify found meeting splits
+        """
         speaker_map = identification_result.get("speaker_map", {})
         confidence = identification_result.get("confidence", {})
         reasoning = identification_result.get("reasoning", {})
@@ -1626,7 +1632,20 @@ class WhisperSync:
                                     if new_name:
                                         var.set(new_name)
 
-                                bounds = deep_result.get("meeting_boundaries", [])
+                                raw_bounds = deep_result.get("meeting_boundaries", [])
+                                bounds = []
+                                if isinstance(raw_bounds, list):
+                                    for boundary in raw_bounds:
+                                        if not isinstance(boundary, dict):
+                                            continue
+                                        try:
+                                            split_secs = int(float(boundary.get("split_seconds", 0)))
+                                        except (TypeError, ValueError):
+                                            continue
+                                        normalized = dict(boundary)
+                                        normalized["split_seconds"] = split_secs
+                                        bounds.append(normalized)
+
                                 if bounds:
                                     _boundaries[0] = bounds
                                     pts = ", ".join(
@@ -1634,7 +1653,7 @@ class WhisperSync:
                                         for b in bounds
                                     )
                                     boundary_label.configure(
-                                        text=f"Detected {len(bounds) + 1} meetings. Split at {pts}?"
+                                        text=f"Detected {len(bounds) + 1} meetings (split at {pts}). Use Meetings menu to split."
                                     )
                                     boundary_frame.pack(fill="x", pady=(4, 0))
 

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -192,6 +192,8 @@ class MeetingJob:
 
                     write_speaker_map(json_path, confirmed_map)
                     cfg_path = get_config_path()
+                    # config_updates from initial (light) identification.
+                    # Deep mode config_updates are applied via the Meetings recovery flow.
                     update_config(
                         cfg_path, confirmed_map, id_result.get("config_updates")
                     )
@@ -201,6 +203,8 @@ class MeetingJob:
                     if boundaries:
                         logger.info(f"Meeting boundaries detected: {boundaries}")
                         self._detected_boundaries = boundaries
+                        # Boundaries are informational - user can split via Meetings tray menu.
+                        # Automatic splitting will be added in a future update.
                 else:
                     logger.info("Speaker identification skipped by user")
             except Exception as e:

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -181,8 +181,15 @@ class MeetingJob:
 
         if id_result and id_result.get("speaker_map"):
             try:
-                confirmed_map = self.app._ask_speaker_confirmation(id_result)
-                if confirmed_map:
+                self.app._current_meeting_json_path = json_path
+                confirmation = self.app._ask_speaker_confirmation(id_result)
+                if confirmation:
+                    if isinstance(confirmation, tuple):
+                        confirmed_map, boundaries = confirmation
+                    else:
+                        confirmed_map = confirmation
+                        boundaries = None
+
                     write_speaker_map(json_path, confirmed_map)
                     cfg_path = get_config_path()
                     update_config(
@@ -190,6 +197,10 @@ class MeetingJob:
                     )
                     logger.info("Speakers confirmed: %s", confirmed_map)
                     self.speakers_confirmed = confirmed_map
+
+                    if boundaries:
+                        logger.info(f"Meeting boundaries detected: {boundaries}")
+                        self._detected_boundaries = boundaries
                 else:
                     logger.info("Speaker identification skipped by user")
             except Exception as e:

--- a/whisper_sync/speaker_prompt.md
+++ b/whisper_sync/speaker_prompt.md
@@ -1,19 +1,27 @@
 You are identifying speakers in a meeting transcript. You will receive:
-1. The first 30 segments of a WhisperX transcript (with SPEAKER_XX labels)
+1. A per-speaker summary distilled from the FULL transcript (not just the beginning)
 2. A known speakers database with names and voice notes
 3. The meeting folder name and time
+4. The full readable transcript text (for meeting boundary detection)
 
-Your job: map each SPEAKER_XX to a real person from the known speakers list.
+Your job: map each SPEAKER_XX to a real person AND detect if this recording contains multiple meetings.
 
-Rules:
-- Match name callouts first: "Hey Dinesh", "Thanks Vinod", "{Name}, can you" — these are the strongest signal
-- Use voice notes for disambiguation: if someone discusses "API/MCP topics" and the known speakers list says "Dinesh — Backend engineer, API/MCP topics", that's likely Dinesh
+Speaker identification rules:
+- Match name callouts first: "Hey Dinesh", "Thanks Vinod", "{Name}, can you" - these are the strongest signal
+- Use voice notes for disambiguation: if someone discusses "API/MCP topics" and the known speakers list says "Dinesh - Backend engineer, API/MCP topics", that's likely Dinesh
 - Use meeting pattern matching: if the folder name contains "aloop-syncup", check the meeting map for likely participants
 - SPEAKER_00 is usually Colby (PM, American accent, leads agenda) unless evidence contradicts
-- If you cannot identify a speaker with any confidence, use "Unknown" — do NOT guess
+- IMPORTANT: Accent notes in the config are human-authored reference for humans. You are analyzing TEXT only, not audio. Do not use accent as a signal for speaker attribution.
+- If you cannot identify a speaker with any confidence, use "Unknown" - do NOT guess
 - If a speaker is clearly someone not in the known list, use "New: {best guess name}" and include them in new_speakers
 
-Output ONLY valid JSON in this exact format — no markdown fences, no explanation, no text before or after the JSON:
+Meeting boundary detection:
+- Read the full readable transcript and look for where one meeting ends and another begins
+- Signs: farewell exchanges ("bye", "thank you all", "see you"), topic resets, new greetings ("hello again", "okay let's start"), significant speaker composition changes
+- Report boundary points as seconds from the start of the recording
+- If no boundaries are found, return an empty array
+
+Output ONLY valid JSON in this exact format - no markdown fences, no explanation:
 
 {
   "speaker_map": {
@@ -25,16 +33,18 @@ Output ONLY valid JSON in this exact format — no markdown fences, no explanati
     "SPEAKER_01": "medium"
   },
   "reasoning": {
-    "SPEAKER_00": "Leads agenda, American accent pattern, PM context",
+    "SPEAKER_00": "Leads agenda, called by name at 15:30",
     "SPEAKER_01": "Called by name at segment 12, discusses API topics"
   },
+  "meeting_boundaries": [
+    {
+      "split_seconds": 1815,
+      "evidence": "Goodbye exchange around 30:10, new greeting at 30:42"
+    }
+  ],
   "config_updates": {
-    "new_voice_notes": {
-      "dinesh": "Also discusses server deployment and infrastructure"
-    },
-    "new_speakers": [
-      {"name": "David", "notes": "Sales/partnerships, demos ALoop to prospects"}
-    ]
+    "new_voice_notes": {},
+    "new_speakers": []
   }
 }
 
@@ -43,4 +53,4 @@ Confidence levels:
 - "medium": 2 of 3 signals match
 - "low": only 1 signal or educated guess
 
-If new_speakers is empty, use an empty array: []. If new_voice_notes is empty, use an empty object: {}.
+If meeting_boundaries is empty, use an empty array: []. If new_speakers is empty, use an empty array: []. If new_voice_notes is empty, use an empty object: {}.

--- a/whisper_sync/speaker_prompt_deep.md
+++ b/whisper_sync/speaker_prompt_deep.md
@@ -1,0 +1,59 @@
+You are performing deep speaker identification on a meeting transcript. You will receive:
+1. The FULL transcript with timestamps and SPEAKER_XX labels
+2. A known speakers database with names and voice notes
+3. The meeting folder name
+
+Your job: thoroughly identify every speaker AND detect meeting boundaries.
+
+Speaker identification rules:
+- Scan the ENTIRE transcript for name callouts: "Hey Dinesh", "Thanks Vinod", "{Name}, can you" - note every occurrence with its timestamp
+- Track topic ownership: which speaker consistently discusses which subjects
+- Use voice notes for disambiguation, but IMPORTANT: accent notes in the config are human-authored reference for humans. You are analyzing TEXT only, not audio. Do not use accent as a signal.
+- Use meeting pattern matching: if the folder name matches a known meeting pattern, check expected participants
+- SPEAKER_00 is usually Colby unless evidence contradicts
+- If you cannot identify a speaker, use "Unknown" - do NOT guess
+- For new speakers not in the known list, use "New: {best guess name}" and include in new_speakers
+- Flag any voice notes in the config that appear to be inferred from text rather than audio observation (circular reasoning)
+
+Meeting boundary detection:
+- Look for clear meeting transitions: farewell exchanges followed by pauses (>15s gap between segments) and new greetings
+- Note changes in speaker composition (speakers leaving, new speakers appearing)
+- Report boundary points as seconds from start, with evidence
+- If the recording is a single continuous meeting, return an empty array
+
+Provide detailed reasoning with timestamp evidence for each speaker identification.
+
+Output ONLY valid JSON - no markdown fences, no explanation:
+
+{
+  "speaker_map": {
+    "SPEAKER_00": "Colby",
+    "SPEAKER_01": "Dinesh"
+  },
+  "confidence": {
+    "SPEAKER_00": "high",
+    "SPEAKER_01": "high"
+  },
+  "reasoning": {
+    "SPEAKER_00": "Named at 02:15, 15:30, 45:12. Leads agenda. Assigns action items.",
+    "SPEAKER_01": "Named at 03:20, 28:45. Discusses backend API topics. Exits at 30:12 with goodbye."
+  },
+  "meeting_boundaries": [
+    {
+      "split_seconds": 1815,
+      "evidence": "Goodbye exchange at 30:10-30:13 (SPEAKER_01: 'Bye', SPEAKER_02: 'Bye'). 29s gap. New greeting at 30:42 (SPEAKER_02: 'hello again')."
+    }
+  ],
+  "config_updates": {
+    "new_voice_notes": {},
+    "new_speakers": [],
+    "flagged_notes": ["dinesh: 'Indian accent' appears text-inferred, not audio-observed"]
+  }
+}
+
+Confidence levels:
+- "high": name callout with timestamp + voice notes match + consistent topic ownership
+- "medium": 2 of 3 signals match
+- "low": only 1 signal or educated guess
+
+If meeting_boundaries is empty, use []. If new_speakers is empty, use []. If new_voice_notes is empty, use {}. If flagged_notes is empty, use [].

--- a/whisper_sync/speakers.py
+++ b/whisper_sync/speakers.py
@@ -14,6 +14,66 @@ from pathlib import Path
 from .logger import logger
 
 
+def distill_transcript(json_path: str) -> str:
+    """Distill full transcript into a compact per-speaker summary.
+
+    Groups all segments by speaker, extracts representative samples
+    (first/last appearances, name callouts, longest segments) so that
+    every speaker is represented regardless of when they appear in the meeting.
+    Returns a formatted text block suitable for LLM consumption.
+    """
+    with open(json_path) as f:
+        data = json.load(f)
+    segments = data.get("segments", [])
+    if not segments:
+        return ""
+
+    from collections import defaultdict
+    by_speaker: dict[str, list[dict]] = defaultdict(list)
+    for s in segments:
+        spk = s.get("speaker", "UNKNOWN")
+        by_speaker[spk].append(s)
+
+    name_patterns = re.compile(
+        r"\b(?:hey|hi|thanks|thank you|okay|sorry|right)\s+([A-Z][a-z]+)\b"
+        r"|(?:^|\W)([A-Z][a-z]+),?\s+(?:can you|could you|do you|what do|please|are you)",
+        re.IGNORECASE,
+    )
+
+    lines = []
+    for spk in sorted(by_speaker.keys()):
+        segs = by_speaker[spk]
+        total_time = sum(s.get("end", 0) - s.get("start", 0) for s in segs)
+        lines.append(f"\n=== {spk} ({len(segs)} segments, ~{total_time / 60:.1f} min) ===")
+
+        def _fmt(s):
+            start = s.get("start", 0)
+            m, sec = int(start // 60), int(start % 60)
+            return f"  [{m:02d}:{sec:02d}] {s.get('text', '').strip()}"
+
+        lines.append("  -- First appearances:")
+        for s in segs[:5]:
+            lines.append(_fmt(s))
+
+        if len(segs) > 10:
+            lines.append("  -- Last appearances:")
+            for s in segs[-5:]:
+                lines.append(_fmt(s))
+
+        callouts = [s for s in segs if name_patterns.search(s.get("text", ""))]
+        if callouts:
+            lines.append("  -- Name callouts:")
+            for s in callouts[:5]:
+                lines.append(_fmt(s))
+
+        longest = sorted(segs, key=lambda s: len(s.get("text", "")), reverse=True)[:3]
+        lines.append("  -- Richest content:")
+        for s in longest:
+            lines.append(_fmt(s))
+
+    return "\n".join(lines)
+
+
 def identify_speakers(
     transcript_json_path: str,
     config_path: str,
@@ -35,21 +95,16 @@ def identify_speakers(
         logger.warning(f"Speaker prompt not found: {prompt_path}")
         return None
 
-    # Load first 30 segments
-    with open(transcript_json_path) as f:
-        data = json.load(f)
-    segments = data.get("segments", [])[:30]
-    if not segments:
+    # Distill transcript into per-speaker summary
+    distilled = distill_transcript(transcript_json_path)
+    if not distilled:
         return None
 
-    # Format segments for the prompt
-    seg_text = ""
-    for s in segments:
-        speaker = s.get("speaker", "UNKNOWN")
-        text = s.get("text", "").strip()
-        start = s.get("start", 0)
-        mins, secs = int(start // 60), int(start % 60)
-        seg_text += f"[{mins:02d}:{secs:02d}] {speaker}: {text}\n"
+    # Load readable transcript for boundary detection
+    readable_path = Path(transcript_json_path).parent / "transcript-readable.txt"
+    readable_text = ""
+    if readable_path.exists():
+        readable_text = readable_path.read_text(encoding="utf-8")
 
     # Load config
     config_text = ""
@@ -66,8 +121,10 @@ def identify_speakers(
         f"---\n\n"
         f"Meeting folder: {folder_name}\n\n"
         f"Known speakers config:\n{config_text}\n\n"
-        f"Transcript (first 30 segments):\n{seg_text}"
+        f"Speaker summary (distilled from full transcript):\n{distilled}"
     )
+    if readable_text:
+        full_prompt += f"\n\n---\n\nFull readable transcript (for boundary detection):\n{readable_text}"
 
     max_attempts = 2
     timeout_s = 90
@@ -75,7 +132,7 @@ def identify_speakers(
     for attempt in range(max_attempts):
         try:
             result = subprocess.run(
-                ["claude", "-p", "--model", "haiku"],
+                ["claude", "-p", "--model", "sonnet"],
                 input=full_prompt,
                 capture_output=True,
                 text=True,

--- a/whisper_sync/speakers.py
+++ b/whisper_sync/speakers.py
@@ -175,6 +175,132 @@ def identify_speakers(
             return None
 
 
+def deep_identify_speakers(
+    transcript_json_path: str,
+    config_path: str,
+    folder_name: str,
+    progress_callback=None,
+) -> dict | None:
+    """Deep speaker identification using full transcript with timestamps.
+
+    Sends the complete transcript to sonnet for thorough analysis including
+    meeting boundary detection. More expensive but more accurate than light mode.
+
+    Args:
+        transcript_json_path: Path to transcript.json
+        config_path: Path to transcription-config.md
+        folder_name: Meeting folder name
+        progress_callback: Optional callable(phase: str, pct: float) for UI updates
+
+    Returns:
+        Parsed JSON dict with speaker_map, confidence, reasoning,
+        meeting_boundaries, config_updates. None if failed.
+    """
+    prompt_path = Path(__file__).parent / "speaker_prompt_deep.md"
+    if not prompt_path.exists():
+        logger.warning(f"Deep speaker prompt not found: {prompt_path}")
+        return None
+
+    if progress_callback:
+        progress_callback("Preparing transcript...", 0.1)
+
+    # Load full transcript
+    with open(transcript_json_path) as f:
+        data = json.load(f)
+    segments = data.get("segments", [])
+    if not segments:
+        return None
+
+    # Format segments with timestamps
+    # If >500 segments, sample: first 50, last 50, evenly spaced middle
+    if len(segments) > 500:
+        first = segments[:50]
+        last = segments[-50:]
+        middle_count = 400
+        step = max(1, (len(segments) - 100) // middle_count)
+        middle = segments[50:-50:step][:middle_count]
+        sampled = first + middle + last
+        logger.info(f"Deep ID: sampled {len(sampled)} of {len(segments)} segments")
+    else:
+        sampled = segments
+
+    seg_text = ""
+    for s in sampled:
+        speaker = s.get("speaker", "UNKNOWN")
+        text = s.get("text", "").strip()
+        start = s.get("start", 0)
+        mins, secs = int(start // 60), int(start % 60)
+        seg_text += f"[{mins:02d}:{secs:02d}] {speaker}: {text}\n"
+
+    # Load config
+    config_text = ""
+    config_file = Path(config_path)
+    if config_file.exists():
+        config_text = config_file.read_text(encoding="utf-8")
+
+    # Load deep prompt
+    prompt_template = prompt_path.read_text(encoding="utf-8")
+
+    full_prompt = (
+        f"{prompt_template}\n\n"
+        f"---\n\n"
+        f"Meeting folder: {folder_name}\n\n"
+        f"Known speakers config:\n{config_text}\n\n"
+        f"Full transcript ({len(sampled)} segments):\n{seg_text}"
+    )
+
+    if progress_callback:
+        progress_callback("Analyzing with Sonnet...", 0.25)
+
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--model", "sonnet"],
+            input=full_prompt,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            cwd=str(Path(__file__).parent.parent.parent),
+        )
+
+        if progress_callback:
+            progress_callback("Processing results...", 0.90)
+
+        if result.returncode != 0:
+            logger.warning(f"Deep speaker ID CLI failed: {result.returncode}")
+            if result.stderr:
+                logger.debug(f"Claude CLI stderr: {result.stderr[:500]}")
+            return None
+
+        response = result.stdout.strip()
+        first_brace = response.find("{")
+        last_brace = response.rfind("}")
+        if first_brace == -1 or last_brace == -1 or last_brace <= first_brace:
+            logger.warning("Deep speaker ID response contains no valid JSON")
+            logger.debug(f"Raw response: {response[:500]}")
+            return None
+
+        json_str = response[first_brace:last_brace + 1]
+        parsed = json.loads(json_str)
+
+        if progress_callback:
+            progress_callback("Complete", 1.0)
+
+        return parsed
+
+    except json.JSONDecodeError as e:
+        logger.warning(f"Deep speaker ID returned invalid JSON: {e}")
+        return None
+    except FileNotFoundError:
+        logger.warning("Claude CLI not found - deep speaker ID skipped")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("Deep speaker ID timed out (180s)")
+        return None
+    except Exception as e:
+        logger.warning(f"Deep speaker ID failed: {e}")
+        return None
+
+
 def build_manual_stub(json_path: str, reason: str = "Enter name manually") -> dict | None:
     """Build a stub identification result with empty names for manual entry.
 

--- a/whisper_sync/speakers.py
+++ b/whisper_sync/speakers.py
@@ -212,25 +212,57 @@ def deep_identify_speakers(
         return None
 
     # Format segments with timestamps
-    # If >500 segments, sample: first 50, last 50, evenly spaced middle
+    # Sample segments, preserving context around real pauses for boundary detection
     if len(segments) > 500:
-        first = segments[:50]
-        last = segments[-50:]
-        middle_count = 400
-        step = max(1, (len(segments) - 100) // middle_count)
-        middle = segments[50:-50:step][:middle_count]
-        sampled = first + middle + last
+        max_segments = 500
+        edge_count = 50
+        pause_threshold = 15.0
+        pause_window = 2
+
+        selected_indices = set(range(min(edge_count, len(segments))))
+        selected_indices.update(range(max(0, len(segments) - edge_count), len(segments)))
+
+        # Preserve contiguous context around real pauses
+        for i in range(1, len(segments)):
+            prev_end = segments[i - 1].get("end", segments[i - 1].get("start", 0))
+            curr_start = segments[i].get("start", 0)
+            if curr_start - prev_end > pause_threshold:
+                start_idx = max(edge_count, i - pause_window)
+                end_idx = min(len(segments) - edge_count, i + pause_window + 1)
+                selected_indices.update(range(start_idx, end_idx))
+
+        remaining_budget = max_segments - len(selected_indices)
+        if remaining_budget > 0:
+            middle_start = edge_count
+            middle_end = max(edge_count, len(segments) - edge_count)
+            available_middle = [
+                idx for idx in range(middle_start, middle_end)
+                if idx not in selected_indices
+            ]
+            if available_middle:
+                step = max(1, len(available_middle) // remaining_budget)
+                selected_indices.update(available_middle[::step][:remaining_budget])
+
+        sampled = [(idx, segments[idx]) for idx in sorted(selected_indices)]
         logger.info(f"Deep ID: sampled {len(sampled)} of {len(segments)} segments")
     else:
-        sampled = segments
+        sampled = list(enumerate(segments))
 
     seg_text = ""
-    for s in sampled:
+    for idx, s in sampled:
         speaker = s.get("speaker", "UNKNOWN")
         text = s.get("text", "").strip()
         start = s.get("start", 0)
         mins, secs = int(start // 60), int(start % 60)
-        seg_text += f"[{mins:02d}:{secs:02d}] {speaker}: {text}\n"
+
+        gap_note = ""
+        if idx > 0:
+            prev_end = segments[idx - 1].get("end", segments[idx - 1].get("start", 0))
+            gap_before = start - prev_end
+            if gap_before > 15:
+                gap_note = f" [gap={gap_before:.0f}s]"
+
+        seg_text += f"[{mins:02d}:{secs:02d}]{gap_note} {speaker}: {text}\n"
 
     # Load config
     config_text = ""


### PR DESCRIPTION
## Summary
- Upgrade speaker identification from haiku to sonnet
- Light mode: Python distill_transcript() pre-filters full transcript into per-speaker summary, sonnet reads compact input + readable text for boundary detection
- Deep mode: "Deep Identify" button sends full timestamped transcript to sonnet
- Progress bar in speaker dialog shows analysis phases
- Meeting boundary detection in both modes (farewell/greeting patterns)
- Updated prompts: accent notes explicitly excluded from text-based attribution

Closes #114.

## Test plan
- [ ] Record meeting, verify light mode uses sonnet with distilled transcript
- [ ] Verify all speakers identified even if they appear late in the meeting
- [ ] Click Deep Identify, verify progress bar and in-place field updates
- [ ] Test with a recording containing two meetings back-to-back
- [ ] Verify boundary notice appears and split is offered

Generated with [Claude Code](https://claude.com/claude-code)