### PR TITLE
feat: reliability instrumentation + silent-death forensics

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,33 @@ See the `.claude/rules/` directory for transcription workflow conventions used w
 
 Logs: `whisper_sync/logs/app/whisper-sync-YYYY-MM-DD.log`
 
+### Reading the log
+
+Each run emits a startup banner with PID, Python version, OS, and git SHA:
+
+```
+=== WhisperSync starting === pid=12840 python=3.13.0 os=Windows-11-10.0.26200 git=a1b2c3d
+```
+
+Every clean exit (tray quit, restart, SIGTERM, uncaught exception) emits a matching exit banner with a reason:
+
+```
+=== WhisperSync exiting === reason=user_quit
+=== WhisperSync exiting === reason=exception type=RuntimeError
+```
+
+**Missing exit banner** between two startups = silent native crash. Check the Windows Application Event Log:
+
+```powershell
+Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='Application Error'; StartTime=(Get-Date).AddHours(-1)} | Format-List Message
+```
+
+The faulting module name identifies the culprit (e.g. `tcl86t.dll` = Tk GUI thread, `torch_cuda.dll` = CUDA DLL load). WhisperSync also scans the Event Log on startup and logs any recent crashes it finds with the faulting module highlighted.
+
+A `heartbeat` DEBUG line fires every 60 seconds; the last heartbeat before a silent death pins down time-of-death within a minute.
+
+Meeting post-processing logs each step start/end at INFO (`step start: transcribe job=...`, `step done: transcribe job=... elapsed=12.3s`) so a crash mid-step reveals which step was active.
+
 ---
 
 ## Updating

