### PR TITLE
fix: scrollable speaker dialog + simplify follow-ups

### DIFF
--- a/tests/test_faulthandler_install.py
+++ b/tests/test_faulthandler_install.py
@@ -1,0 +1,41 @@
+"""Tests for crash_diagnostics.install_faulthandler helper.
+
+Extracted from __main__.py so worker.py can use the same fix. The key
+property is that the opened file object is retained at module scope so
+it cannot be garbage-collected (which was the historic silent-death bug
+that lost native crash dumps).
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class InstallFaulthandlerTests(unittest.TestCase):
+    def test_returns_a_file_object_that_is_retained(self):
+        from whisper_sync import crash_diagnostics
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "fh.log"
+            f = crash_diagnostics.install_faulthandler(log_path)
+            try:
+                self.assertIsNotNone(f, "should return the opened file")
+                self.assertFalse(f.closed, "file must be open")
+                # The module should keep a strong ref so GC can't close it.
+                self.assertIs(crash_diagnostics._FAULTHANDLER_FILE, f)
+            finally:
+                crash_diagnostics._reset_faulthandler_for_tests()
+
+    def test_returns_none_on_bad_path_and_falls_back(self):
+        from whisper_sync import crash_diagnostics
+        # A path inside a nonexistent parent directory cannot be opened
+        # "a" mode, which forces the fallback branch.
+        bad = Path("/this/path/should/not/exist/fh.log")
+        result = crash_diagnostics.install_faulthandler(bad)
+        try:
+            self.assertIsNone(result)
+        finally:
+            crash_diagnostics._reset_faulthandler_for_tests()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_faulthandler_install.py
+++ b/tests/test_faulthandler_install.py
@@ -27,14 +27,16 @@ class InstallFaulthandlerTests(unittest.TestCase):
 
     def test_returns_none_on_bad_path_and_falls_back(self):
         from whisper_sync import crash_diagnostics
-        # A path inside a nonexistent parent directory cannot be opened
-        # "a" mode, which forces the fallback branch.
-        bad = Path("/this/path/should/not/exist/fh.log")
-        result = crash_diagnostics.install_faulthandler(bad)
-        try:
-            self.assertIsNone(result)
-        finally:
-            crash_diagnostics._reset_faulthandler_for_tests()
+        # A subpath of a temp directory whose intermediate segment does not
+        # exist guarantees open("a") fails regardless of platform or prior
+        # filesystem state.
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "does-not-exist" / "fh.log"
+            result = crash_diagnostics.install_faulthandler(bad)
+            try:
+                self.assertIsNone(result)
+            finally:
+                crash_diagnostics._reset_faulthandler_for_tests()
 
 
 if __name__ == "__main__":

--- a/tests/test_lifecycle_reasons.py
+++ b/tests/test_lifecycle_reasons.py
@@ -1,0 +1,40 @@
+"""Tests for exit-reason constants in whisper_sync.lifecycle.
+
+The lifecycle module is the grep anchor for forensic log analysis. Exit
+reasons scattered as raw strings across call sites drift over time; these
+tests pin the canonical values so greppers and dashboards don't break
+silently.
+"""
+
+import unittest
+
+
+class ExitReasonConstantsTests(unittest.TestCase):
+    def test_all_known_reasons_exported(self):
+        from whisper_sync import lifecycle
+        expected = {
+            "REASON_UNKNOWN": "unknown",
+            "REASON_USER_QUIT": "user_quit",
+            "REASON_USER_RESTART": "user_restart",
+            "REASON_ATEXIT": "atexit",
+            "REASON_SIGNAL": "signal",
+            "REASON_EXCEPTION": "exception",
+            "REASON_SYSTEM_EXIT": "system_exit",
+        }
+        for name, value in expected.items():
+            self.assertTrue(
+                hasattr(lifecycle, name),
+                f"lifecycle.{name} is not exported",
+            )
+            self.assertEqual(getattr(lifecycle, name), value)
+
+    def test_default_get_exit_reason_uses_constant(self):
+        # Sanity: the default sentinel matches the exported constant
+        from whisper_sync import lifecycle
+        lifecycle._reset_for_tests()
+        reason, _ = lifecycle.get_exit_reason()
+        self.assertEqual(reason, lifecycle.REASON_UNKNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifications_helper.py
+++ b/tests/test_notifications_helper.py
@@ -1,0 +1,51 @@
+"""Tests for notifications.is_toast_enabled helper.
+
+Extracted so both the ToastListener and MeetingJob.step_notify can share
+the same config-gate logic rather than each implementing its own
+isinstance-check + membership-check pair.
+"""
+
+import unittest
+
+
+class IsToastEnabledTests(unittest.TestCase):
+    def test_event_in_config_list(self):
+        from whisper_sync.notifications import is_toast_enabled
+        self.assertTrue(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": ["meeting_completed", "error"]})
+        )
+
+    def test_event_absent_from_config(self):
+        from whisper_sync.notifications import is_toast_enabled
+        self.assertFalse(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": ["error"]})
+        )
+
+    def test_missing_config_falls_back_to_defaults(self):
+        from whisper_sync.notifications import is_toast_enabled, DEFAULT_TOAST_EVENTS
+        # Empty cfg => defaults apply; meeting_completed is in defaults
+        self.assertIn("meeting_completed", DEFAULT_TOAST_EVENTS)
+        self.assertTrue(is_toast_enabled("meeting_completed", {}))
+
+    def test_garbage_config_value_falls_back_to_defaults(self):
+        from whisper_sync.notifications import is_toast_enabled
+        # Non-iterable junk should not crash; defaults apply instead
+        self.assertTrue(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": "nonsense"})
+        )
+        self.assertTrue(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": None})
+        )
+
+    def test_none_cfg_tolerated(self):
+        from whisper_sync.notifications import is_toast_enabled
+        # step_notify may pass None/empty cfg defensively
+        self.assertTrue(is_toast_enabled("meeting_completed", None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -51,15 +51,9 @@ from . import dictation_log
 from . import feature_log
 from . import weekly_stats
 from .streaming_wav import fix_orphan
-from .crash_diagnostics import install_excepthook, check_previous_crash
+from .crash_diagnostics import install_excepthook, check_previous_crash, install_faulthandler
 from . import lifecycle
 from .heartbeat import Heartbeat
-
-# Module-level reference to the faulthandler log file. Without holding this,
-# the FileIO object is garbage-collected, its fd closes, and any later native
-# crash dumps vanish — which is exactly what happened historically with silent
-# deaths that left no trace.
-_FAULTHANDLER_FILE = None
 from .flatten import flatten as flatten_transcript
 from .notifications import notify, ToastListener
 from .state_manager import (
@@ -1469,23 +1463,64 @@ class WhisperSync:
             conf_colors = {"high": green, "medium": yellow, "low": red}
 
             num_speakers = len(speaker_map)
-            # Each speaker row ~44px + reasoning line ~22px + padding
             screen_h = root.winfo_screenheight()
             max_h = min(700, int(screen_h * 0.8))
+            # Size to content, capped at max_h. When content exceeds the cap,
+            # the middle scrolls (see _make_scrollable below) and the bottom
+            # button bar remains visible because it is packed with side=BOTTOM
+            # BEFORE the scrollable middle.
             height = min(180 + (num_speakers * 70), max_h)
             root.geometry(f"500x{height}")
+            root.minsize(500, 260)  # guarantee the buttons are always reachable
 
-            # Header
+            # Header — packed FIRST (top)
             header = tk.Frame(root, bg=bg)
-            header.pack(fill="x", padx=24, pady=(14, 0))
+            header.pack(side=tk.TOP, fill="x", padx=24, pady=(14, 0))
             tk.Label(header, text="\U0001f3a4", font=("Segoe UI", 13), bg=bg).pack(side=tk.LEFT)
             tk.Label(header, text="  Identify Speakers", font=("Segoe UI", 11, "bold"),
                      bg=bg, fg=fg).pack(side=tk.LEFT)
 
-            # Speaker rows
+            # Bottom panel: progress + boundary notice + buttons. These are
+            # packed NOW (before the scrollable middle) with side=BOTTOM so
+            # Tk's pack algorithm reserves space for them regardless of how
+            # many speakers are added — the Confirm button never slides off.
+            bottom_panel = tk.Frame(root, bg=bg)
+            bottom_panel.pack(side=tk.BOTTOM, fill="x")
+
+            # Scrollable middle: contains speaker rows + reasoning text.
+            # Tk does not have a native scrollable frame; the idiom is a
+            # Canvas + Scrollbar + inner Frame. The inner frame behaves like
+            # a normal Frame you can pack into.
+            middle = tk.Frame(root, bg=bg)
+            middle.pack(side=tk.TOP, fill="both", expand=True, padx=0, pady=(12, 0))
+            _scroll_canvas = tk.Canvas(middle, bg=bg, highlightthickness=0)
+            _scroll_canvas.pack(side=tk.LEFT, fill="both", expand=True)
+            _scrollbar = tk.Scrollbar(middle, orient="vertical", command=_scroll_canvas.yview)
+            _scrollbar.pack(side=tk.RIGHT, fill="y")
+            _scroll_canvas.configure(yscrollcommand=_scrollbar.set)
+
+            rows_frame = tk.Frame(_scroll_canvas, bg=bg)
+            _rows_window = _scroll_canvas.create_window((0, 0), window=rows_frame, anchor="nw")
+
+            def _on_rows_configure(_event):
+                _scroll_canvas.configure(scrollregion=_scroll_canvas.bbox("all"))
+            rows_frame.bind("<Configure>", _on_rows_configure)
+
+            def _on_canvas_configure(event):
+                # Make the inner frame match the canvas width so content wraps
+                # correctly instead of being clipped horizontally.
+                _scroll_canvas.itemconfigure(_rows_window, width=event.width)
+            _scroll_canvas.bind("<Configure>", _on_canvas_configure)
+
+            def _on_mousewheel(event):
+                # Windows: event.delta is a multiple of 120 per notch.
+                _scroll_canvas.yview_scroll(int(-event.delta / 120), "units")
+            # Bind only when the mouse is over the canvas so we don't steal
+            # wheel events from child dropdowns.
+            _scroll_canvas.bind("<Enter>", lambda _e: _scroll_canvas.bind_all("<MouseWheel>", _on_mousewheel))
+            _scroll_canvas.bind("<Leave>", lambda _e: _scroll_canvas.unbind_all("<MouseWheel>"))
+
             dropdowns = {}
-            rows_frame = tk.Frame(root, bg=bg)
-            rows_frame.pack(fill="x", padx=24, pady=(12, 0))
 
             for spk_id, name in speaker_map.items():
                 row = tk.Frame(rows_frame, bg=card_bg, highlightbackground="#313244", highlightthickness=1)
@@ -1610,8 +1645,9 @@ class WhisperSync:
                     tk.Label(reason_frame, text=f"\u2514 {reason}", font=("Segoe UI", 7, "italic"),
                              bg=bg, fg=fg_dim, anchor="w", wraplength=400).pack(anchor="w")
 
-            # Progress bar (hidden initially)
-            progress_frame = tk.Frame(root, bg=bg)
+            # Progress bar (hidden initially) — lives in bottom_panel so it
+            # sits above the button row and never disappears behind scroll.
+            progress_frame = tk.Frame(bottom_panel, bg=bg)
             progress_frame.pack(fill="x", padx=24, pady=(4, 0))
             progress_canvas = tk.Canvas(progress_frame, height=4, bg="#313244",
                                          highlightthickness=0)
@@ -1622,8 +1658,8 @@ class WhisperSync:
             progress_label.pack(anchor="w")
             progress_frame.pack_forget()  # hidden until needed
 
-            # Boundary notice (hidden initially)
-            boundary_frame = tk.Frame(root, bg=bg)
+            # Boundary notice (hidden initially) — also in bottom_panel.
+            boundary_frame = tk.Frame(bottom_panel, bg=bg)
             boundary_label = tk.Label(boundary_frame, text="", font=("Segoe UI", 8),
                                        bg=bg, fg=yellow, wraplength=440)
             boundary_label.pack(side=tk.LEFT, padx=(24, 8))
@@ -1631,8 +1667,8 @@ class WhisperSync:
 
             _boundaries = [None]
 
-            # Buttons
-            btn_frame = tk.Frame(root, bg=bg)
+            # Buttons — permanently visible at the bottom.
+            btn_frame = tk.Frame(bottom_panel, bg=bg)
             btn_frame.pack(pady=(14, 12))
 
             _closing = [False]
@@ -1770,11 +1806,25 @@ class WhisperSync:
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _skip)
             root.mainloop()
-            event.set()
 
-        t = threading.Thread(target=_show, daemon=True)
+        def _show_guarded():
+            # Guarantees event.set() fires even if Tk init/geometry raises.
+            # Without this, a crash in _show would hang the meeting
+            # post-processing pipeline indefinitely waiting on the event.
+            try:
+                _show()
+            except Exception:
+                logger.exception("speaker dialog crashed")
+                result[0] = None
+            finally:
+                event.set()
+
+        t = threading.Thread(target=_show_guarded, daemon=True)
         t.start()
-        event.wait(timeout=120)
+        # Wait as long as the user needs. A 2-minute timeout would silently
+        # skip speaker confirmation while the dialog was still on screen —
+        # data loss with no log.
+        event.wait()
 
         return result[0]
 
@@ -3263,7 +3313,7 @@ class WhisperSync:
         def _do_restart():
             import subprocess
             import time
-            lifecycle.record_exit_reason("user_restart")
+            lifecycle.record_exit_reason(lifecycle.REASON_USER_RESTART)
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
             # Spawn new process first so it starts loading immediately
@@ -3286,11 +3336,17 @@ class WhisperSync:
         """Quit WhisperSync. Deferred like _restart for the same reason."""
         def _do_quit():
             import time
-            lifecycle.record_exit_reason("user_quit")
+            lifecycle.record_exit_reason(lifecycle.REASON_USER_QUIT)
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
             if self.tray:
                 self.tray.stop()
+            # Explicit banner for symmetry with _restart. In theory the
+            # atexit hook emits one when the interpreter shuts down, but
+            # daemon threads keeping the interpreter alive can swallow
+            # atexit — better to log here and let atexit be a no-op via
+            # the first-wins rule in record_exit_reason.
+            lifecycle.log_exit_banner(logger)
         threading.Thread(target=_do_quit, daemon=True).start()
 
     @staticmethod
@@ -3494,15 +3550,9 @@ class WhisperSync:
 
 
 def main():
-    global _FAULTHANDLER_FILE
-    # Enable faulthandler FIRST so native segfaults get logged to the log file.
-    # Keep a module-level reference to the file; otherwise CPython can GC the
-    # FileIO object, close its fd, and silently drop later crash dumps.
-    try:
-        _FAULTHANDLER_FILE = open(get_log_path(), "a", buffering=1, encoding="utf-8")
-        faulthandler.enable(file=_FAULTHANDLER_FILE, all_threads=True)
-    except Exception:
-        faulthandler.enable()  # fallback to stderr
+    # Install faulthandler FIRST so native segfaults are persisted. The
+    # helper retains the file handle module-scope so it cannot be GC'd.
+    install_faulthandler(get_log_path())
 
     heartbeat = Heartbeat(logger, interval=60.0)
     try:
@@ -3514,11 +3564,14 @@ def main():
         app = WhisperSync()
         app.run()
     except SystemExit:
-        lifecycle.record_exit_reason("system_exit")
+        lifecycle.record_exit_reason(lifecycle.REASON_SYSTEM_EXIT)
         raise
     except Exception:
         import traceback
-        lifecycle.record_exit_reason("exception", {"type": type(sys.exc_info()[1]).__name__})
+        lifecycle.record_exit_reason(
+            lifecycle.REASON_EXCEPTION,
+            {"type": type(sys.exc_info()[1]).__name__},
+        )
         logger.critical(f"FATAL CRASH:\n{traceback.format_exc()}")
         # Last-resort hook cleanup — prevents stuck Ctrl key on crash
         try:

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1466,14 +1466,14 @@ class WhisperSync:
             screen_h = root.winfo_screenheight()
             max_h = min(700, int(screen_h * 0.8))
             # Size to content, capped at max_h. When content exceeds the cap,
-            # the middle scrolls (see _make_scrollable below) and the bottom
-            # button bar remains visible because it is packed with side=BOTTOM
-            # BEFORE the scrollable middle.
+            # the middle content scrolls via the inline Canvas/Scrollbar setup,
+            # and the bottom button bar remains visible because it is packed
+            # with side=BOTTOM BEFORE the scrollable middle.
             height = min(180 + (num_speakers * 70), max_h)
             root.geometry(f"500x{height}")
             root.minsize(500, 260)  # guarantee the buttons are always reachable
 
-            # Header — packed FIRST (top)
+            # Header: packed FIRST (top)
             header = tk.Frame(root, bg=bg)
             header.pack(side=tk.TOP, fill="x", padx=24, pady=(14, 0))
             tk.Label(header, text="\U0001f3a4", font=("Segoe UI", 13), bg=bg).pack(side=tk.LEFT)
@@ -1483,7 +1483,7 @@ class WhisperSync:
             # Bottom panel: progress + boundary notice + buttons. These are
             # packed NOW (before the scrollable middle) with side=BOTTOM so
             # Tk's pack algorithm reserves space for them regardless of how
-            # many speakers are added — the Confirm button never slides off.
+            # many speakers are added; the Confirm button never slides off.
             bottom_panel = tk.Frame(root, bg=bg)
             bottom_panel.pack(side=tk.BOTTOM, fill="x")
 
@@ -1645,7 +1645,7 @@ class WhisperSync:
                     tk.Label(reason_frame, text=f"\u2514 {reason}", font=("Segoe UI", 7, "italic"),
                              bg=bg, fg=fg_dim, anchor="w", wraplength=400).pack(anchor="w")
 
-            # Progress bar (hidden initially) — lives in bottom_panel so it
+            # Progress bar (hidden initially): lives in bottom_panel so it
             # sits above the button row and never disappears behind scroll.
             progress_frame = tk.Frame(bottom_panel, bg=bg)
             progress_frame.pack(fill="x", padx=24, pady=(4, 0))
@@ -1658,7 +1658,7 @@ class WhisperSync:
             progress_label.pack(anchor="w")
             progress_frame.pack_forget()  # hidden until needed
 
-            # Boundary notice (hidden initially) — also in bottom_panel.
+            # Boundary notice (hidden initially): also in bottom_panel.
             boundary_frame = tk.Frame(bottom_panel, bg=bg)
             boundary_label = tk.Label(boundary_frame, text="", font=("Segoe UI", 8),
                                        bg=bg, fg=yellow, wraplength=440)
@@ -1667,7 +1667,7 @@ class WhisperSync:
 
             _boundaries = [None]
 
-            # Buttons — permanently visible at the bottom.
+            # Buttons: permanently visible at the bottom.
             btn_frame = tk.Frame(bottom_panel, bg=bg)
             btn_frame.pack(pady=(14, 12))
 
@@ -1822,7 +1822,7 @@ class WhisperSync:
         t = threading.Thread(target=_show_guarded, daemon=True)
         t.start()
         # Wait as long as the user needs. A 2-minute timeout would silently
-        # skip speaker confirmation while the dialog was still on screen —
+        # skip speaker confirmation while the dialog was still on screen:
         # data loss with no log.
         event.wait()
 
@@ -3344,7 +3344,7 @@ class WhisperSync:
             # Explicit banner for symmetry with _restart. In theory the
             # atexit hook emits one when the interpreter shuts down, but
             # daemon threads keeping the interpreter alive can swallow
-            # atexit — better to log here and let atexit be a no-op via
+            # atexit; better to log here and let atexit be a no-op via
             # the first-wins rule in record_exit_reason.
             lifecycle.log_exit_banner(logger)
         threading.Thread(target=_do_quit, daemon=True).start()

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -253,27 +253,24 @@ class AudioRecorder:
         shows exactly which recording was dropped when the user aborts
         the meeting-name dialog or the app decides to discard.
         """
