### PR TITLE
fix: mic open fallback + hotkey dispatcher survival

### DIFF
--- a/tests/test_capture_open_input.py
+++ b/tests/test_capture_open_input.py
@@ -1,0 +1,122 @@
+"""Tests for capture.AudioRecorder input-stream open behavior.
+
+The mic stream is opened inside ``start()`` via ``sd.InputStream(...)``.
+On Windows, ``device=None`` selects the MME default device which often
+rejects ``float32 @ 16000 Hz`` with ``PaErrorCode -9999 / MME error 32``.
+Before this change the error propagated up to the keyboard dispatcher
+thread and killed it, bricking every hotkey.
+
+``_open_input_stream`` encapsulates the retry ladder:
+  1. Try the caller-provided ``samplerate`` / ``dtype``.
+  2. On ``PortAudioError``, retry at the device's native samplerate.
+  3. On ``PortAudioError`` again, retry at native rate + ``int16``.
+
+The helper returns the opened stream plus the effective samplerate so
+callers can resample downstream if needed.
+"""
+
+import types
+import unittest
+from unittest import mock
+
+
+class _FakePortAudioError(Exception):
+    """Stand-in for sounddevice.PortAudioError."""
+
+
+class OpenInputStreamLadderTests(unittest.TestCase):
+    def _install_fake_sd(self):
+        """Install a fake ``sd`` module inside capture for a single test."""
+        fake = types.SimpleNamespace()
+        fake.PortAudioError = _FakePortAudioError
+
+        self.calls = []
+
+        def _fake_input_stream(**kwargs):
+            self.calls.append(kwargs)
+            # Behavior is driven by the test: self._responder is swapped in.
+            return self._responder(kwargs)
+
+        fake.InputStream = _fake_input_stream
+        fake.query_devices = lambda device: {"default_samplerate": 48000.0}
+
+        from whisper_sync import capture
+        self._orig_sd = capture.sd
+        capture.sd = fake
+        self.addCleanup(lambda: setattr(capture, "sd", self._orig_sd))
+
+    def setUp(self):
+        self._install_fake_sd()
+
+    def test_first_attempt_succeeds_returns_requested_rate(self):
+        self._responder = lambda kwargs: mock.Mock(name="stream")
+        from whisper_sync.capture import _open_input_stream
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 16000)
+        self.assertEqual(len(self.calls), 1)
+
+    def test_falls_back_to_native_samplerate_on_portaudio_error(self):
+        responses = [
+            _FakePortAudioError("MME error 32"),  # first try
+            mock.Mock(name="stream"),             # second try ok
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 48000)  # device default from fake query_devices
+        # First attempt at 16000, second at 48000
+        self.assertEqual(self.calls[0]["samplerate"], 16000)
+        self.assertEqual(self.calls[1]["samplerate"], 48000)
+
+    def test_falls_back_to_int16_when_float32_and_native_both_fail(self):
+        responses = [
+            _FakePortAudioError("float32/16k rejected"),
+            _FakePortAudioError("float32/48k rejected"),
+            mock.Mock(name="stream"),
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 48000)
+        self.assertEqual(self.calls[-1]["dtype"], "int16")
+
+    def test_reraises_if_all_attempts_fail(self):
+        def _responder(kwargs):
+            raise _FakePortAudioError("always fails")
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        with self.assertRaises(_FakePortAudioError):
+            _open_input_stream(
+                device=7, target_samplerate=16000, channels=1,
+                dtype="float32", callback=lambda *_: None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capture_recorder.py
+++ b/tests/test_capture_recorder.py
@@ -1,0 +1,142 @@
+"""Tests for AudioRecorder state transitions.
+
+These tests drive the recorder directly (without opening a real audio
+device) to pin behavior that review surfaced:
+
+  * start() must not leave ``_recording=True`` if the mic open fails
+    (Copilot review comment #3 on PR 125).
+  * start_streaming() must not flip ``_disk_only`` if the WAV writer
+    fails to open - otherwise the callback would silently skip both
+    RAM accumulation and disk write (comment #2).
+  * _mic_callback must normalize int16 samples to [-1, 1] BEFORE
+    resampling (comment #1).
+"""
+
+import types
+import unittest
+from unittest import mock
+
+import numpy as np
+
+
+class _FakePortAudioError(Exception):
+    pass
+
+
+def _make_recorder(install_fake_sd=True):
+    """Build an AudioRecorder with a fake sd module swapped in."""
+    from whisper_sync import capture
+    recorder = capture.AudioRecorder(sample_rate=16000)
+    if install_fake_sd:
+        fake = types.SimpleNamespace()
+        fake.PortAudioError = _FakePortAudioError
+        fake.InputStream = mock.Mock()
+        fake.query_devices = lambda device: {"default_samplerate": 48000.0}
+        capture.sd = fake
+    return recorder, capture
+
+
+class StartTransactionalTests(unittest.TestCase):
+    def test_recording_stays_false_when_open_fails(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        capture.sd.InputStream.side_effect = _FakePortAudioError("always fail")
+
+        with self.assertRaises(_FakePortAudioError):
+            recorder.start(mic_device=7)
+
+        self.assertFalse(recorder._recording)
+        self.assertIsNone(recorder._mic_stream)
+
+    def test_open_stream_is_closed_if_start_fails(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        stream = mock.Mock()
+        stream.start.side_effect = RuntimeError("start fails")
+        capture.sd.InputStream.return_value = stream
+
+        with self.assertRaises(RuntimeError):
+            recorder.start(mic_device=7)
+
+        stream.close.assert_called_once()
+        self.assertFalse(recorder._recording)
+        self.assertIsNone(recorder._mic_stream)
+
+
+class StartStreamingTransactionalTests(unittest.TestCase):
+    def test_disk_only_not_flipped_when_writer_fails(self):
+        recorder, capture = _make_recorder(install_fake_sd=False)
+        recorder._disk_only = False  # baseline
+
+        with mock.patch.object(capture, "StreamingWavWriter",
+                               side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                recorder.start_streaming(mic_path="/tmp/x.wav", disk_only=True)
+
+        self.assertFalse(recorder._disk_only,
+                         "_disk_only must stay False when writer open fails")
+        self.assertIsNone(recorder._mic_writer)
+
+
+class MicCallbackNormalizationTests(unittest.TestCase):
+    def test_int16_samples_are_scaled_to_minus_one_to_one(self):
+        from whisper_sync.capture import AudioRecorder
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder._recording = True
+        # Same-rate path (no resample). int16 input must be normalized.
+        recorder._mic_resample_up = 1
+        recorder._mic_resample_down = 1
+
+        int16_block = np.array([[32767], [-32768], [0]], dtype=np.int16)
+        recorder._mic_callback(int16_block, 3, None, None)
+
+        self.assertEqual(len(recorder._mic_data), 1)
+        out = recorder._mic_data[0]
+        self.assertEqual(out.dtype, np.float32)
+        # 32767/32768.0 ~= 1.0; -32768/32768.0 == -1.0; 0 == 0
+        self.assertAlmostEqual(float(out[0, 0]), 1.0, places=3)
+        self.assertAlmostEqual(float(out[1, 0]), -1.0, places=6)
+        self.assertAlmostEqual(float(out[2, 0]), 0.0, places=6)
+
+    def test_int16_with_resample_stays_normalized(self):
+        # Resample + int16 path was the original bug: values stayed in
+        # the [-32768, 32767] range and would clip catastrophically.
+        from whisper_sync.capture import AudioRecorder
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder._recording = True
+        recorder._mic_effective_rate = 48000
+        recorder._mic_resample_up = 1
+        recorder._mic_resample_down = 3
+
+        # A 48-sample int16 buffer at full positive scale.
+        block = np.full((48, 1), 32767, dtype=np.int16)
+        recorder._mic_callback(block, 48, None, None)
+
+        self.assertEqual(len(recorder._mic_data), 1)
+        out = recorder._mic_data[0]
+        self.assertEqual(out.dtype, np.float32)
+        # After resampling a constant signal, values should still be ~1.0,
+        # nowhere near 32767. Accept a generous upper bound.
+        peak = float(np.max(np.abs(out)))
+        self.assertLess(peak, 1.1,
+                        f"int16 was not normalized before resampling; peak={peak}")
+
+    def test_float32_passthrough_same_rate(self):
+        from whisper_sync.capture import AudioRecorder
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder._recording = True
+        recorder._mic_resample_up = 1
+        recorder._mic_resample_down = 1
+
+        block = np.array([[0.5], [-0.25], [0.0]], dtype=np.float32)
+        recorder._mic_callback(block, 3, None, None)
+
+        out = recorder._mic_data[0]
+        self.assertEqual(out.dtype, np.float32)
+        np.testing.assert_array_equal(out, block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -391,8 +391,18 @@ class WhisperSync:
         self.state.emit(DICTATION_STARTED, mode="dictation")
         mic = self.cfg.get("mic_device")
         if self.cfg.get("use_system_devices", True):
-            mic = None
-        self.recorder.start(mic_device=mic)
+            # Explicitly use the WASAPI default instead of falling through
+            # to sd.default.device[0], which on Windows resolves to an MME
+            # device and often rejects float32 @ 16 kHz with MME error 32.
+            mic = get_default_devices().get("input")
+        try:
+            self.recorder.start(mic_device=mic)
+        except Exception as e:
+            logger.error("Failed to start mic for dictation: %s", e, exc_info=True)
+            notify("Dictation unavailable", f"Mic could not be opened: {e}")
+            self._feature_suggest_active = False
+            self.state.emit(IDLE, mode=None)
+            return
         # Stream to disk for crash recovery -- skip when incognito (RAM only)
         if self.cfg.get("incognito", False):
             self._dictation_wav_path = None
@@ -402,7 +412,11 @@ class WhisperSync:
             ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             prefix = "feature_" if self._feature_suggest_active else ""
             self._dictation_wav_path = log_dir / f"{prefix}{ts}.wav"
-            self.recorder.start_streaming(self._dictation_wav_path)
+            try:
+                self.recorder.start_streaming(self._dictation_wav_path)
+            except Exception as e:
+                logger.warning("Dictation disk streaming disabled: %s", e)
+                self._dictation_wav_path = None
 
     def _stop_dictation(self):
         audio = self.recorder.stop()
@@ -551,8 +565,15 @@ class WhisperSync:
         self._overlay_recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
         mic = self.cfg.get("mic_device")
         if self.cfg.get("use_system_devices", True):
-            mic = None
-        self._overlay_recorder.start(mic_device=mic)
+            mic = get_default_devices().get("input")
+        try:
+            self._overlay_recorder.start(mic_device=mic)
+        except Exception as e:
+            logger.error("Failed to start overlay dictation mic: %s", e, exc_info=True)
+            notify("Dictation unavailable", f"Mic could not be opened: {e}")
+            self._overlay_recorder = None
+            self._feature_suggest_active = False
+            return
         logger.info("Dictation during meeting: recording started", extra={"secondary": True})
         self.state.emit(DICTATION_STARTED, dictation_overlay=True)
 
@@ -1033,20 +1054,30 @@ class WhisperSync:
         mic = self.cfg.get("mic_device")
         speaker = self.cfg.get("speaker_device")
         if self.cfg.get("use_system_devices", True):
-            mic = None
             defaults = get_default_devices()
+            # Route mic through WASAPI too (not sd.default.device[0]'s MME)
+            mic = defaults.get("input")
             speaker = defaults["output"]
         elif speaker is None:
             defaults = get_default_devices()
             speaker = defaults["output"]
-        self.recorder.start(mic_device=mic, speaker_device=speaker)
+        try:
+            self.recorder.start(mic_device=mic, speaker_device=speaker)
+        except Exception as e:
+            logger.error("Failed to start mic for meeting: %s", e, exc_info=True)
+            notify("Meeting unavailable", f"Mic could not be opened: {e}")
+            self.state.emit(IDLE, mode=None)
+            return
         if self.recorder.speaker_loopback_active:
             logger.info("Meeting started: mic + speaker loopback")
         else:
             logger.warning("Meeting started: mic only (speaker loopback unavailable)")
         temp = self._meeting_temp_dir()
         mic_temp = temp / "mic-temp.wav"
-        self.recorder.start_streaming(mic_temp, disk_only=True)
+        try:
+            self.recorder.start_streaming(mic_temp, disk_only=True)
+        except Exception as e:
+            logger.warning("Meeting streaming disabled: %s", e)
         if self.cfg.get("always_available_dictation", True):
             self._backup.preload()
 
@@ -3417,21 +3448,38 @@ class WhisperSync:
         # Bootstrap: ensure base models are cached, prompt for large ones
         bootstrap_models(self.cfg, on_large_model=self._prompt_large_download)
 
+        def _guarded(fn, label):
+            # Any exception that escapes a hotkey callback propagates to
+            # keyboard._generic.process and kills the single dispatcher
+            # thread, bricking ALL hotkeys for the rest of the session.
+            # This wrapper is the last line of defense; individual handlers
+            # also try/except their own failures.
+            def _inner():
+                try:
+                    return fn()
+                except Exception as e:
+                    logger.error("%s hotkey handler crashed: %s", label, e, exc_info=True)
+                    try:
+                        notify("WhisperSync error", f"{label}: {e}")
+                    except Exception:
+                        pass
+            return _inner
+
         keyboard.add_hotkey(
             self.cfg["hotkeys"]["dictation_toggle"],
-            self.toggle_dictation,
+            _guarded(self.toggle_dictation, "dictation"),
             suppress=False,
         )
         keyboard.add_hotkey(
             self.cfg["hotkeys"]["meeting_toggle"],
-            self.toggle_meeting,
+            _guarded(self.toggle_meeting, "meeting"),
             suppress=False,
         )
         feature_hk = self.cfg["hotkeys"].get("feature_suggest", "ctrl+shift+alt+f")
         if feature_hk:
             keyboard.add_hotkey(
                 feature_hk,
-                self.toggle_feature_suggest,
+                _guarded(self.toggle_feature_suggest, "feature-suggest"),
                 suppress=False,
             )
 

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -51,9 +51,68 @@ def get_default_devices(api_filter: str | None = "WASAPI") -> dict:
     return {"input": defaults[0], "output": defaults[1]}
 
 
+def _open_input_stream(*, device, target_samplerate: int, channels: int,
+                       dtype: str, callback):
+    """Open ``sd.InputStream`` with a fallback ladder for format rejections.
+
+    On Windows, ``device=None`` often resolves to an MME device that rejects
+    ``float32 @ 16000 Hz`` with ``PaErrorCode -9999 / MME error 32`` even
+    though the hardware supports the format under WASAPI. Without this
+    retry, a single failed open propagates out of the hotkey handler and
+    kills the keyboard dispatcher thread, bricking all further hotkeys.
+
+    Retry ladder:
+      1. Caller-requested ``target_samplerate`` at ``dtype``.
+      2. Device's native ``default_samplerate`` at the same ``dtype``.
+      3. Device's native ``default_samplerate`` at ``int16``.
+
+    Returns ``(stream, effective_samplerate)``. Callers are responsible
+    for resampling downstream audio when the effective rate differs from
+    the target.
+
+    Reraises the last ``PortAudioError`` if every attempt fails.
+    """
+    attempts = [(target_samplerate, dtype)]
+    try:
+        native = int(sd.query_devices(device)["default_samplerate"])
+    except Exception:
+        native = None
+    if native and native != target_samplerate:
+        attempts.append((native, dtype))
+        attempts.append((native, "int16"))
+    else:
+        attempts.append((target_samplerate, "int16"))
+
+    last_err = None
+    for rate, this_dtype in attempts:
+        try:
+            stream = sd.InputStream(
+                samplerate=rate,
+                channels=channels,
+                dtype=this_dtype,
+                device=device,
+                callback=callback,
+            )
+            if rate != target_samplerate or this_dtype != dtype:
+                logger.warning(
+                    "mic: requested %d Hz %s rejected; using %d Hz %s",
+                    target_samplerate, dtype, rate, this_dtype,
+                )
+            return stream, rate
+        except sd.PortAudioError as e:
+            last_err = e
+            logger.debug("mic open attempt failed (rate=%s dtype=%s): %s", rate, this_dtype, e)
+    assert last_err is not None
+    raise last_err
+
+
 class AudioRecorder:
     def __init__(self, sample_rate: int = 16000):
         self.sample_rate = sample_rate
+        # Effective mic samplerate for the current session. Usually matches
+        # ``sample_rate``, but ``_open_input_stream`` may fall back to the
+        # device's native rate if the requested rate is rejected.
+        self._mic_effective_rate: int = sample_rate
         self._mic_data: list[np.ndarray] = []
         self._speaker_data: list[np.ndarray] = []
         self._mic_stream = None
@@ -71,10 +130,27 @@ class AudioRecorder:
     def _mic_callback(self, indata, frames, time_info, status):
         try:
             if self._recording:
+                # If the device rejected our target rate and _open_input_stream
+                # fell back to the device's native rate, resample to the
+                # recorder's canonical sample_rate so downstream consumers
+                # (accumulator, WAV writer, transcription) see 16 kHz data.
+                if self._mic_effective_rate != self.sample_rate:
+                    from math import gcd
+                    from scipy.signal import resample_poly
+                    up = self.sample_rate // gcd(self.sample_rate, self._mic_effective_rate)
+                    down = self._mic_effective_rate // gcd(self.sample_rate, self._mic_effective_rate)
+                    raw = indata.astype("float32", copy=False) if indata.dtype != np.float32 else indata
+                    resampled = resample_poly(raw.flatten(), up, down).reshape(-1, 1)
+                    data = resampled.astype("float32", copy=False)
+                elif indata.dtype != np.float32:
+                    # int16 fallback dtype: convert to float32 in [-1, 1].
+                    data = (indata.astype("float32") / 32768.0)
+                else:
+                    data = indata
                 if not self._disk_only:
-                    self._mic_data.append(indata.copy())
+                    self._mic_data.append(data.copy() if data is indata else data)
                 if self._mic_writer is not None:
-                    self._mic_writer.write(indata)
+                    self._mic_writer.write(data)
         except Exception as e:
             # Never let exceptions escape into PortAudio's C thread
             if not getattr(self, "_mic_error_logged", False):
@@ -100,11 +176,11 @@ class AudioRecorder:
             self._speaker_error_logged = False
             self._recording = True
 
-            self._mic_stream = sd.InputStream(
-                samplerate=self.sample_rate,
+            self._mic_stream, self._mic_effective_rate = _open_input_stream(
+                device=mic_device,
+                target_samplerate=self.sample_rate,
                 channels=1,
                 dtype="float32",
-                device=mic_device,
                 callback=self._mic_callback,
             )
             self._mic_stream.start()

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -1,11 +1,13 @@
-"""Audio capture — mic and system audio (WASAPI loopback on Windows)."""
+"""Audio capture - mic and system audio (WASAPI loopback on Windows)."""
 
 import threading
 import wave
+from math import gcd
 from pathlib import Path
 
 import numpy as np
 import sounddevice as sd
+from scipy.signal import resample_poly
 
 try:
     import pyaudiowpatch as pyaudio
@@ -113,6 +115,11 @@ class AudioRecorder:
         # ``sample_rate``, but ``_open_input_stream`` may fall back to the
         # device's native rate if the requested rate is rejected.
         self._mic_effective_rate: int = sample_rate
+        # Precomputed resample ratio for the current session. Set in
+        # ``start()`` alongside the stream so the audio callback never
+        # recomputes it per buffer.
+        self._mic_resample_up: int = 1
+        self._mic_resample_down: int = 1
         self._mic_data: list[np.ndarray] = []
         self._speaker_data: list[np.ndarray] = []
         self._mic_stream = None
@@ -129,28 +136,39 @@ class AudioRecorder:
 
     def _mic_callback(self, indata, frames, time_info, status):
         try:
-            if self._recording:
-                # If the device rejected our target rate and _open_input_stream
-                # fell back to the device's native rate, resample to the
-                # recorder's canonical sample_rate so downstream consumers
-                # (accumulator, WAV writer, transcription) see 16 kHz data.
-                if self._mic_effective_rate != self.sample_rate:
-                    from math import gcd
-                    from scipy.signal import resample_poly
-                    up = self.sample_rate // gcd(self.sample_rate, self._mic_effective_rate)
-                    down = self._mic_effective_rate // gcd(self.sample_rate, self._mic_effective_rate)
-                    raw = indata.astype("float32", copy=False) if indata.dtype != np.float32 else indata
-                    resampled = resample_poly(raw.flatten(), up, down).reshape(-1, 1)
-                    data = resampled.astype("float32", copy=False)
-                elif indata.dtype != np.float32:
-                    # int16 fallback dtype: convert to float32 in [-1, 1].
-                    data = (indata.astype("float32") / 32768.0)
-                else:
-                    data = indata
-                if not self._disk_only:
-                    self._mic_data.append(data.copy() if data is indata else data)
-                if self._mic_writer is not None:
-                    self._mic_writer.write(data)
+            if not self._recording:
+                return
+
+            # Normalize to float32 in [-1, 1] regardless of what dtype the
+            # device actually produced. Integer samples must be scaled
+            # BEFORE resampling, otherwise downstream audio stays in the
+            # ~[-32768, 32767] range and clips catastrophically when
+            # written to disk or fed to the transcriber.
+            if indata.dtype == np.int16:
+                normalized = indata.astype(np.float32) / 32768.0
+            elif indata.dtype != np.float32:
+                normalized = indata.astype(np.float32)
+            else:
+                normalized = indata
+
+            # Resample to the canonical sample_rate only when the device
+            # fell back to its native rate. up/down are precomputed in
+            # start() so the callback is a single resample_poly call.
+            if self._mic_resample_up != self._mic_resample_down:
+                # Mono view; reshape(-1) avoids the copy flatten() would do.
+                mono = normalized.reshape(-1)
+                resampled = resample_poly(mono, self._mic_resample_up, self._mic_resample_down)
+                data = resampled.reshape(-1, 1).astype(np.float32, copy=False)
+            else:
+                data = normalized
+
+            if not self._disk_only:
+                # Always copy into the accumulator - PortAudio reuses the
+                # indata buffer for the next callback, and normalized may
+                # alias indata on the float32 no-op path.
+                self._mic_data.append(data.copy() if data is indata else data)
+            if self._mic_writer is not None:
+                self._mic_writer.write(data)
         except Exception as e:
             # Never let exceptions escape into PortAudio's C thread
             if not getattr(self, "_mic_error_logged", False):
@@ -174,16 +192,40 @@ class AudioRecorder:
             self._speaker_data = []
             self._mic_error_logged = False
             self._speaker_error_logged = False
-            self._recording = True
 
-            self._mic_stream, self._mic_effective_rate = _open_input_stream(
-                device=mic_device,
-                target_samplerate=self.sample_rate,
-                channels=1,
-                dtype="float32",
-                callback=self._mic_callback,
-            )
-            self._mic_stream.start()
+            # Transactional: the recorder only becomes "recording" AFTER
+            # the mic stream is fully open and started. On any failure we
+            # close a partially created stream and leave ``_recording``
+            # False so stop()/subsequent starts see a clean state.
+            stream = None
+            try:
+                stream, effective_rate = _open_input_stream(
+                    device=mic_device,
+                    target_samplerate=self.sample_rate,
+                    channels=1,
+                    dtype="float32",
+                    callback=self._mic_callback,
+                )
+                stream.start()
+            except Exception:
+                if stream is not None:
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
+                raise
+
+            self._mic_stream = stream
+            self._mic_effective_rate = effective_rate
+            # Precompute the resample ratio once per session.
+            if effective_rate != self.sample_rate:
+                g = gcd(self.sample_rate, effective_rate)
+                self._mic_resample_up = self.sample_rate // g
+                self._mic_resample_down = effective_rate // g
+            else:
+                self._mic_resample_up = 1
+                self._mic_resample_down = 1
+            self._recording = True
 
             if speaker_device is not None:
                 self._start_speaker_loopback()
@@ -307,11 +349,20 @@ class AudioRecorder:
         Args:
             mic_path: Path for mic WAV file.
             speaker_path: Optional path for speaker WAV file.
-            disk_only: If True, skip RAM accumulation — audio lives only on disk.
+            disk_only: If True, skip RAM accumulation -- audio lives only on disk.
                 Use for long meetings to prevent MemoryError.
+
+        Transactional: if ``StreamingWavWriter`` raises (e.g. unwritable
+        disk), the ``_disk_only`` flag is NOT flipped, so the callback
+        continues to accumulate into RAM and the meeting is still usable.
         """
+        writer = StreamingWavWriter(mic_path, channels=1, rate=self.sample_rate)
+        # Only commit state after the writer is successfully opened. The
+        # old ordering flipped _disk_only first; a writer-open failure
+        # then left the callback skipping BOTH RAM and disk and the
+        # meeting silently captured nothing.
+        self._mic_writer = writer
         self._disk_only = disk_only
-        self._mic_writer = StreamingWavWriter(mic_path, channels=1, rate=self.sample_rate)
 
     def stop_streaming(self):
         """Close and finalize streaming WAV writers."""


### PR DESCRIPTION
## Summary

User reported dictation and meetings stopped working after PRs #123/#124: hotkeys do nothing, no yellow flash, but tray icon colors still respond. Today's log shows the real cause:

```
[CRITICAL] Unhandled exception in thread 'Thread-8 (process)':
  File "capture.py", line 103, in start
    self._mic_stream = sd.InputStream(samplerate=self.sample_rate, ...)
  sounddevice.PortAudioError: Error opening InputStream:
    Unanticipated host error [PaErrorCode -9999]: 'The specified format
    is not supported or cannot be translated.' [MME error 32]
```

The unhandled exception escaped up to `keyboard._generic.process` and killed the single dispatcher thread, bricking every hotkey for the rest of the session. Icon colors still worked because those run on a separate pystray thread.

**The mic format mismatch is environmental**, not caused by my earlier PRs. `device=None` falls through to `sd.default.device[0]`, which on Windows resolves to an **MME** device. Some MME drivers reject `float32 @ 16 kHz` even when the hardware supports the format under WASAPI. But the app's lack of error handling is a real robustness bug.

## Changes

### Root cause: robust mic open
- New `capture._open_input_stream()` with a retry ladder:
  1. Requested samplerate at requested dtype
  2. Device's native samplerate at requested dtype
  3. Device's native samplerate at `int16`
- `AudioRecorder` now tracks `_mic_effective_rate`; when it differs from the canonical 16 kHz, `_mic_callback` resamples via `scipy.signal.resample_poly` so downstream consumers always see 16 kHz float32.
- `_start_dictation` / `_start_meeting` / `_start_overlay_dictation` now route mic through `get_default_devices()['input']` (WASAPI) when `use_system_devices=True`, instead of falling back to `sd.default.device[0]`'s MME.

### Robustness: keyboard thread survival
- Each `_start_*` method wraps `recorder.start()` in try/except. On failure: log, toast, reset state to IDLE.
- `keyboard.add_hotkey` callbacks are now wrapped in a `_guarded()` lambda so any exception that still escapes cannot propagate to `keyboard._generic.process` and kill the dispatcher thread. Last line of defense.
- `start_streaming` failures are caught separately so an unwritable disk doesn't prevent in-memory capture.

## Tests

`tests/test_capture_open_input.py` (new) — 4 cases exercising the retry ladder with a fake `sounddevice`:
- Happy path: first attempt succeeds, returns requested rate
- Native-rate fallback on first PortAudioError
- int16 fallback when both float32 attempts fail
- Reraise when all attempts fail

34 tests total, all green.

## Test plan

- [x] Unit tests pass
- [x] Smoke import
- [ ] Manual: user relaunches app, presses Ctrl+Shift+Space — dictation records and transcribes (expect log line `mic: requested 16000 Hz float32 rejected; using <N> Hz <dtype>` if the mic still rejects, confirming fallback kicked in)
- [ ] Manual: Ctrl+Shift+M starts a meeting
- [ ] If mic continues to reject all formats, user sees a toast "Dictation unavailable: Mic could not be opened: ..." instead of silent death

🤖 Generated with [Claude Code](https://claude.com/claude-code)