--- a/build-dist.ps1
+++ b/build-dist.ps1
@@ -40,6 +40,8 @@ $pyFiles = @(
     "dictation_log.py",
     "streaming_wav.py",
     "crash_diagnostics.py",
+    "lifecycle.py",
+    "heartbeat.py",
     "watchdog.py",
     "worker.py",
     "worker_manager.py",

--- a/tests/test_crash_diagnostics.py
+++ b/tests/test_crash_diagnostics.py
@@ -1,0 +1,27 @@
+"""Tests for whisper_sync.crash_diagnostics helpers."""
+
+import unittest
+
+
+class ExtractFaultingModuleTests(unittest.TestCase):
+    def test_extracts_tcl_module(self):
+        from whisper_sync.crash_diagnostics import _extract_faulting_module
+        msg = (
+            "Faulting application name: python.exe, version: 3.13.0.1013 "
+            "| Faulting module name: tcl86t.dll, version: 8.6.13.0 "
+            "| Exception code: 0xc0000005"
+        )
+        self.assertEqual(_extract_faulting_module(msg), "tcl86t.dll")
+
+    def test_extracts_torch_module(self):
+        from whisper_sync.crash_diagnostics import _extract_faulting_module
+        msg = "... Faulting module name: torch_cuda.dll ..."
+        self.assertEqual(_extract_faulting_module(msg), "torch_cuda.dll")
+
+    def test_returns_none_when_absent(self):
+        from whisper_sync.crash_diagnostics import _extract_faulting_module
+        self.assertIsNone(_extract_faulting_module("no module info here"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -55,6 +55,29 @@ class HeartbeatTests(unittest.TestCase):
         output = self.stream.getvalue()
         self.assertIn("uptime=", output)
 
+    def test_uptime_computed_even_when_started_at_is_zero(self):
+        # Regression for review #5: a 0.0 value for _started_at must not
+        # be treated as falsey (which `or` would do) and force uptime
+        # to collapse to ~0 forever.
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        # Overwrite after start() so the worker thread sees 0.0
+        hb._started_at = 0.0
+        time.sleep(0.12)
+        hb.stop(timeout=0.5)
+        import re
+        matches = re.findall(r"uptime=([\d.]+)s", self.stream.getvalue())
+        self.assertTrue(matches, "no heartbeat uptime lines captured")
+        # With _started_at=0.0 and monotonic typically >>0, uptime should
+        # be a large positive number. If `or` were still in place, the
+        # fallback would use time.monotonic() and uptime would collapse
+        # to ~0s each tick. With `is None`, it stays anchored at 0.
+        self.assertGreater(
+            float(matches[-1]), 1.0,
+            "uptime collapsed to ~0s — the `or` fallback is back",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,60 @@
+"""Tests for whisper_sync.heartbeat."""
+
+import io
+import logging
+import time
+import unittest
+
+
+class HeartbeatTests(unittest.TestCase):
+    def setUp(self):
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self.logger = logging.getLogger(f"test_heartbeat.{self.id()}")
+        self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_heartbeat_emits_lines_at_interval(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        try:
+            time.sleep(0.18)
+        finally:
+            hb.stop(timeout=0.5)
+        lines = [ln for ln in self.stream.getvalue().splitlines() if "heartbeat" in ln]
+        # Expect at least 2 heartbeats in ~180ms with 50ms interval
+        self.assertGreaterEqual(len(lines), 2)
+
+    def test_heartbeat_stops_cleanly(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        time.sleep(0.08)
+        hb.stop(timeout=0.5)
+        # After stop, no more heartbeats should fire
+        baseline = self.stream.getvalue().count("heartbeat")
+        time.sleep(0.15)
+        self.assertEqual(self.stream.getvalue().count("heartbeat"), baseline)
+
+    def test_start_twice_is_safe(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        hb.start()  # second start must not raise or leak a second thread
+        hb.stop(timeout=0.5)
+
+    def test_heartbeat_line_has_uptime(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        time.sleep(0.1)
+        hb.stop(timeout=0.5)
+        output = self.stream.getvalue()
+        self.assertIn("uptime=", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,90 @@
+"""Tests for whisper_sync.lifecycle."""
+
+import io
+import logging
+import unittest
+
+
+class RecordExitReasonTests(unittest.TestCase):
+    def setUp(self):
+        from whisper_sync import lifecycle
+        lifecycle._reset_for_tests()
+
+    def test_default_reason_is_unknown(self):
+        from whisper_sync import lifecycle
+        reason, extra = lifecycle.get_exit_reason()
+        self.assertEqual(reason, "unknown")
+        self.assertEqual(extra, {})
+
+    def test_recording_reason_sets_state(self):
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("user_quit", {"menu": "tray"})
+        reason, extra = lifecycle.get_exit_reason()
+        self.assertEqual(reason, "user_quit")
+        self.assertEqual(extra, {"menu": "tray"})
+
+    def test_first_reason_wins(self):
+        # Once set, later calls should not overwrite the first recorded reason
+        # (prevents late-firing atexit callbacks from masking the real cause).
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("crash_worker", {"step": "transcribe"})
+        lifecycle.record_exit_reason("atexit")
+        reason, extra = lifecycle.get_exit_reason()
+        self.assertEqual(reason, "crash_worker")
+        self.assertEqual(extra, {"step": "transcribe"})
+
+
+class LogExitBannerTests(unittest.TestCase):
+    def setUp(self):
+        from whisper_sync import lifecycle
+        lifecycle._reset_for_tests()
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self.logger = logging.getLogger("test_lifecycle_exit")
+        self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_exit_banner_uses_recorded_reason(self):
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("user_quit", {"menu": "tray"})
+        lifecycle.log_exit_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("WhisperSync exiting", output)
+        self.assertIn("reason=user_quit", output)
+
+    def test_exit_banner_default_reason(self):
+        from whisper_sync import lifecycle
+        lifecycle.log_exit_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("reason=unknown", output)
+
+
+class StartupBannerTests(unittest.TestCase):
+    def setUp(self):
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self.logger = logging.getLogger("test_lifecycle_startup")
+        self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_startup_banner_includes_pid_and_python(self):
+        from whisper_sync import lifecycle
+        lifecycle.log_startup_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("pid=", output)
+        self.assertIn("python=", output)
+
+    def test_startup_banner_includes_git_sha_when_available(self):
+        # Banner should at least attempt a git SHA; missing is OK (returns 'unknown')
+        from whisper_sync import lifecycle
+        lifecycle.log_startup_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("git=", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meeting_job.py
+++ b/tests/test_meeting_job.py
@@ -1,0 +1,71 @@
+"""Tests for whisper_sync.meeting_job.MeetingJob.execute_next_step.
+
+Only the step-driver behavior is exercised here. The actual step
+implementations touch the worker subprocess / filesystem / state manager
+and are out of scope.
+"""
+
+import unittest
+from pathlib import Path
+
+
+class _StubApp:
+    """Minimal stand-in for the WhisperSync application object."""
+
+
+def _make_job(steps):
+    from whisper_sync.meeting_job import MeetingJob
+
+    job = MeetingJob(
+        app=_StubApp(),
+        wav_path=Path("/tmp/x.wav"),
+        meeting_dir=Path("/tmp/x"),
+        name="unit-test",
+        summarize=False,
+        date_time_str="0101_0000",
+        week_dir="01-w1",
+        folder_name="0101_0000_unit-test",
+    )
+    # Replace real steps with cheap callables so we can exercise the driver
+    # without touching the worker/filesystem.
+    job._steps = list(steps)
+    return job
+
+
+class ExecuteNextStepTests(unittest.TestCase):
+    def test_successful_step_advances_index(self):
+        calls = []
+        job = _make_job([lambda: calls.append("a"), lambda: calls.append("b")])
+        self.assertEqual(job._current_step, 0)
+        job.execute_next_step()
+        self.assertEqual(job._current_step, 1)
+        job.execute_next_step()
+        self.assertEqual(job._current_step, 2)
+        self.assertTrue(job.is_complete)
+
+    def test_failed_step_does_not_advance_index(self):
+        # Regression for review #2: the step index must not be 'consumed'
+        # when a step raises — otherwise a retry/inspection would think
+        # the step completed.
+        def _boom():
+            raise RuntimeError("kaboom")
+        job = _make_job([_boom, lambda: None])
+        self.assertEqual(job._current_step, 0)
+        with self.assertRaises(RuntimeError):
+            job.execute_next_step()
+        self.assertEqual(
+            job._current_step, 0,
+            "failed step should leave _current_step unchanged",
+        )
+
+    def test_returns_true_when_more_steps_remain(self):
+        job = _make_job([lambda: None, lambda: None])
+        self.assertTrue(job.execute_next_step())
+
+    def test_returns_false_when_complete(self):
+        job = _make_job([lambda: None])
+        self.assertFalse(job.execute_next_step())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,33 @@
+"""Tests for whisper_sync.notifications.
+
+Focused on the toast registry. ``meeting_completed`` toasts are fired
+directly from ``MeetingJob.step_notify`` (which uses an explicit body
+and attaches an Open Folder button). The state-driven
+``ToastListener`` previously also had a template entry, which fired on
+the ``MEETING_COMPLETED`` state event without the ``{words}``/``{speakers}``
+keys and produced ``KeyError`` noise at DEBUG. The registry entry is
+the source of that noise, so it is removed.
+"""
+
+import unittest
+
+
+class ToastRegistryTests(unittest.TestCase):
+    def test_meeting_completed_not_in_registry(self):
+        from whisper_sync.notifications import TOAST_REGISTRY
+        self.assertNotIn(
+            "meeting_completed",
+            TOAST_REGISTRY,
+            "meeting_completed toast is owned by MeetingJob.step_notify; "
+            "the template path was misfiring and must be absent.",
+        )
+
+    def test_error_template_still_present(self):
+        # Guardrail: ensure the trim didn't accidentally drop other entries.
+        from whisper_sync.notifications import TOAST_REGISTRY
+        self.assertIn("error", TOAST_REGISTRY)
+        self.assertIn("dictation_completed", TOAST_REGISTRY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1226,9 +1226,22 @@ class WhisperSync:
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _abort)
             root.mainloop()
-            event.set()
 
-        t = threading.Thread(target=_show_dialog, daemon=True)
+        def _show_dialog_guarded():
+            # Guarantees event.set() + a well-defined outcome even if
+            # _show_dialog raises before root.mainloop() returns. Without
+            # this, _save_and_enqueue's event.wait() blocks forever and the
+            # tray stays stuck in mode="saving" with the recording neither
+            # saved nor discarded.
+            try:
+                _show_dialog()
+            except Exception:
+                logger.exception("dialog crashed: _ask_meeting_name")
+                result[0] = self._ABORT
+            finally:
+                event.set()
+
+        t = threading.Thread(target=_show_dialog_guarded, daemon=True)
         t.start()
         # Previously this used a 60s timeout that silently returned _ABORT
         # while the dialog was still on screen — discarding the recording

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -52,6 +52,14 @@ from . import feature_log
 from . import weekly_stats
 from .streaming_wav import fix_orphan
 from .crash_diagnostics import install_excepthook, check_previous_crash
+from . import lifecycle
+from .heartbeat import Heartbeat
+
+# Module-level reference to the faulthandler log file. Without holding this,
+# the FileIO object is garbage-collected, its fd closes, and any later native
+# crash dumps vanish — which is exactly what happened historically with silent
+# deaths that left no trace.
+_FAULTHANDLER_FILE = None
 from .flatten import flatten as flatten_transcript
 from .notifications import notify, ToastListener
 from .state_manager import (
@@ -1106,6 +1114,9 @@ class WhisperSync:
             (str, True, str|None): user clicked Save & Summarize (name, summarize, diarize_method)
             (str, False, str|None): user clicked Save (name, summarize, diarize_method)
         """
+        import time as _time
+        dialog_started = _time.monotonic()
+        logger.info("dialog open: _ask_meeting_name")
         result = [self._ABORT]
         event = threading.Event()
 
@@ -1219,7 +1230,29 @@ class WhisperSync:
 
         t = threading.Thread(target=_show_dialog, daemon=True)
         t.start()
-        event.wait(timeout=60)
+        # Previously this used a 60s timeout that silently returned _ABORT
+        # while the dialog was still on screen — discarding the recording
+        # while the user thought they were still naming it. The dialog
+        # itself has no auto-close timer, so we wait as long as it's open.
+        event.wait()
+
+        # Report dialog outcome with the actual returned value so forensic
+        # logs can distinguish ABORT vs save vs timeout vs garbage.
+        elapsed = _time.monotonic() - dialog_started
+        outcome = result[0]
+        if outcome is self._ABORT:
+            logger.info("dialog close: _ask_meeting_name outcome=abort elapsed=%.1fs", elapsed)
+        elif isinstance(outcome, tuple) and len(outcome) == 3:
+            name, summarize, method = outcome
+            logger.info(
+                "dialog close: _ask_meeting_name outcome=save name=%r summarize=%s method=%s elapsed=%.1fs",
+                name or "", summarize, method, elapsed,
+            )
+        else:
+            logger.warning(
+                "dialog close: _ask_meeting_name outcome=unexpected value=%r elapsed=%.1fs",
+                outcome, elapsed,
+            )
 
         return result[0]
 
@@ -3217,6 +3250,7 @@ class WhisperSync:
         def _do_restart():
             import subprocess
             import time
+            lifecycle.record_exit_reason("user_restart")
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
             # Spawn new process first so it starts loading immediately
@@ -3230,6 +3264,7 @@ class WhisperSync:
             if self.tray:
                 self.tray.stop()
             time.sleep(0.2)
+            lifecycle.log_exit_banner(logger)
             os._exit(0)
 
         threading.Thread(target=_do_restart, daemon=True).start()
@@ -3238,6 +3273,7 @@ class WhisperSync:
         """Quit WhisperSync. Deferred like _restart for the same reason."""
         def _do_quit():
             import time
+            lifecycle.record_exit_reason("user_quit")
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
             if self.tray:
@@ -3445,19 +3481,31 @@ class WhisperSync:
 
 
 def main():
-    # Enable faulthandler FIRST so native segfaults get logged to the log file
+    global _FAULTHANDLER_FILE
+    # Enable faulthandler FIRST so native segfaults get logged to the log file.
+    # Keep a module-level reference to the file; otherwise CPython can GC the
+    # FileIO object, close its fd, and silently drop later crash dumps.
     try:
-        faulthandler.enable(file=open(get_log_path(), "a"), all_threads=True)
+        _FAULTHANDLER_FILE = open(get_log_path(), "a", buffering=1, encoding="utf-8")
+        faulthandler.enable(file=_FAULTHANDLER_FILE, all_threads=True)
     except Exception:
         faulthandler.enable()  # fallback to stderr
+
+    heartbeat = Heartbeat(logger, interval=60.0)
     try:
-        logger.info("=== WhisperSync starting ===")
+        lifecycle.log_startup_banner(logger)
+        lifecycle.install(logger)
         install_excepthook(logger)
         check_previous_crash(logger)
+        heartbeat.start()
         app = WhisperSync()
         app.run()
+    except SystemExit:
+        lifecycle.record_exit_reason("system_exit")
+        raise
     except Exception:
         import traceback
+        lifecycle.record_exit_reason("exception", {"type": type(sys.exc_info()[1]).__name__})
         logger.critical(f"FATAL CRASH:\n{traceback.format_exc()}")
         # Last-resort hook cleanup — prevents stuck Ctrl key on crash
         try:
@@ -3465,6 +3513,8 @@ def main():
         except Exception:
             pass
         raise
+    finally:
+        heartbeat.stop(timeout=1.0)
 
 
 if __name__ == "__main__":

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -247,16 +247,33 @@ class AudioRecorder:
             self._speaker_writer = None
 
     def discard_streaming(self):
-        """Close writers and delete the temp files."""
+        """Close writers and delete the temp files.
+
+        Logs each discarded channel (path + size) so the forensic record
+        shows exactly which recording was dropped when the user aborts
+        the meeting-name dialog or the app decides to discard.
+        """
+        import logging as _logging
+        _log = _logging.getLogger("whisper_sync.capture")
         from .streaming_wav import cleanup_temp_files
         parent = None
-        for w in (self._mic_writer, self._speaker_writer):
-            if w is not None:
-                parent = w.path.parent
-                try:
-                    w.close()
-                except Exception:
-                    pass
+        for label, w in (("mic", self._mic_writer), ("speaker", self._speaker_writer)):
+            if w is None:
+                continue
+            parent = w.path.parent
+            size = 0
+            try:
+                size = w.path.stat().st_size if w.path.exists() else 0
+            except OSError:
+                pass
+            _log.info(
+                "discard_streaming: channel=%s path=%s size=%d",
+                label, w.path, size,
+            )
+            try:
+                w.close()
+            except Exception:
+                _log.debug("discard_streaming: close failed for %s", label, exc_info=True)
         self._mic_writer = None
         self._speaker_writer = None
         if parent is not None:

--- a/whisper_sync/crash_diagnostics.py
+++ b/whisper_sync/crash_diagnostics.py
@@ -52,9 +52,13 @@ def install_excepthook(log: logging.Logger) -> None:
 def check_previous_crash(log: logging.Logger) -> str | None:
     """Query Windows Event Log for recent python.exe crashes.
 
-    Looks for 'Application Error' events from the last 24 hours
-    matching our venv's python.exe path. Returns a summary string
-    if found, or None.
+    Looks for 'Application Error' events from the last 24 hours matching
+    our venv's python.exe path. Now pulls a larger slice of each event
+    message (the first ~12 lines) so the faulting module name and offset
+    are surfaced — without that detail we can't tell a Tcl/Tk crash from
+    a torch-DLL crash from a Python runtime crash.
+
+    Returns the summary string if any events were found, else None.
     """
     python_exe = sys.executable.replace("\\", "\\\\")
 
@@ -66,8 +70,11 @@ def check_previous_crash(log: logging.Logger) -> str | None:
         "} -ErrorAction SilentlyContinue "
         f"| Where-Object {{ $_.Message -like '*{python_exe}*' }} "
         "| Select-Object -First 3 "
-        "| ForEach-Object { $_.TimeCreated.ToString('HH:mm:ss') + ' | ' + "
-        "($_.Message -split \"`n\" | Select-Object -First 2) -join ' ' }"
+        "| ForEach-Object { "
+        "  $ts = $_.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss'); "
+        "  $msg = ($_.Message -split \"`n\" | Select-Object -First 12) -join ' | '; "
+        "  \"$ts -- $msg\" "
+        "}"
     )
 
     try:
@@ -79,9 +86,26 @@ def check_previous_crash(log: logging.Logger) -> str | None:
         )
         output = result.stdout.strip()
         if output:
-            log.warning(f"Previous crash detected in Windows Event Log:\n{output}")
+            log.warning("Previous crash(es) in Windows Event Log:\n%s", output)
+            faulting_module = _extract_faulting_module(output)
+            if faulting_module:
+                log.warning(
+                    "Previous crash faulting module: %s (common culprits: "
+                    "tcl86t.dll/tk86t.dll=Tk GUI thread issue; "
+                    "torch_*.dll=CUDA/DLL load; python3*.dll=Python runtime)",
+                    faulting_module,
+                )
             return output
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         log.debug(f"Event Log check skipped: {e}")
 
+    return None
+
+
+def _extract_faulting_module(message: str) -> str | None:
+    """Pull 'Faulting module name: X.dll' out of an Application Error message."""
+    import re
+    match = re.search(r"Faulting module name:\s*([^\s,|]+)", message, re.IGNORECASE)
+    if match:
+        return match.group(1)
     return None

--- a/whisper_sync/heartbeat.py
+++ b/whisper_sync/heartbeat.py
@@ -1,0 +1,52 @@
+"""Periodic heartbeat log line.
+
+A background daemon thread writes a short DEBUG line every ``interval``
+seconds. The purpose is forensic: if the app dies silently, the gap between
+the last heartbeat and the next restart banner pins down the time-of-death.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+
+
+class Heartbeat:
+    """Periodic heartbeat emitter. Start/stop are idempotent."""
+
+    def __init__(self, logger: logging.Logger, interval: float = 60.0):
+        self._logger = logger
+        self._interval = float(interval)
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_at: float | None = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._started_at = time.monotonic()
+        self._thread = threading.Thread(
+            target=self._run, name="whisper-sync-heartbeat", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float | None = 2.0) -> None:
+        self._stop.set()
+        t = self._thread
+        if t is not None:
+            t.join(timeout=timeout)
+        self._thread = None
+
+    def _run(self) -> None:
+        pid = os.getpid()
+        while not self._stop.wait(self._interval):
+            uptime = time.monotonic() - (self._started_at or time.monotonic())
+            self._logger.debug(
+                "heartbeat pid=%d uptime=%.1fs threads=%d",
+                pid,
+                uptime,
+                threading.active_count(),
+            )

--- a/whisper_sync/heartbeat.py
+++ b/whisper_sync/heartbeat.py
@@ -43,7 +43,8 @@ class Heartbeat:
     def _run(self) -> None:
         pid = os.getpid()
         while not self._stop.wait(self._interval):
-            uptime = time.monotonic() - (self._started_at or time.monotonic())
+            start = self._started_at if self._started_at is not None else time.monotonic()
+            uptime = time.monotonic() - start
             self._logger.debug(
                 "heartbeat pid=%d uptime=%.1fs threads=%d",
                 pid,

--- a/whisper_sync/lifecycle.py
+++ b/whisper_sync/lifecycle.py
@@ -129,9 +129,11 @@ def install(logger: logging.Logger) -> None:
             name = signal.Signals(signum).name
         except ValueError:
             name = str(signum)
+        # Only record the reason here. The atexit hook emits the single
+        # exit banner during normal interpreter shutdown — doing logging
+        # inside a signal handler is both risky (async-signal-safety) and
+        # duplicates the atexit banner once sys.exit() runs.
         record_exit_reason("signal", {"signal": name})
-        log_exit_banner(logger)
-        # Restore default handler and re-raise so the OS reports the signal.
         try:
             signal.signal(signum, signal.SIG_DFL)
         except Exception:

--- a/whisper_sync/lifecycle.py
+++ b/whisper_sync/lifecycle.py
@@ -1,0 +1,150 @@
+"""Process lifecycle logging.
+
+Every process start and end should produce an identifiable log line so that
+silent deaths can be distinguished from clean quits. This module owns the
+startup/exit banners and the exit-reason state.
+
+Design:
+    * The first call to ``record_exit_reason`` wins. Later calls are ignored
+      so that a late-firing atexit callback can't mask the real cause
+      (e.g. an unhandled exception that already recorded ``exception``).
+    * ``install`` wires up atexit + signal handlers. On any exit path we
+      emit a single ``=== WhisperSync exiting (reason=..., ...) ===`` line
+      so grep-for-gaps analysis can tell crashes from clean exits.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import platform
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+_state_lock = threading.Lock()
+_exit_reason: str = "unknown"
+_exit_extra: dict = {}
+_installed: bool = False
+
+
+def _reset_for_tests() -> None:
+    """Reset module state. Test-only."""
+    global _exit_reason, _exit_extra, _installed
+    with _state_lock:
+        _exit_reason = "unknown"
+        _exit_extra = {}
+        _installed = False
+
+
+def record_exit_reason(reason: str, extra: dict | None = None) -> None:
+    """Record why the process is about to exit. First caller wins."""
+    global _exit_reason, _exit_extra
+    with _state_lock:
+        if _exit_reason != "unknown":
+            return
+        _exit_reason = reason
+        _exit_extra = dict(extra) if extra else {}
+
+
+def get_exit_reason() -> tuple[str, dict]:
+    """Return the currently-recorded exit reason + extras."""
+    with _state_lock:
+        return _exit_reason, dict(_exit_extra)
+
+
+def _git_sha() -> str:
+    """Best-effort short git SHA for this checkout. 'unknown' on failure."""
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        sha = result.stdout.strip()
+        if sha:
+            return sha
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return "unknown"
+
+
+def _format_extra(extra: dict) -> str:
+    """Render extras as ``k1=v1 k2=v2`` for grep-friendly logs."""
+    if not extra:
+        return ""
+    return " " + " ".join(f"{k}={v}" for k, v in extra.items())
+
+
+def log_startup_banner(logger: logging.Logger) -> None:
+    """Emit the startup banner with PID, Python/OS/git identifiers."""
+    logger.info(
+        "=== WhisperSync starting === pid=%d python=%s os=%s git=%s",
+        os.getpid(),
+        platform.python_version(),
+        platform.platform(terse=True),
+        _git_sha(),
+    )
+
+
+def log_exit_banner(logger: logging.Logger) -> None:
+    """Emit the exit banner using the currently-recorded reason."""
+    reason, extra = get_exit_reason()
+    logger.info(
+        "=== WhisperSync exiting === reason=%s%s",
+        reason,
+        _format_extra(extra),
+    )
+    for handler in logger.handlers:
+        try:
+            handler.flush()
+        except Exception:
+            pass
+
+
+def install(logger: logging.Logger) -> None:
+    """Register atexit + signal handlers that emit the exit banner.
+
+    Safe to call multiple times; the second call is a no-op.
+    """
+    global _installed
+    with _state_lock:
+        if _installed:
+            return
+        _installed = True
+
+    def _atexit():
+        record_exit_reason("atexit")
+        log_exit_banner(logger)
+
+    atexit.register(_atexit)
+
+    def _signal_handler(signum, _frame):
+        try:
+            name = signal.Signals(signum).name
+        except ValueError:
+            name = str(signum)
+        record_exit_reason("signal", {"signal": name})
+        log_exit_banner(logger)
+        # Restore default handler and re-raise so the OS reports the signal.
+        try:
+            signal.signal(signum, signal.SIG_DFL)
+        except Exception:
+            pass
+        sys.exit(128 + signum)
+
+    # SIGTERM + SIGBREAK (Windows) + SIGINT (Ctrl+C) are the common paths.
+    for sig_name in ("SIGTERM", "SIGBREAK", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, _signal_handler)
+        except (ValueError, OSError):
+            # Some signals are not settable on every platform/thread.
+            pass

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -82,7 +82,9 @@ class MeetingJob:
         """Execute the next step. Returns True if more steps remain.
 
         Logs the step name at INFO before and after execution so a silent
-        death mid-step can be pinpointed from the log.
+        death mid-step can be pinpointed from the log. The step index is
+        advanced only on successful completion so a failed step is not
+        silently 'consumed' if any caller inspects/retries the job.
         """
         import time as _time
         if self.is_complete:
@@ -101,14 +103,12 @@ class MeetingJob:
                 step_name, job_label, elapsed,
             )
             raise
-        else:
-            elapsed = _time.monotonic() - started
-            logger.info(
-                "step done: %s job=%s elapsed=%.2fs",
-                step_name, job_label, elapsed,
-            )
-        finally:
-            self._current_step += 1
+        elapsed = _time.monotonic() - started
+        logger.info(
+            "step done: %s job=%s elapsed=%.2fs",
+            step_name, job_label, elapsed,
+        )
+        self._current_step += 1
         return not self.is_complete
 
     # ------------------------------------------------------------------
@@ -320,10 +320,24 @@ class MeetingJob:
             logger.warning("Index rebuild failed (non-fatal): %s", e)
 
     def step_notify(self):
-        """Show toast notification with meeting stats and Open Folder button."""
-        from .notifications import notify
+        """Show toast notification with meeting stats and Open Folder button.
+
+        Honors the user's ``toast_events`` config (tray menu toggle). This
+        toast is dispatched directly rather than through the TOAST_REGISTRY
+        template so it can attach an Open Folder button, but it still must
+        respect the configurable toggle — otherwise disabling 'Meeting
+        Complete' in the tray menu has no effect.
+        """
+        from .notifications import notify, DEFAULT_TOAST_EVENTS
 
         try:
+            cfg = getattr(self.app, "cfg", {}) or {}
+            enabled = cfg.get("toast_events", DEFAULT_TOAST_EVENTS)
+            if not isinstance(enabled, (list, tuple, set)):
+                enabled = DEFAULT_TOAST_EVENTS
+            if "meeting_completed" not in enabled:
+                return
+
             words = self.transcript_result.get("word_count", 0) if self.transcript_result else 0
             speakers = self.transcript_result.get("num_speakers", 0) if self.transcript_result else 0
             body = f"{words} words, {speakers} speakers"

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -79,12 +79,36 @@ class MeetingJob:
         return self._steps[self._current_step].__name__
 
     def execute_next_step(self):
-        """Execute the next step. Returns True if more steps remain."""
+        """Execute the next step. Returns True if more steps remain.
+
+        Logs the step name at INFO before and after execution so a silent
+        death mid-step can be pinpointed from the log.
+        """
+        import time as _time
         if self.is_complete:
             return False
         step = self._steps[self._current_step]
-        step()
-        self._current_step += 1
+        step_name = step.__name__
+        job_label = self.name or "meeting"
+        logger.info("step start: %s job=%s", step_name, job_label)
+        started = _time.monotonic()
+        try:
+            step()
+        except Exception:
+            elapsed = _time.monotonic() - started
+            logger.error(
+                "step failed: %s job=%s elapsed=%.2fs",
+                step_name, job_label, elapsed,
+            )
+            raise
+        else:
+            elapsed = _time.monotonic() - started
+            logger.info(
+                "step done: %s job=%s elapsed=%.2fs",
+                step_name, job_label, elapsed,
+            )
+        finally:
+            self._current_step += 1
         return not self.is_complete
 
     # ------------------------------------------------------------------

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -229,10 +229,11 @@ def has_input_text_box():
 # Toast templates keyed by event type.  Only events listed here AND enabled
 # in config["toast_events"] will trigger a toast.
 TOAST_REGISTRY: dict[str, dict] = {
-    "meeting_completed": {
-        "title": "Meeting transcribed",
-        "body": "{words} words, {speakers} speakers",
-    },
+    # NOTE: meeting_completed toasts are fired directly from
+    # MeetingJob.step_notify so the toast can attach an "Open Folder"
+    # button. A template entry here would double-fire and the
+    # MEETING_COMPLETED state event does not carry words/speakers,
+    # so it produced a DEBUG-level KeyError every meeting.
     "dictation_completed": {
         "title": "Dictation complete",
         "body": "",


### PR DESCRIPTION
## Summary

Whisper-sync has been dying silently after meeting recordings. The log shows multiple `=== WhisperSync starting ===` banners per day with no ERROR/CRITICAL between them, and `Recording discarded` events followed by restarts. Root-cause analysis was blocked because:

1. `faulthandler.enable(file=open(...))` handed faulthandler an unreferenced FileIO — GC could close the fd and drop later native crash dumps.
2. No exit-reason logging, so clean quits were indistinguishable from silent deaths.
3. No step-level or dialog-level logging, so mid-pipeline crashes left no breadcrumbs.

This PR is **instrumentation-first** — it does not try to fix the crash itself. One more day of real logs with the new instrumentation should name the faulting module and pinpoint the failing step.

## Changes

### New modules
- **`whisper_sync/lifecycle.py`** — first-caller-wins exit-reason state; `log_startup_banner` (PID, Python version, OS, git SHA); `log_exit_banner` with reason; `install()` wires `atexit` + SIGTERM/SIGBREAK/SIGINT handlers so every exit path produces an identifiable log line.
- **`whisper_sync/heartbeat.py`** — 60s DEBUG heartbeat (`heartbeat pid=... uptime=... threads=...`). Gap between last heartbeat and next startup = time-of-death, ±60s.

### Wired into `__main__.main()`
- Module-level `_FAULTHANDLER_FILE` reference with `buffering=1` so crash dumps survive GC.
- `lifecycle.log_startup_banner` / `lifecycle.install` / `Heartbeat.start` / `heartbeat.stop` in `finally`.
- `SystemExit` / `Exception` now record structured exit reasons before re-raising.
- `quit` and `_restart` record `user_quit` / `user_restart` so clean exits stop looking like crashes.

### Instrumentation
- `MeetingJob.execute_next_step` — `step start` / `step done` / `step failed` at INFO with elapsed time. Mid-step crashes now reveal the step.
- `__main__._ask_meeting_name` — dialog open/close bookends. Logs the actual returned outcome (abort / save / unexpected).
- `capture.AudioRecorder.discard_streaming` — logs channel / path / size of every discarded recording.
- `crash_diagnostics.check_previous_crash` — pulls 12 lines of each Application Error event; new `_extract_faulting_module` highlights e.g. `tcl86t.dll` vs `torch_cuda.dll` so the culprit is named.

### Bug fixes bundled in
- **B1 — 60s silent-abort removed.** `_ask_meeting_name` used `event.wait(timeout=60)` that returned `_ABORT` while the dialog was still on screen, silently discarding the user's recording. Now waits indefinitely on the dialog's completion event.
- **B3 — `meeting_completed` removed from `TOAST_REGISTRY`.** That toast is fired directly from `MeetingJob.step_notify` with an Open Folder button; the registry template was missing `{words}`/`{speakers}` on the MEETING_COMPLETED state event and KeyErrored every meeting (DEBUG log noise).

### Deferred
- **B2 — Tk mainloop on daemon thread.** Known Windows reliability hazard; refactoring `_ask_meeting_name` onto the main Tk context is a larger change. Held for a follow-up once this PR's logging identifies whether Tk is actually the faulting module.

### Tests
`tests/` directory created (unittest, no pytest dependency). 16 tests covering:
- `lifecycle`: default / first-wins / startup+exit banner content
- `heartbeat`: interval emission / clean stop / idempotent start / uptime line
- `notifications`: `meeting_completed` absent, other templates preserved
- `crash_diagnostics._extract_faulting_module`: tcl / torch / missing cases

All 16 pass.

## How to read the new logs

```
=== WhisperSync starting === pid=12840 python=3.13.0 os=Windows-11-10.0.26200 git=a1b2c3d
...
heartbeat pid=12840 uptime=120.0s threads=7
...
step start: transcribe job=Abhi-sync
step done: transcribe job=Abhi-sync elapsed=12.3s
...
=== WhisperSync exiting === reason=user_quit
```

A missing exit banner between two startups now reliably flags a silent native crash. The startup `check_previous_crash` call will then log the Event Log entry and the faulting module so the next iteration of debugging has something to go on.

## Test plan

- [x] All 16 unit tests pass (`python -m unittest discover tests`)
- [x] Package import smoke-tests cleanly
- [x] `py_compile` check on every modified module
- [ ] Run locally for 24h — confirm startup+exit banners bracket every session, heartbeats appear, and the next silent death (if any) produces Event Log output with a faulting module name

🤖 Generated with [Claude Code](https://claude.com/claude-code)