-        import logging as _logging
-        _log = _logging.getLogger("whisper_sync.capture")
         from .streaming_wav import cleanup_temp_files
         parent = None
         for label, w in (("mic", self._mic_writer), ("speaker", self._speaker_writer)):
             if w is None:
                 continue
             parent = w.path.parent
-            size = 0
             try:
-                size = w.path.stat().st_size if w.path.exists() else 0
+                size = w.path.stat().st_size
             except OSError:
-                pass
-            _log.info(
+                size = 0
+            logger.info(
                 "discard_streaming: channel=%s path=%s size=%d",
                 label, w.path, size,
             )
             try:
                 w.close()
             except Exception:
-                _log.debug("discard_streaming: close failed for %s", label, exc_info=True)
+                logger.debug("discard_streaming: close failed for %s", label, exc_info=True)
         self._mic_writer = None
         self._speaker_writer = None
         if parent is not None:

--- a/whisper_sync/crash_diagnostics.py
+++ b/whisper_sync/crash_diagnostics.py
@@ -1,4 +1,4 @@
-"""Crash diagnostics — exception hooks and Windows Event Log check.
+"""Crash diagnostics - exception hooks and Windows Event Log check.
 
 Zero runtime cost: excepthook is a passive function pointer,
 Event Log is queried once at startup.
@@ -14,7 +14,7 @@ from pathlib import Path
 
 # Module-level reference to the faulthandler log file. Without a strong ref,
 # the FileIO can be garbage-collected, its fd closes, and later native crash
-# dumps are silently lost — which is exactly what produced the historic
+# dumps are silently lost, which is exactly what produced the historic
 # silent-death logs with no forensic trace. Both the main tray process and
 # the worker subprocess install their faulthandler via this module so the
 # fix applies uniformly.
@@ -37,27 +37,40 @@ def install_faulthandler(log_path) -> "object | None":
 
     Opens ``log_path`` in line-buffered append mode, stores the handle at
     module scope so CPython cannot GC it, then registers the handle with
-    ``faulthandler.enable``. On failure (e.g. path not writable) falls back
-    to the stderr default and returns ``None``.
+    ``faulthandler.enable``. On any failure (path not writable, enable
+    raising), closes the file, clears the retained ref, and best-effort
+    falls back to the stderr default with ``all_threads=True`` so thread
+    crashes are still captured.
 
-    Returns the open file object on success so callers can inspect it; the
-    file is also retained internally for the lifetime of the interpreter.
+    Returns the open file object on success, ``None`` if the file-backed
+    install failed (stderr fallback may still be active).
     """
     global _FAULTHANDLER_FILE
+
+    def _fallback_to_stderr():
+        try:
+            faulthandler.enable(all_threads=True)
+        except Exception:
+            pass
+
     try:
         f = open(Path(log_path), "a", buffering=1, encoding="utf-8")
     except (OSError, ValueError):
-        try:
-            faulthandler.enable()
-        except Exception:
-            pass
+        _fallback_to_stderr()
         return None
+
     _FAULTHANDLER_FILE = f
     try:
         faulthandler.enable(file=f, all_threads=True)
     except Exception:
-        # Extremely unusual; leave the file retained so any later attempt
-        # to enable can still target it, but don't hide the failure.
+        # enable() failed with the file. Release the file and fall back
+        # to stderr so thread crashes are still captured.
+        try:
+            f.close()
+        except Exception:
+            pass
+        _FAULTHANDLER_FILE = None
+        _fallback_to_stderr()
         return None
     return f
 

--- a/whisper_sync/crash_diagnostics.py
+++ b/whisper_sync/crash_diagnostics.py
@@ -4,11 +4,62 @@ Zero runtime cost: excepthook is a passive function pointer,
 Event Log is queried once at startup.
 """
 
+import faulthandler
 import logging
 import subprocess
 import sys
 import threading
 import traceback
+from pathlib import Path
+
+# Module-level reference to the faulthandler log file. Without a strong ref,
+# the FileIO can be garbage-collected, its fd closes, and later native crash
+# dumps are silently lost — which is exactly what produced the historic
+# silent-death logs with no forensic trace. Both the main tray process and
+# the worker subprocess install their faulthandler via this module so the
+# fix applies uniformly.
+_FAULTHANDLER_FILE = None
+
+
+def _reset_faulthandler_for_tests() -> None:
+    """Test-only: close and drop the retained faulthandler file."""
+    global _FAULTHANDLER_FILE
+    try:
+        if _FAULTHANDLER_FILE is not None and not _FAULTHANDLER_FILE.closed:
+            _FAULTHANDLER_FILE.close()
+    except Exception:
+        pass
+    _FAULTHANDLER_FILE = None
+
+
+def install_faulthandler(log_path) -> "object | None":
+    """Enable ``faulthandler`` with a retained log file.
+
+    Opens ``log_path`` in line-buffered append mode, stores the handle at
+    module scope so CPython cannot GC it, then registers the handle with
+    ``faulthandler.enable``. On failure (e.g. path not writable) falls back
+    to the stderr default and returns ``None``.
+
+    Returns the open file object on success so callers can inspect it; the
+    file is also retained internally for the lifetime of the interpreter.
+    """
+    global _FAULTHANDLER_FILE
+    try:
+        f = open(Path(log_path), "a", buffering=1, encoding="utf-8")
+    except (OSError, ValueError):
+        try:
+            faulthandler.enable()
+        except Exception:
+            pass
+        return None
+    _FAULTHANDLER_FILE = f
+    try:
+        faulthandler.enable(file=f, all_threads=True)
+    except Exception:
+        # Extremely unusual; leave the file retained so any later attempt
+        # to enable can still target it, but don't hide the failure.
+        return None
+    return f
 
 
 def install_excepthook(log: logging.Logger) -> None:

--- a/whisper_sync/lifecycle.py
+++ b/whisper_sync/lifecycle.py
@@ -25,8 +25,19 @@ import sys
 import threading
 from pathlib import Path
 
+# Canonical exit-reason strings. Greppable log markers; callers should
+# import these constants rather than pass raw strings so the labels stay
+# stable across the codebase.
+REASON_UNKNOWN = "unknown"
+REASON_USER_QUIT = "user_quit"
+REASON_USER_RESTART = "user_restart"
+REASON_ATEXIT = "atexit"
+REASON_SIGNAL = "signal"
+REASON_EXCEPTION = "exception"
+REASON_SYSTEM_EXIT = "system_exit"
+
 _state_lock = threading.Lock()
-_exit_reason: str = "unknown"
+_exit_reason: str = REASON_UNKNOWN
 _exit_extra: dict = {}
 _installed: bool = False
 
@@ -35,7 +46,7 @@ def _reset_for_tests() -> None:
     """Reset module state. Test-only."""
     global _exit_reason, _exit_extra, _installed
     with _state_lock:
-        _exit_reason = "unknown"
+        _exit_reason = REASON_UNKNOWN
         _exit_extra = {}
         _installed = False
 
@@ -44,7 +55,7 @@ def record_exit_reason(reason: str, extra: dict | None = None) -> None:
     """Record why the process is about to exit. First caller wins."""
     global _exit_reason, _exit_extra
     with _state_lock:
-        if _exit_reason != "unknown":
+        if _exit_reason != REASON_UNKNOWN:
             return
         _exit_reason = reason
         _exit_extra = dict(extra) if extra else {}
@@ -119,7 +130,7 @@ def install(logger: logging.Logger) -> None:
         _installed = True
 
     def _atexit():
-        record_exit_reason("atexit")
+        record_exit_reason(REASON_ATEXIT)
         log_exit_banner(logger)
 
     atexit.register(_atexit)
@@ -133,7 +144,7 @@ def install(logger: logging.Logger) -> None:
         # exit banner during normal interpreter shutdown — doing logging
         # inside a signal handler is both risky (async-signal-safety) and
         # duplicates the atexit banner once sys.exit() runs.
-        record_exit_reason("signal", {"signal": name})
+        record_exit_reason(REASON_SIGNAL, {"signal": name})
         try:
             signal.signal(signum, signal.SIG_DFL)
         except Exception:

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -328,14 +328,11 @@ class MeetingJob:
         respect the configurable toggle — otherwise disabling 'Meeting
         Complete' in the tray menu has no effect.
         """
-        from .notifications import notify, DEFAULT_TOAST_EVENTS
+        from .notifications import notify, is_toast_enabled
 
         try:
-            cfg = getattr(self.app, "cfg", {}) or {}
-            enabled = cfg.get("toast_events", DEFAULT_TOAST_EVENTS)
-            if not isinstance(enabled, (list, tuple, set)):
-                enabled = DEFAULT_TOAST_EVENTS
-            if "meeting_completed" not in enabled:
+            cfg = getattr(self.app, "cfg", None)
+            if not is_toast_enabled("meeting_completed", cfg):
                 return
 
             words = self.transcript_result.get("word_count", 0) if self.transcript_result else 0

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -252,6 +252,20 @@ TOAST_REGISTRY: dict[str, dict] = {
 DEFAULT_TOAST_EVENTS = ["meeting_completed", "error", "pr_status_changed"]
 
 
+def is_toast_enabled(event_type: str, cfg: dict | None) -> bool:
+    """Return True if ``event_type`` should fire a toast per ``cfg``.
+
+    Shared between ``ToastListener`` and direct-dispatch call sites such as
+    ``MeetingJob.step_notify`` so both respect the same user toggle and
+    the same config-validation rules (garbage values fall back to
+    ``DEFAULT_TOAST_EVENTS``).
+    """
+    raw = (cfg or {}).get("toast_events", DEFAULT_TOAST_EVENTS)
+    if not isinstance(raw, (list, tuple, set)):
+        raw = DEFAULT_TOAST_EVENTS
+    return event_type in raw
+
+
 class ToastListener:
     """State event subscriber that shows configurable Windows toasts.
 
@@ -264,15 +278,7 @@ class ToastListener:
         self._config = config
 
     def __call__(self, event) -> None:
-        raw_events = self._config.get("toast_events", DEFAULT_TOAST_EVENTS)
-        if not isinstance(raw_events, (list, tuple, set)):
-            _logger.debug(
-                "Invalid toast_events config (%r); falling back to defaults",
-                raw_events,
-            )
-            raw_events = DEFAULT_TOAST_EVENTS
-        enabled = set(raw_events)
-        if event.type not in enabled:
+        if not is_toast_enabled(event.type, self._config):
             return
 
         template = TOAST_REGISTRY.get(event.type)

--- a/whisper_sync/worker.py
+++ b/whisper_sync/worker.py
@@ -88,8 +88,17 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
         preload_model_name: Model to preload at startup. None = skip preload
             (model loads on first request instead).
     """
-    # Enable faulthandler in child so segfaults are logged to stderr
-    faulthandler.enable()
+    # Enable faulthandler in the worker subprocess. Use the shared helper
+    # so the file handle is retained module-scope; otherwise CPython can
+    # GC it and native crash dumps from CTranslate2/CUDA vanish. The log
+    # path mirrors the main process so both streams land in the same
+    # dated file.
+    try:
+        from .crash_diagnostics import install_faulthandler
+        from .logger import get_log_path
+        install_faulthandler(get_log_path())
+    except Exception:
+        faulthandler.enable()  # best-effort fallback to stderr
 
     # Suppress known harmless warnings before any imports trigger them
     import warnings

--- a/whisper_sync/worker.py
+++ b/whisper_sync/worker.py
@@ -98,7 +98,9 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
         from .logger import get_log_path
         install_faulthandler(get_log_path())
     except Exception:
-        faulthandler.enable()  # best-effort fallback to stderr
+        # Thread crashes in native libs (CTranslate2, CUDA) are common here;
+        # all_threads=True is essential so they are captured.
+        faulthandler.enable(all_threads=True)  # best-effort fallback to stderr
 
     # Suppress known harmless warnings before any imports trigger them
     import warnings


### PR DESCRIPTION
## Summary

Fixes a user-reported bug where the speaker-confirmation dialog became unusable with 4+ speakers: the **Confirm / Skip / Deep Identify** buttons scrolled off the bottom and could not be pressed. Also bundles the five simplify follow-ups from PR #123's code review.

## Dialog fix — `_ask_speaker_confirmation`

Before: rows packed top-to-bottom into `root` with a fixed height computed from `num_speakers * 70`. When reasoning lines wrapped or height was capped, the button frame (packed last) slid off-screen.

After:
1. A `bottom_panel` is packed with `side=BOTTOM` **first** so Tk reserves space for the progress bar + boundary notice + buttons regardless of row content.
2. The speaker rows now live in a `Canvas` + `Scrollbar` + inner `Frame` scrollable container with `fill="both", expand=True`.
3. Mouse-wheel scrolling is bound only while the pointer is over the canvas so child dropdown widgets keep their own wheel events.
4. `minsize(500, 260)` guarantees the button bar is always reachable even if the user resizes.
5. The dialog thread body is wrapped in `try/except/finally` so `event.set()` always fires — a Tk init crash no longer hangs the meeting pipeline.
6. Removed the 120s silent-abort timeout on `event.wait()` (same pattern as the meeting-name dialog in PR #123): it was dropping speaker confirmation while the dialog was still on screen.

## Simplify follow-ups (from PR #123 review)

| # | Finding | Fix |
|---|---------|-----|
| 1 | `_quit` never logged the exit banner (only `_restart` did) | Explicit `lifecycle.log_exit_banner(logger)` in `_quit` for symmetry |
| 2 | Exit reasons were stringly-typed across 6+ call sites | New `REASON_*` constants in `lifecycle.py`; call sites import them |
| 3 | `capture.discard_streaming` bypassed the package logger with inline `logging.getLogger(...)` | Uses the existing `from .logger import logger`; drops `exists()+stat()` TOCTOU for a single `try/except OSError` |
| 4 | `step_notify` duplicated `ToastListener`'s config-gate logic | New `notifications.is_toast_enabled(event, cfg)` helper; both call sites share the validator |
| 5 | Faulthandler file-retention fix lived in `__main__.main()` only; `worker.py` still had the historic bug | New `crash_diagnostics.install_faulthandler(path)` helper with retained module-scope file. Used by both the tray and worker processes |

## Tests

- `tests/test_lifecycle_reasons.py` — exported constants + default sentinel match
- `tests/test_notifications_helper.py` — `is_toast_enabled` edge cases (list / absent / garbage / None cfg)
- `tests/test_faulthandler_install.py` — retained file, None fallback on bad path

Total: 30 tests, all green.

## Test plan

- [x] `python -m unittest discover tests` — 30 passing
- [x] Package import smoke-test
- [ ] Manual: run a meeting with 5+ speakers, resize the dialog down to 300px tall, confirm Confirm button is still reachable via scroll
- [ ] Manual: observe one meeting completion, confirm `=== WhisperSync exiting === reason=user_quit` appears on tray Quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)