### PR TITLE
fix: install torchvision from CUDA index

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -170,7 +170,7 @@ Ok "Dependencies installed"
 
 if ($cudaVersion) {
     Step 5 "Installing PyTorch ($cudaVersion)..."
-    RunWithSpinner "Installing PyTorch" $VenvPip "install torch torchaudio --index-url https://download.pytorch.org/whl/$cudaVersion --force-reinstall --no-deps -qq"
+    RunWithSpinner "Installing PyTorch" $VenvPip "install torch torchaudio torchvision --index-url https://download.pytorch.org/whl/$cudaVersion --force-reinstall --no-deps -qq"
     Ok "PyTorch GPU installed"
 } else {
     Step 5 "Skipping GPU PyTorch (no GPU detected)"


### PR DESCRIPTION
## Summary

- `install.ps1` installs `torch` and `torchaudio` from the CUDA index but omits `torchvision`
- When `whisperx` pulls in `pyannote.audio` (via `torchmetrics`/`lightning`), `torchvision` resolves from regular PyPI as a CPU-only build
- CPU-only `torchvision` is incompatible with CUDA-enabled `torch`, crashing the worker subprocess on import before GPU detection runs
- Latent bug that surfaced when upstream dependencies started requiring `torchvision`

**Fix:** Add `torchvision` to the CUDA index install line, matching the PyTorch recommended install pattern.

## Test plan

- [ ] Fresh install on Windows with NVIDIA GPU (cu128): verify `torchvision` installs from CUDA index
- [ ] Verify `python -c "import torch; print(torch.cuda.is_available())"` returns `True`
- [ ] Verify WhisperSync starts and detects GPU in system tray
- [ ] Verify meeting recording and dictation work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)