### PR TITLE
fix: cache GPU name from worker to prevent tray menu CUDA crash

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2277,13 +2277,9 @@ class WhisperSync:
 
         # Device (compute) selection
         current_device = self.cfg.get("device", "auto")
-        # Build per-option labels with GPU name for auto
+        # Build per-option labels with GPU name from worker (avoids torch import in main process)
         device_options = []
-        try:
-            from .transcribe import get_gpu_name
-            gpu_name = get_gpu_name()
-        except Exception:
-            gpu_name = None
+        gpu_name = self.worker.gpu_name if self.worker else None
         auto_suffix = f"\t{gpu_name}" if gpu_name else "\tCPU -- no GPU detected"
         device_options.append(("auto", f"Auto{auto_suffix}"))
         gpu_suffix = f"\t{gpu_name}" if gpu_name else "\tnot available"
@@ -2939,24 +2935,15 @@ class WhisperSync:
     def _get_device_label(self) -> str:
         """Return display string for the active resolved device."""
         device_setting = self.cfg.get("device", "auto")
+        gpu = self.worker.gpu_name if self.worker else None
         if device_setting == "cpu":
             return "CPU"
         elif device_setting in ("gpu", "cuda"):
-            try:
-                from .transcribe import get_gpu_name
-                gpu_name = get_gpu_name()
-                return gpu_name if gpu_name else "GPU"
-            except Exception:
-                return "GPU"
+            return gpu if gpu else "GPU"
         else:  # auto
-            try:
-                from .transcribe import get_gpu_name
-                gpu_name = get_gpu_name()
-                if gpu_name:
-                    return f"Auto ({gpu_name})"
-                return "Auto (CPU)"
-            except Exception:
-                return "Auto"
+            if gpu:
+                return f"Auto ({gpu})"
+            return "Auto (CPU)"
 
     def _toggle_always_available_dictation(self):
         self.cfg["always_available_dictation"] = not self.cfg.get("always_available_dictation", True)

--- a/whisper_sync/worker.py
+++ b/whisper_sync/worker.py
@@ -140,7 +140,13 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
             })
             return
 
-    response_queue.put({"type": "ready"})
+    # Report GPU name so the main process can display it without importing torch
+    from .transcribe import get_gpu_name, _get_device
+    response_queue.put({
+        "type": "ready",
+        "gpu_name": get_gpu_name(),
+        "device": _get_device(),
+    })
 
     def _check_priority():
         """Check for priority requests. Returns True if shutdown requested."""

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -48,6 +48,8 @@ class TranscriptionWorker:
         self._ready = False
         self._request_counter = 0
         self._lock = threading.Lock()
+        self.gpu_name: str | None = None
+        self.device: str | None = None
 
     def _next_id(self) -> int:
         self._request_counter += 1
@@ -78,6 +80,8 @@ class TranscriptionWorker:
                 msg = self._response_q.get(timeout=1.0)
                 if msg.get("type") == "ready":
                     self._ready = True
+                    self.gpu_name = msg.get("gpu_name")
+                    self.device = msg.get("device")
                     return True
                 if msg.get("type") == "error":
                     logger.error(f"Worker startup error: {msg.get('message')}")
@@ -219,6 +223,8 @@ class TranscriptionWorker:
                 # Handle "ready" messages that arrive while waiting for a response
                 if msg.get("type") == "ready":
                     self._ready = True
+                    self.gpu_name = msg.get("gpu_name")
+                    self.device = msg.get("device")
                 # Stale message from a previous request — discard
             except queue.Empty:
                 continue


### PR DESCRIPTION
## Summary

- `get_gpu_name()` calls `torch.cuda` from the pystray menu thread, causing repeated Windows access violations (`0x8001010e`)
- These are OS-level structured exceptions that bypass Python's `try/except`, so `get_gpu_name()` returns `None`
- The menu displays "CPU - no GPU detected" even though the worker subprocess detects and uses CUDA correctly
- Every menu rebuild triggers the crash, creating a storm of access violations in the log

**Fix:** The worker subprocess already initializes CUDA safely. It now reports `gpu_name` and `device` in its `"ready"` message. The worker manager caches these values, and all menu/label code reads from the cache instead of importing torch in the main process.

**Files changed:**
- `worker.py` - include `gpu_name` and `device` in ready message
- `worker_manager.py` - cache `gpu_name` and `device` from ready message
- `__main__.py` - replace all `get_gpu_name()` calls with `self.worker.gpu_name`

## Test plan

- [ ] Start WhisperSync, verify tray menu shows GPU name (not "no GPU detected")
- [ ] Verify Device submenu shows GPU name for Auto and GPU options
- [ ] Verify no "access violation" entries in log related to `get_gpu_name`
- [ ] Verify dictation and meeting recording still work on CUDA

🤖 Generated with [Claude Code](https://claude.com/claude-code)