### PR TITLE
restore: un-revert PR #126, bring back PRs #123/#124/#125

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,33 @@ See the `.claude/rules/` directory for transcription workflow conventions used w
 
 Logs: `whisper_sync/logs/app/whisper-sync-YYYY-MM-DD.log`
 
+### Reading the log
+
+Each run emits a startup banner with PID, Python version, OS, and git SHA:
+
+```
+=== WhisperSync starting === pid=12840 python=3.13.0 os=Windows-11-10.0.26200 git=a1b2c3d
+```
+
+Every clean exit (tray quit, restart, SIGTERM, uncaught exception) emits a matching exit banner with a reason:
+
+```
+=== WhisperSync exiting === reason=user_quit
+=== WhisperSync exiting === reason=exception type=RuntimeError
+```
+
+**Missing exit banner** between two startups = silent native crash. Check the Windows Application Event Log:
+
+```powershell
+Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='Application Error'; StartTime=(Get-Date).AddHours(-1)} | Format-List Message
+```
+
+The faulting module name identifies the culprit (e.g. `tcl86t.dll` = Tk GUI thread, `torch_cuda.dll` = CUDA DLL load). WhisperSync also scans the Event Log on startup and logs any recent crashes it finds with the faulting module highlighted.
+
+A `heartbeat` DEBUG line fires every 60 seconds; the last heartbeat before a silent death pins down time-of-death within a minute.
+
+Meeting post-processing logs each step start/end at INFO (`step start: transcribe job=...`, `step done: transcribe job=... elapsed=12.3s`) so a crash mid-step reveals which step was active.
+
 ---
 
 ## Updating

--- a/build-dist.ps1
+++ b/build-dist.ps1
@@ -40,6 +40,8 @@ $pyFiles = @(
     "dictation_log.py",
     "streaming_wav.py",
     "crash_diagnostics.py",
+    "lifecycle.py",
+    "heartbeat.py",
     "watchdog.py",
     "worker.py",
     "worker_manager.py",

--- a/tests/test_capture_open_input.py
+++ b/tests/test_capture_open_input.py
@@ -1,0 +1,122 @@
+"""Tests for capture.AudioRecorder input-stream open behavior.
+
+The mic stream is opened inside ``start()`` via ``sd.InputStream(...)``.
+On Windows, ``device=None`` selects the MME default device which often
+rejects ``float32 @ 16000 Hz`` with ``PaErrorCode -9999 / MME error 32``.
+Before this change the error propagated up to the keyboard dispatcher
+thread and killed it, bricking every hotkey.
+
+``_open_input_stream`` encapsulates the retry ladder:
+  1. Try the caller-provided ``samplerate`` / ``dtype``.
+  2. On ``PortAudioError``, retry at the device's native samplerate.
+  3. On ``PortAudioError`` again, retry at native rate + ``int16``.
+
+The helper returns the opened stream plus the effective samplerate so
+callers can resample downstream if needed.
+"""
+
+import types
+import unittest
+from unittest import mock
+
+
+class _FakePortAudioError(Exception):
+    """Stand-in for sounddevice.PortAudioError."""
+
+
+class OpenInputStreamLadderTests(unittest.TestCase):
+    def _install_fake_sd(self):
+        """Install a fake ``sd`` module inside capture for a single test."""
+        fake = types.SimpleNamespace()
+        fake.PortAudioError = _FakePortAudioError
+
+        self.calls = []
+
+        def _fake_input_stream(**kwargs):
+            self.calls.append(kwargs)
+            # Behavior is driven by the test: self._responder is swapped in.
+            return self._responder(kwargs)
+
+        fake.InputStream = _fake_input_stream
+        fake.query_devices = lambda device: {"default_samplerate": 48000.0}
+
+        from whisper_sync import capture
+        self._orig_sd = capture.sd
+        capture.sd = fake
+        self.addCleanup(lambda: setattr(capture, "sd", self._orig_sd))
+
+    def setUp(self):
+        self._install_fake_sd()
+
+    def test_first_attempt_succeeds_returns_requested_rate(self):
+        self._responder = lambda kwargs: mock.Mock(name="stream")
+        from whisper_sync.capture import _open_input_stream
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 16000)
+        self.assertEqual(len(self.calls), 1)
+
+    def test_falls_back_to_native_samplerate_on_portaudio_error(self):
+        responses = [
+            _FakePortAudioError("MME error 32"),  # first try
+            mock.Mock(name="stream"),             # second try ok
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 48000)  # device default from fake query_devices
+        # First attempt at 16000, second at 48000
+        self.assertEqual(self.calls[0]["samplerate"], 16000)
+        self.assertEqual(self.calls[1]["samplerate"], 48000)
+
+    def test_falls_back_to_int16_when_float32_and_native_both_fail(self):
+        responses = [
+            _FakePortAudioError("float32/16k rejected"),
+            _FakePortAudioError("float32/48k rejected"),
+            mock.Mock(name="stream"),
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 48000)
+        self.assertEqual(self.calls[-1]["dtype"], "int16")
+
+    def test_reraises_if_all_attempts_fail(self):
+        def _responder(kwargs):
+            raise _FakePortAudioError("always fails")
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        with self.assertRaises(_FakePortAudioError):
+            _open_input_stream(
+                device=7, target_samplerate=16000, channels=1,
+                dtype="float32", callback=lambda *_: None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capture_recorder.py
+++ b/tests/test_capture_recorder.py
@@ -1,0 +1,142 @@
+"""Tests for AudioRecorder state transitions.
+
+These tests drive the recorder directly (without opening a real audio
+device) to pin behavior that review surfaced:
+
+  * start() must not leave ``_recording=True`` if the mic open fails
+    (Copilot review comment #3 on PR 125).
+  * start_streaming() must not flip ``_disk_only`` if the WAV writer
+    fails to open - otherwise the callback would silently skip both
+    RAM accumulation and disk write (comment #2).
+  * _mic_callback must normalize int16 samples to [-1, 1] BEFORE
+    resampling (comment #1).
+"""
+
+import types
+import unittest
+from unittest import mock
+
+import numpy as np
+
+
+class _FakePortAudioError(Exception):
+    pass
+
+
+def _make_recorder(install_fake_sd=True):
+    """Build an AudioRecorder with a fake sd module swapped in."""
+    from whisper_sync import capture
+    recorder = capture.AudioRecorder(sample_rate=16000)
+    if install_fake_sd:
+        fake = types.SimpleNamespace()
+        fake.PortAudioError = _FakePortAudioError
+        fake.InputStream = mock.Mock()
+        fake.query_devices = lambda device: {"default_samplerate": 48000.0}
+        capture.sd = fake
+    return recorder, capture
+
+
+class StartTransactionalTests(unittest.TestCase):
+    def test_recording_stays_false_when_open_fails(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        capture.sd.InputStream.side_effect = _FakePortAudioError("always fail")
+
+        with self.assertRaises(_FakePortAudioError):
+            recorder.start(mic_device=7)
+
+        self.assertFalse(recorder._recording)
+        self.assertIsNone(recorder._mic_stream)
+
+    def test_open_stream_is_closed_if_start_fails(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        stream = mock.Mock()
+        stream.start.side_effect = RuntimeError("start fails")
+        capture.sd.InputStream.return_value = stream
+
+        with self.assertRaises(RuntimeError):
+            recorder.start(mic_device=7)
+
+        stream.close.assert_called_once()
+        self.assertFalse(recorder._recording)
+        self.assertIsNone(recorder._mic_stream)
+
+
+class StartStreamingTransactionalTests(unittest.TestCase):
+    def test_disk_only_not_flipped_when_writer_fails(self):
+        recorder, capture = _make_recorder(install_fake_sd=False)
+        recorder._disk_only = False  # baseline
+
+        with mock.patch.object(capture, "StreamingWavWriter",
+                               side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                recorder.start_streaming(mic_path="/tmp/x.wav", disk_only=True)
+
+        self.assertFalse(recorder._disk_only,
+                         "_disk_only must stay False when writer open fails")
+        self.assertIsNone(recorder._mic_writer)
+
+
+class MicCallbackNormalizationTests(unittest.TestCase):
+    def test_int16_samples_are_scaled_to_minus_one_to_one(self):
+        from whisper_sync.capture import AudioRecorder
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder._recording = True
+        # Same-rate path (no resample). int16 input must be normalized.
+        recorder._mic_resample_up = 1
+        recorder._mic_resample_down = 1
+
+        int16_block = np.array([[32767], [-32768], [0]], dtype=np.int16)
+        recorder._mic_callback(int16_block, 3, None, None)
+
+        self.assertEqual(len(recorder._mic_data), 1)
+        out = recorder._mic_data[0]
+        self.assertEqual(out.dtype, np.float32)
+        # 32767/32768.0 ~= 1.0; -32768/32768.0 == -1.0; 0 == 0
+        self.assertAlmostEqual(float(out[0, 0]), 1.0, places=3)
+        self.assertAlmostEqual(float(out[1, 0]), -1.0, places=6)
+        self.assertAlmostEqual(float(out[2, 0]), 0.0, places=6)
+
+    def test_int16_with_resample_stays_normalized(self):
+        # Resample + int16 path was the original bug: values stayed in
+        # the [-32768, 32767] range and would clip catastrophically.
+        from whisper_sync.capture import AudioRecorder
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder._recording = True
+        recorder._mic_effective_rate = 48000
+        recorder._mic_resample_up = 1
+        recorder._mic_resample_down = 3
+
+        # A 48-sample int16 buffer at full positive scale.
+        block = np.full((48, 1), 32767, dtype=np.int16)
+        recorder._mic_callback(block, 48, None, None)
+
+        self.assertEqual(len(recorder._mic_data), 1)
+        out = recorder._mic_data[0]
+        self.assertEqual(out.dtype, np.float32)
+        # After resampling a constant signal, values should still be ~1.0,
+        # nowhere near 32767. Accept a generous upper bound.
+        peak = float(np.max(np.abs(out)))
+        self.assertLess(peak, 1.1,
+                        f"int16 was not normalized before resampling; peak={peak}")
+
+    def test_float32_passthrough_same_rate(self):
+        from whisper_sync.capture import AudioRecorder
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder._recording = True
+        recorder._mic_resample_up = 1
+        recorder._mic_resample_down = 1
+
+        block = np.array([[0.5], [-0.25], [0.0]], dtype=np.float32)
+        recorder._mic_callback(block, 3, None, None)
+
+        out = recorder._mic_data[0]
+        self.assertEqual(out.dtype, np.float32)
+        np.testing.assert_array_equal(out, block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_crash_diagnostics.py
+++ b/tests/test_crash_diagnostics.py
@@ -1,0 +1,27 @@
+"""Tests for whisper_sync.crash_diagnostics helpers."""
+
+import unittest
+
+
+class ExtractFaultingModuleTests(unittest.TestCase):
+    def test_extracts_tcl_module(self):
+        from whisper_sync.crash_diagnostics import _extract_faulting_module
+        msg = (
+            "Faulting application name: python.exe, version: 3.13.0.1013 "
+            "| Faulting module name: tcl86t.dll, version: 8.6.13.0 "
+            "| Exception code: 0xc0000005"
+        )
+        self.assertEqual(_extract_faulting_module(msg), "tcl86t.dll")
+
+    def test_extracts_torch_module(self):
+        from whisper_sync.crash_diagnostics import _extract_faulting_module
+        msg = "... Faulting module name: torch_cuda.dll ..."
+        self.assertEqual(_extract_faulting_module(msg), "torch_cuda.dll")
+
+    def test_returns_none_when_absent(self):
+        from whisper_sync.crash_diagnostics import _extract_faulting_module
+        self.assertIsNone(_extract_faulting_module("no module info here"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_faulthandler_install.py
+++ b/tests/test_faulthandler_install.py
@@ -1,0 +1,43 @@
+"""Tests for crash_diagnostics.install_faulthandler helper.
+
+Extracted from __main__.py so worker.py can use the same fix. The key
+property is that the opened file object is retained at module scope so
+it cannot be garbage-collected (which was the historic silent-death bug
+that lost native crash dumps).
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class InstallFaulthandlerTests(unittest.TestCase):
+    def test_returns_a_file_object_that_is_retained(self):
+        from whisper_sync import crash_diagnostics
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "fh.log"
+            f = crash_diagnostics.install_faulthandler(log_path)
+            try:
+                self.assertIsNotNone(f, "should return the opened file")
+                self.assertFalse(f.closed, "file must be open")
+                # The module should keep a strong ref so GC can't close it.
+                self.assertIs(crash_diagnostics._FAULTHANDLER_FILE, f)
+            finally:
+                crash_diagnostics._reset_faulthandler_for_tests()
+
+    def test_returns_none_on_bad_path_and_falls_back(self):
+        from whisper_sync import crash_diagnostics
+        # A subpath of a temp directory whose intermediate segment does not
+        # exist guarantees open("a") fails regardless of platform or prior
+        # filesystem state.
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "does-not-exist" / "fh.log"
+            result = crash_diagnostics.install_faulthandler(bad)
+            try:
+                self.assertIsNone(result)
+            finally:
+                crash_diagnostics._reset_faulthandler_for_tests()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_faulthandler_install.py
+++ b/tests/test_faulthandler_install.py
@@ -38,6 +38,27 @@ class InstallFaulthandlerTests(unittest.TestCase):
             finally:
                 crash_diagnostics._reset_faulthandler_for_tests()
 
+    def test_second_call_closes_previous_file_no_fd_leak(self):
+        # Regression for PR #127 review #4: calling install_faulthandler
+        # twice must not leak the previously retained file descriptor.
+        from whisper_sync import crash_diagnostics
+        with tempfile.TemporaryDirectory() as tmp:
+            first = crash_diagnostics.install_faulthandler(Path(tmp) / "first.log")
+            try:
+                self.assertIsNotNone(first)
+                self.assertFalse(first.closed)
+                second = crash_diagnostics.install_faulthandler(Path(tmp) / "second.log")
+                self.assertIsNotNone(second)
+                # The first handle must now be closed by the helper.
+                self.assertTrue(
+                    first.closed,
+                    "previous faulthandler file must be closed on re-install",
+                )
+                # And the module should only retain the newest one.
+                self.assertIs(crash_diagnostics._FAULTHANDLER_FILE, second)
+            finally:
+                crash_diagnostics._reset_faulthandler_for_tests()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,83 @@
+"""Tests for whisper_sync.heartbeat."""
+
+import io
+import logging
+import time
+import unittest
+
+
+class HeartbeatTests(unittest.TestCase):
+    def setUp(self):
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self.logger = logging.getLogger(f"test_heartbeat.{self.id()}")
+        self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_heartbeat_emits_lines_at_interval(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        try:
+            time.sleep(0.18)
+        finally:
+            hb.stop(timeout=0.5)
+        lines = [ln for ln in self.stream.getvalue().splitlines() if "heartbeat" in ln]
+        # Expect at least 2 heartbeats in ~180ms with 50ms interval
+        self.assertGreaterEqual(len(lines), 2)
+
+    def test_heartbeat_stops_cleanly(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        time.sleep(0.08)
+        hb.stop(timeout=0.5)
+        # After stop, no more heartbeats should fire
+        baseline = self.stream.getvalue().count("heartbeat")
+        time.sleep(0.15)
+        self.assertEqual(self.stream.getvalue().count("heartbeat"), baseline)
+
+    def test_start_twice_is_safe(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        hb.start()  # second start must not raise or leak a second thread
+        hb.stop(timeout=0.5)
+
+    def test_heartbeat_line_has_uptime(self):
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        time.sleep(0.1)
+        hb.stop(timeout=0.5)
+        output = self.stream.getvalue()
+        self.assertIn("uptime=", output)
+
+    def test_uptime_computed_even_when_started_at_is_zero(self):
+        # Regression for review #5: a 0.0 value for _started_at must not
+        # be treated as falsey (which `or` would do) and force uptime
+        # to collapse to ~0 forever.
+        from whisper_sync.heartbeat import Heartbeat
+        hb = Heartbeat(self.logger, interval=0.05)
+        hb.start()
+        # Overwrite after start() so the worker thread sees 0.0
+        hb._started_at = 0.0
+        time.sleep(0.12)
+        hb.stop(timeout=0.5)
+        import re
+        matches = re.findall(r"uptime=([\d.]+)s", self.stream.getvalue())
+        self.assertTrue(matches, "no heartbeat uptime lines captured")
+        # With _started_at=0.0 and monotonic typically >>0, uptime should
+        # be a large positive number. If `or` were still in place, the
+        # fallback would use time.monotonic() and uptime would collapse
+        # to ~0s each tick. With `is None`, it stays anchored at 0.
+        self.assertGreater(
+            float(matches[-1]), 1.0,
+            "uptime collapsed to ~0s — the `or` fallback is back",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,90 @@
+"""Tests for whisper_sync.lifecycle."""
+
+import io
+import logging
+import unittest
+
+
+class RecordExitReasonTests(unittest.TestCase):
+    def setUp(self):
+        from whisper_sync import lifecycle
+        lifecycle._reset_for_tests()
+
+    def test_default_reason_is_unknown(self):
+        from whisper_sync import lifecycle
+        reason, extra = lifecycle.get_exit_reason()
+        self.assertEqual(reason, "unknown")
+        self.assertEqual(extra, {})
+
+    def test_recording_reason_sets_state(self):
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("user_quit", {"menu": "tray"})
+        reason, extra = lifecycle.get_exit_reason()
+        self.assertEqual(reason, "user_quit")
+        self.assertEqual(extra, {"menu": "tray"})
+
+    def test_first_reason_wins(self):
+        # Once set, later calls should not overwrite the first recorded reason
+        # (prevents late-firing atexit callbacks from masking the real cause).
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("crash_worker", {"step": "transcribe"})
+        lifecycle.record_exit_reason("atexit")
+        reason, extra = lifecycle.get_exit_reason()
+        self.assertEqual(reason, "crash_worker")
+        self.assertEqual(extra, {"step": "transcribe"})
+
+
+class LogExitBannerTests(unittest.TestCase):
+    def setUp(self):
+        from whisper_sync import lifecycle
+        lifecycle._reset_for_tests()
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self.logger = logging.getLogger("test_lifecycle_exit")
+        self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_exit_banner_uses_recorded_reason(self):
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("user_quit", {"menu": "tray"})
+        lifecycle.log_exit_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("WhisperSync exiting", output)
+        self.assertIn("reason=user_quit", output)
+
+    def test_exit_banner_default_reason(self):
+        from whisper_sync import lifecycle
+        lifecycle.log_exit_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("reason=unknown", output)
+
+
+class StartupBannerTests(unittest.TestCase):
+    def setUp(self):
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self.logger = logging.getLogger("test_lifecycle_startup")
+        self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_startup_banner_includes_pid_and_python(self):
+        from whisper_sync import lifecycle
+        lifecycle.log_startup_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("pid=", output)
+        self.assertIn("python=", output)
+
+    def test_startup_banner_includes_git_sha_when_available(self):
+        # Banner should at least attempt a git SHA; missing is OK (returns 'unknown')
+        from whisper_sync import lifecycle
+        lifecycle.log_startup_banner(self.logger)
+        output = self.stream.getvalue()
+        self.assertIn("git=", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -60,6 +60,20 @@ class LogExitBannerTests(unittest.TestCase):
         output = self.stream.getvalue()
         self.assertIn("reason=unknown", output)
 
+    def test_exit_banner_is_idempotent(self):
+        # Regression for PR #127 review #1+#2: both quit() and the atexit
+        # hook call log_exit_banner. Without dedupe, every shutdown logs
+        # two banners.
+        from whisper_sync import lifecycle
+        lifecycle.record_exit_reason("user_quit")
+        lifecycle.log_exit_banner(self.logger)
+        lifecycle.log_exit_banner(self.logger)  # simulate atexit firing
+        lifecycle.log_exit_banner(self.logger)  # belt and suspenders
+        banners = [ln for ln in self.stream.getvalue().splitlines()
+                   if "WhisperSync exiting" in ln]
+        self.assertEqual(len(banners), 1,
+                         f"expected exactly 1 banner, got {len(banners)}: {banners}")
+
 
 class StartupBannerTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_lifecycle_reasons.py
+++ b/tests/test_lifecycle_reasons.py
@@ -1,0 +1,40 @@
+"""Tests for exit-reason constants in whisper_sync.lifecycle.
+
+The lifecycle module is the grep anchor for forensic log analysis. Exit
+reasons scattered as raw strings across call sites drift over time; these
+tests pin the canonical values so greppers and dashboards don't break
+silently.
+"""
+
+import unittest
+
+
+class ExitReasonConstantsTests(unittest.TestCase):
+    def test_all_known_reasons_exported(self):
+        from whisper_sync import lifecycle
+        expected = {
+            "REASON_UNKNOWN": "unknown",
+            "REASON_USER_QUIT": "user_quit",
+            "REASON_USER_RESTART": "user_restart",
+            "REASON_ATEXIT": "atexit",
+            "REASON_SIGNAL": "signal",
+            "REASON_EXCEPTION": "exception",
+            "REASON_SYSTEM_EXIT": "system_exit",
+        }
+        for name, value in expected.items():
+            self.assertTrue(
+                hasattr(lifecycle, name),
+                f"lifecycle.{name} is not exported",
+            )
+            self.assertEqual(getattr(lifecycle, name), value)
+
+    def test_default_get_exit_reason_uses_constant(self):
+        # Sanity: the default sentinel matches the exported constant
+        from whisper_sync import lifecycle
+        lifecycle._reset_for_tests()
+        reason, _ = lifecycle.get_exit_reason()
+        self.assertEqual(reason, lifecycle.REASON_UNKNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meeting_job.py
+++ b/tests/test_meeting_job.py
@@ -1,0 +1,71 @@
+"""Tests for whisper_sync.meeting_job.MeetingJob.execute_next_step.
+
+Only the step-driver behavior is exercised here. The actual step
+implementations touch the worker subprocess / filesystem / state manager
+and are out of scope.
+"""
+
+import unittest
+from pathlib import Path
+
+
+class _StubApp:
+    """Minimal stand-in for the WhisperSync application object."""
+
+
+def _make_job(steps):
+    from whisper_sync.meeting_job import MeetingJob
+
+    job = MeetingJob(
+        app=_StubApp(),
+        wav_path=Path("/tmp/x.wav"),
+        meeting_dir=Path("/tmp/x"),
+        name="unit-test",
+        summarize=False,
+        date_time_str="0101_0000",
+        week_dir="01-w1",
+        folder_name="0101_0000_unit-test",
+    )
+    # Replace real steps with cheap callables so we can exercise the driver
+    # without touching the worker/filesystem.
+    job._steps = list(steps)
+    return job
+
+
+class ExecuteNextStepTests(unittest.TestCase):
+    def test_successful_step_advances_index(self):
+        calls = []
+        job = _make_job([lambda: calls.append("a"), lambda: calls.append("b")])
+        self.assertEqual(job._current_step, 0)
+        job.execute_next_step()
+        self.assertEqual(job._current_step, 1)
+        job.execute_next_step()
+        self.assertEqual(job._current_step, 2)
+        self.assertTrue(job.is_complete)
+
+    def test_failed_step_does_not_advance_index(self):
+        # Regression for review #2: the step index must not be 'consumed'
+        # when a step raises — otherwise a retry/inspection would think
+        # the step completed.
+        def _boom():
+            raise RuntimeError("kaboom")
+        job = _make_job([_boom, lambda: None])
+        self.assertEqual(job._current_step, 0)
+        with self.assertRaises(RuntimeError):
+            job.execute_next_step()
+        self.assertEqual(
+            job._current_step, 0,
+            "failed step should leave _current_step unchanged",
+        )
+
+    def test_returns_true_when_more_steps_remain(self):
+        job = _make_job([lambda: None, lambda: None])
+        self.assertTrue(job.execute_next_step())
+
+    def test_returns_false_when_complete(self):
+        job = _make_job([lambda: None])
+        self.assertFalse(job.execute_next_step())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,33 @@
+"""Tests for whisper_sync.notifications.
+
+Focused on the toast registry. ``meeting_completed`` toasts are fired
+directly from ``MeetingJob.step_notify`` (which uses an explicit body
+and attaches an Open Folder button). The state-driven
+``ToastListener`` previously also had a template entry, which fired on
+the ``MEETING_COMPLETED`` state event without the ``{words}``/``{speakers}``
+keys and produced ``KeyError`` noise at DEBUG. The registry entry is
+the source of that noise, so it is removed.
+"""
+
+import unittest
+
+
+class ToastRegistryTests(unittest.TestCase):
+    def test_meeting_completed_not_in_registry(self):
+        from whisper_sync.notifications import TOAST_REGISTRY
+        self.assertNotIn(
+            "meeting_completed",
+            TOAST_REGISTRY,
+            "meeting_completed toast is owned by MeetingJob.step_notify; "
+            "the template path was misfiring and must be absent.",
+        )
+
+    def test_error_template_still_present(self):
+        # Guardrail: ensure the trim didn't accidentally drop other entries.
+        from whisper_sync.notifications import TOAST_REGISTRY
+        self.assertIn("error", TOAST_REGISTRY)
+        self.assertIn("dictation_completed", TOAST_REGISTRY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifications_helper.py
+++ b/tests/test_notifications_helper.py
@@ -1,0 +1,51 @@
+"""Tests for notifications.is_toast_enabled helper.
+
+Extracted so both the ToastListener and MeetingJob.step_notify can share
+the same config-gate logic rather than each implementing its own
+isinstance-check + membership-check pair.
+"""
+
+import unittest
+
+
+class IsToastEnabledTests(unittest.TestCase):
+    def test_event_in_config_list(self):
+        from whisper_sync.notifications import is_toast_enabled
+        self.assertTrue(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": ["meeting_completed", "error"]})
+        )
+
+    def test_event_absent_from_config(self):
+        from whisper_sync.notifications import is_toast_enabled
+        self.assertFalse(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": ["error"]})
+        )
+
+    def test_missing_config_falls_back_to_defaults(self):
+        from whisper_sync.notifications import is_toast_enabled, DEFAULT_TOAST_EVENTS
+        # Empty cfg => defaults apply; meeting_completed is in defaults
+        self.assertIn("meeting_completed", DEFAULT_TOAST_EVENTS)
+        self.assertTrue(is_toast_enabled("meeting_completed", {}))
+
+    def test_garbage_config_value_falls_back_to_defaults(self):
+        from whisper_sync.notifications import is_toast_enabled
+        # Non-iterable junk should not crash; defaults apply instead
+        self.assertTrue(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": "nonsense"})
+        )
+        self.assertTrue(
+            is_toast_enabled("meeting_completed",
+                             {"toast_events": None})
+        )
+
+    def test_none_cfg_tolerated(self):
+        from whisper_sync.notifications import is_toast_enabled
+        # step_notify may pass None/empty cfg defensively
+        self.assertTrue(is_toast_enabled("meeting_completed", None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -51,7 +51,9 @@ from . import dictation_log
 from . import feature_log
 from . import weekly_stats
 from .streaming_wav import fix_orphan
-from .crash_diagnostics import install_excepthook, check_previous_crash
+from .crash_diagnostics import install_excepthook, check_previous_crash, install_faulthandler
+from . import lifecycle
+from .heartbeat import Heartbeat
 from .flatten import flatten as flatten_transcript
 from .notifications import notify, ToastListener
 from .state_manager import (
@@ -389,8 +391,18 @@ class WhisperSync:
         self.state.emit(DICTATION_STARTED, mode="dictation")
         mic = self.cfg.get("mic_device")
         if self.cfg.get("use_system_devices", True):
-            mic = None
-        self.recorder.start(mic_device=mic)
+            # Explicitly use the WASAPI default instead of falling through
+            # to sd.default.device[0], which on Windows resolves to an MME
+            # device and often rejects float32 @ 16 kHz with MME error 32.
+            mic = get_default_devices().get("input")
+        try:
+            self.recorder.start(mic_device=mic)
+        except Exception as e:
+            logger.error("Failed to start mic for dictation: %s", e, exc_info=True)
+            notify("Dictation unavailable", f"Mic could not be opened: {e}")
+            self._feature_suggest_active = False
+            self.state.emit(IDLE, mode=None)
+            return
         # Stream to disk for crash recovery -- skip when incognito (RAM only)
         if self.cfg.get("incognito", False):
             self._dictation_wav_path = None
@@ -400,7 +412,11 @@ class WhisperSync:
             ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             prefix = "feature_" if self._feature_suggest_active else ""
             self._dictation_wav_path = log_dir / f"{prefix}{ts}.wav"
-            self.recorder.start_streaming(self._dictation_wav_path)
+            try:
+                self.recorder.start_streaming(self._dictation_wav_path)
+            except Exception as e:
+                logger.warning("Dictation disk streaming disabled: %s", e)
+                self._dictation_wav_path = None
 
     def _stop_dictation(self):
         audio = self.recorder.stop()
@@ -549,8 +565,15 @@ class WhisperSync:
         self._overlay_recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
         mic = self.cfg.get("mic_device")
         if self.cfg.get("use_system_devices", True):
-            mic = None
-        self._overlay_recorder.start(mic_device=mic)
+            mic = get_default_devices().get("input")
+        try:
+            self._overlay_recorder.start(mic_device=mic)
+        except Exception as e:
+            logger.error("Failed to start overlay dictation mic: %s", e, exc_info=True)
+            notify("Dictation unavailable", f"Mic could not be opened: {e}")
+            self._overlay_recorder = None
+            self._feature_suggest_active = False
+            return
         logger.info("Dictation during meeting: recording started", extra={"secondary": True})
         self.state.emit(DICTATION_STARTED, dictation_overlay=True)
 
@@ -1031,20 +1054,30 @@ class WhisperSync:
         mic = self.cfg.get("mic_device")
         speaker = self.cfg.get("speaker_device")
         if self.cfg.get("use_system_devices", True):
-            mic = None
             defaults = get_default_devices()
+            # Route mic through WASAPI too (not sd.default.device[0]'s MME)
+            mic = defaults.get("input")
             speaker = defaults["output"]
         elif speaker is None:
             defaults = get_default_devices()
             speaker = defaults["output"]
-        self.recorder.start(mic_device=mic, speaker_device=speaker)
+        try:
+            self.recorder.start(mic_device=mic, speaker_device=speaker)
+        except Exception as e:
+            logger.error("Failed to start mic for meeting: %s", e, exc_info=True)
+            notify("Meeting unavailable", f"Mic could not be opened: {e}")
+            self.state.emit(IDLE, mode=None)
+            return
         if self.recorder.speaker_loopback_active:
             logger.info("Meeting started: mic + speaker loopback")
         else:
             logger.warning("Meeting started: mic only (speaker loopback unavailable)")
         temp = self._meeting_temp_dir()
         mic_temp = temp / "mic-temp.wav"
-        self.recorder.start_streaming(mic_temp, disk_only=True)
+        try:
+            self.recorder.start_streaming(mic_temp, disk_only=True)
+        except Exception as e:
+            logger.warning("Meeting streaming disabled: %s", e)
         if self.cfg.get("always_available_dictation", True):
             self._backup.preload()
 
@@ -1106,6 +1139,9 @@ class WhisperSync:
             (str, True, str|None): user clicked Save & Summarize (name, summarize, diarize_method)
             (str, False, str|None): user clicked Save (name, summarize, diarize_method)
         """
+        import time as _time
+        dialog_started = _time.monotonic()
+        logger.info("dialog open: _ask_meeting_name")
         result = [self._ABORT]
         event = threading.Event()
 
@@ -1215,11 +1251,46 @@ class WhisperSync:
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _abort)
             root.mainloop()
-            event.set()
 
-        t = threading.Thread(target=_show_dialog, daemon=True)
+        def _show_dialog_guarded():
+            # Guarantees event.set() + a well-defined outcome even if
+            # _show_dialog raises before root.mainloop() returns. Without
+            # this, _save_and_enqueue's event.wait() blocks forever and the
+            # tray stays stuck in mode="saving" with the recording neither
+            # saved nor discarded.
+            try:
+                _show_dialog()
+            except Exception:
+                logger.exception("dialog crashed: _ask_meeting_name")
+                result[0] = self._ABORT
+            finally:
+                event.set()
+
+        t = threading.Thread(target=_show_dialog_guarded, daemon=True)
         t.start()
-        event.wait(timeout=60)
+        # Previously this used a 60s timeout that silently returned _ABORT
+        # while the dialog was still on screen — discarding the recording
+        # while the user thought they were still naming it. The dialog
+        # itself has no auto-close timer, so we wait as long as it's open.
+        event.wait()
+
+        # Report dialog outcome with the actual returned value so forensic
+        # logs can distinguish ABORT vs save vs timeout vs garbage.
+        elapsed = _time.monotonic() - dialog_started
+        outcome = result[0]
+        if outcome is self._ABORT:
+            logger.info("dialog close: _ask_meeting_name outcome=abort elapsed=%.1fs", elapsed)
+        elif isinstance(outcome, tuple) and len(outcome) == 3:
+            name, summarize, method = outcome
+            logger.info(
+                "dialog close: _ask_meeting_name outcome=save name=%r summarize=%s method=%s elapsed=%.1fs",
+                name or "", summarize, method, elapsed,
+            )
+        else:
+            logger.warning(
+                "dialog close: _ask_meeting_name outcome=unexpected value=%r elapsed=%.1fs",
+                outcome, elapsed,
+            )
 
         return result[0]
 
@@ -1426,9 +1497,9 @@ class WhisperSync:
             screen_h = root.winfo_screenheight()
             max_h = min(700, int(screen_h * 0.8))
             # Size to content, capped at max_h. When content exceeds the cap,
-            # the rows scroll via the Canvas+Scrollbar below and the bottom
-            # button bar stays visible because it is packed with side=BOTTOM
-            # BEFORE the scrollable middle.
+            # the middle content scrolls via the inline Canvas/Scrollbar setup,
+            # and the bottom button bar remains visible because it is packed
+            # with side=BOTTOM BEFORE the scrollable middle.
             height = min(180 + (num_speakers * 70), max_h)
             root.geometry(f"500x{height}")
             root.minsize(500, 260)  # guarantee the buttons are always reachable
@@ -1440,15 +1511,17 @@ class WhisperSync:
             tk.Label(header, text="  Identify Speakers", font=("Segoe UI", 11, "bold"),
                      bg=bg, fg=fg).pack(side=tk.LEFT)
 
-            # Bottom panel: progress + boundary notice + buttons. Packed
-            # NOW (before the scrollable middle) with side=BOTTOM so Tk's
-            # pack algorithm reserves space for them regardless of how
+            # Bottom panel: progress + boundary notice + buttons. These are
+            # packed NOW (before the scrollable middle) with side=BOTTOM so
+            # Tk's pack algorithm reserves space for them regardless of how
             # many speakers are added; the Confirm button never slides off.
             bottom_panel = tk.Frame(root, bg=bg)
             bottom_panel.pack(side=tk.BOTTOM, fill="x")
 
-            # Scrollable middle: Canvas + Scrollbar + inner Frame. Tk has
-            # no native scrollable frame; this is the standard idiom.
+            # Scrollable middle: contains speaker rows + reasoning text.
+            # Tk does not have a native scrollable frame; the idiom is a
+            # Canvas + Scrollbar + inner Frame. The inner frame behaves like
+            # a normal Frame you can pack into.
             middle = tk.Frame(root, bg=bg)
             middle.pack(side=tk.TOP, fill="both", expand=True, padx=0, pady=(12, 0))
             _scroll_canvas = tk.Canvas(middle, bg=bg, highlightthickness=0)
@@ -1457,7 +1530,6 @@ class WhisperSync:
             _scrollbar.pack(side=tk.RIGHT, fill="y")
             _scroll_canvas.configure(yscrollcommand=_scrollbar.set)
 
-            dropdowns = {}
             rows_frame = tk.Frame(_scroll_canvas, bg=bg)
             _rows_window = _scroll_canvas.create_window((0, 0), window=rows_frame, anchor="nw")
 
@@ -1466,17 +1538,20 @@ class WhisperSync:
             rows_frame.bind("<Configure>", _on_rows_configure)
 
             def _on_canvas_configure(event):
-                # Match the inner frame width so content wraps correctly.
+                # Make the inner frame match the canvas width so content wraps
+                # correctly instead of being clipped horizontally.
                 _scroll_canvas.itemconfigure(_rows_window, width=event.width)
             _scroll_canvas.bind("<Configure>", _on_canvas_configure)
 
             def _on_mousewheel(event):
                 # Windows: event.delta is a multiple of 120 per notch.
                 _scroll_canvas.yview_scroll(int(-event.delta / 120), "units")
-            # Bind only while the pointer is over the canvas so child
-            # widgets (dropdowns) keep their own wheel events.
+            # Bind only when the mouse is over the canvas so we don't steal
+            # wheel events from child dropdowns.
             _scroll_canvas.bind("<Enter>", lambda _e: _scroll_canvas.bind_all("<MouseWheel>", _on_mousewheel))
             _scroll_canvas.bind("<Leave>", lambda _e: _scroll_canvas.unbind_all("<MouseWheel>"))
+
+            dropdowns = {}
 
             for spk_id, name in speaker_map.items():
                 row = tk.Frame(rows_frame, bg=card_bg, highlightbackground="#313244", highlightthickness=1)
@@ -1762,11 +1837,25 @@ class WhisperSync:
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _skip)
             root.mainloop()
-            event.set()
 
-        t = threading.Thread(target=_show, daemon=True)
+        def _show_guarded():
+            # Guarantees event.set() fires even if Tk init/geometry raises.
+            # Without this, a crash in _show would hang the meeting
+            # post-processing pipeline indefinitely waiting on the event.
+            try:
+                _show()
+            except Exception:
+                logger.exception("speaker dialog crashed")
+                result[0] = None
+            finally:
+                event.set()
+
+        t = threading.Thread(target=_show_guarded, daemon=True)
         t.start()
-        event.wait(timeout=120)
+        # Wait as long as the user needs. A 2-minute timeout would silently
+        # skip speaker confirmation while the dialog was still on screen:
+        # data loss with no log.
+        event.wait()
 
         return result[0]
 
@@ -3255,6 +3344,7 @@ class WhisperSync:
         def _do_restart():
             import subprocess
             import time
+            lifecycle.record_exit_reason(lifecycle.REASON_USER_RESTART)
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
             # Spawn new process first so it starts loading immediately
@@ -3268,6 +3358,7 @@ class WhisperSync:
             if self.tray:
                 self.tray.stop()
             time.sleep(0.2)
+            lifecycle.log_exit_banner(logger)
             os._exit(0)
 
         threading.Thread(target=_do_restart, daemon=True).start()
@@ -3276,10 +3367,17 @@ class WhisperSync:
         """Quit WhisperSync. Deferred like _restart for the same reason."""
         def _do_quit():
             import time
+            lifecycle.record_exit_reason(lifecycle.REASON_USER_QUIT)
             time.sleep(self._CALLBACK_DEFER_SECS)
             self._cleanup()
             if self.tray:
                 self.tray.stop()
+            # Explicit banner for symmetry with _restart. In theory the
+            # atexit hook emits one when the interpreter shuts down, but
+            # daemon threads keeping the interpreter alive can swallow
+            # atexit; better to log here and let atexit be a no-op via
+            # the first-wins rule in record_exit_reason.
+            lifecycle.log_exit_banner(logger)
         threading.Thread(target=_do_quit, daemon=True).start()
 
     @staticmethod
@@ -3350,21 +3448,38 @@ class WhisperSync:
         # Bootstrap: ensure base models are cached, prompt for large ones
         bootstrap_models(self.cfg, on_large_model=self._prompt_large_download)
 
+        def _guarded(fn, label):
+            # Any exception that escapes a hotkey callback propagates to
+            # keyboard._generic.process and kills the single dispatcher
+            # thread, bricking ALL hotkeys for the rest of the session.
+            # This wrapper is the last line of defense; individual handlers
+            # also try/except their own failures.
+            def _inner():
+                try:
+                    return fn()
+                except Exception as e:
+                    logger.error("%s hotkey handler crashed: %s", label, e, exc_info=True)
+                    try:
+                        notify("WhisperSync error", f"{label}: {e}")
+                    except Exception:
+                        pass
+            return _inner
+
         keyboard.add_hotkey(
             self.cfg["hotkeys"]["dictation_toggle"],
-            self.toggle_dictation,
+            _guarded(self.toggle_dictation, "dictation"),
             suppress=False,
         )
         keyboard.add_hotkey(
             self.cfg["hotkeys"]["meeting_toggle"],
-            self.toggle_meeting,
+            _guarded(self.toggle_meeting, "meeting"),
             suppress=False,
         )
         feature_hk = self.cfg["hotkeys"].get("feature_suggest", "ctrl+shift+alt+f")
         if feature_hk:
             keyboard.add_hotkey(
                 feature_hk,
-                self.toggle_feature_suggest,
+                _guarded(self.toggle_feature_suggest, "feature-suggest"),
                 suppress=False,
             )
 
@@ -3483,19 +3598,28 @@ class WhisperSync:
 
 
 def main():
-    # Enable faulthandler FIRST so native segfaults get logged to the log file
+    # Install faulthandler FIRST so native segfaults are persisted. The
+    # helper retains the file handle module-scope so it cannot be GC'd.
+    install_faulthandler(get_log_path())
+
+    heartbeat = Heartbeat(logger, interval=60.0)
     try:
-        faulthandler.enable(file=open(get_log_path(), "a"), all_threads=True)
-    except Exception:
-        faulthandler.enable()  # fallback to stderr
-    try:
-        logger.info("=== WhisperSync starting ===")
+        lifecycle.log_startup_banner(logger)
+        lifecycle.install(logger)
         install_excepthook(logger)
         check_previous_crash(logger)
+        heartbeat.start()
         app = WhisperSync()
         app.run()
+    except SystemExit:
+        lifecycle.record_exit_reason(lifecycle.REASON_SYSTEM_EXIT)
+        raise
     except Exception:
         import traceback
+        lifecycle.record_exit_reason(
+            lifecycle.REASON_EXCEPTION,
+            {"type": type(sys.exc_info()[1]).__name__},
+        )
         logger.critical(f"FATAL CRASH:\n{traceback.format_exc()}")
         # Last-resort hook cleanup — prevents stuck Ctrl key on crash
         try:
@@ -3503,6 +3627,8 @@ def main():
         except Exception:
             pass
         raise
+    finally:
+        heartbeat.stop(timeout=1.0)
 
 
 if __name__ == "__main__":

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -1,11 +1,13 @@
-"""Audio capture — mic and system audio (WASAPI loopback on Windows)."""
+"""Audio capture - mic and system audio (WASAPI loopback on Windows)."""
 
 import threading
 import wave
+from math import gcd
 from pathlib import Path
 
 import numpy as np
 import sounddevice as sd
+from scipy.signal import resample_poly
 
 try:
     import pyaudiowpatch as pyaudio
@@ -51,9 +53,73 @@ def get_default_devices(api_filter: str | None = "WASAPI") -> dict:
     return {"input": defaults[0], "output": defaults[1]}
 
 
+def _open_input_stream(*, device, target_samplerate: int, channels: int,
+                       dtype: str, callback):
+    """Open ``sd.InputStream`` with a fallback ladder for format rejections.
+
+    On Windows, ``device=None`` often resolves to an MME device that rejects
+    ``float32 @ 16000 Hz`` with ``PaErrorCode -9999 / MME error 32`` even
+    though the hardware supports the format under WASAPI. Without this
+    retry, a single failed open propagates out of the hotkey handler and
+    kills the keyboard dispatcher thread, bricking all further hotkeys.
+
+    Retry ladder:
+      1. Caller-requested ``target_samplerate`` at ``dtype``.
+      2. Device's native ``default_samplerate`` at the same ``dtype``.
+      3. Device's native ``default_samplerate`` at ``int16``.
+
+    Returns ``(stream, effective_samplerate)``. Callers are responsible
+    for resampling downstream audio when the effective rate differs from
+    the target.
+
+    Reraises the last ``PortAudioError`` if every attempt fails.
+    """
+    attempts = [(target_samplerate, dtype)]
+    try:
+        native = int(sd.query_devices(device)["default_samplerate"])
+    except Exception:
+        native = None
+    if native and native != target_samplerate:
+        attempts.append((native, dtype))
+        attempts.append((native, "int16"))
+    else:
+        attempts.append((target_samplerate, "int16"))
+
+    last_err = None
+    for rate, this_dtype in attempts:
+        try:
+            stream = sd.InputStream(
+                samplerate=rate,
+                channels=channels,
+                dtype=this_dtype,
+                device=device,
+                callback=callback,
+            )
+            if rate != target_samplerate or this_dtype != dtype:
+                logger.warning(
+                    "mic: requested %d Hz %s rejected; using %d Hz %s",
+                    target_samplerate, dtype, rate, this_dtype,
+                )
+            return stream, rate
+        except sd.PortAudioError as e:
+            last_err = e
+            logger.debug("mic open attempt failed (rate=%s dtype=%s): %s", rate, this_dtype, e)
+    assert last_err is not None
+    raise last_err
+
+
 class AudioRecorder:
     def __init__(self, sample_rate: int = 16000):
         self.sample_rate = sample_rate
+        # Effective mic samplerate for the current session. Usually matches
+        # ``sample_rate``, but ``_open_input_stream`` may fall back to the
+        # device's native rate if the requested rate is rejected.
+        self._mic_effective_rate: int = sample_rate
+        # Precomputed resample ratio for the current session. Set in
+        # ``start()`` alongside the stream so the audio callback never
+        # recomputes it per buffer.
+        self._mic_resample_up: int = 1
+        self._mic_resample_down: int = 1
         self._mic_data: list[np.ndarray] = []
         self._speaker_data: list[np.ndarray] = []
         self._mic_stream = None
@@ -70,11 +136,39 @@ class AudioRecorder:
 
     def _mic_callback(self, indata, frames, time_info, status):
         try:
-            if self._recording:
-                if not self._disk_only:
-                    self._mic_data.append(indata.copy())
-                if self._mic_writer is not None:
-                    self._mic_writer.write(indata)
+            if not self._recording:
+                return
+
+            # Normalize to float32 in [-1, 1] regardless of what dtype the
+            # device actually produced. Integer samples must be scaled
+            # BEFORE resampling, otherwise downstream audio stays in the
+            # ~[-32768, 32767] range and clips catastrophically when
+            # written to disk or fed to the transcriber.
+            if indata.dtype == np.int16:
+                normalized = indata.astype(np.float32) / 32768.0
+            elif indata.dtype != np.float32:
+                normalized = indata.astype(np.float32)
+            else:
+                normalized = indata
+
+            # Resample to the canonical sample_rate only when the device
+            # fell back to its native rate. up/down are precomputed in
+            # start() so the callback is a single resample_poly call.
+            if self._mic_resample_up != self._mic_resample_down:
+                # Mono view; reshape(-1) avoids the copy flatten() would do.
+                mono = normalized.reshape(-1)
+                resampled = resample_poly(mono, self._mic_resample_up, self._mic_resample_down)
+                data = resampled.reshape(-1, 1).astype(np.float32, copy=False)
+            else:
+                data = normalized
+
+            if not self._disk_only:
+                # Always copy into the accumulator - PortAudio reuses the
+                # indata buffer for the next callback, and normalized may
+                # alias indata on the float32 no-op path.
+                self._mic_data.append(data.copy() if data is indata else data)
+            if self._mic_writer is not None:
+                self._mic_writer.write(data)
         except Exception as e:
             # Never let exceptions escape into PortAudio's C thread
             if not getattr(self, "_mic_error_logged", False):
@@ -98,16 +192,40 @@ class AudioRecorder:
             self._speaker_data = []
             self._mic_error_logged = False
             self._speaker_error_logged = False
-            self._recording = True
 
-            self._mic_stream = sd.InputStream(
-                samplerate=self.sample_rate,
-                channels=1,
-                dtype="float32",
-                device=mic_device,
-                callback=self._mic_callback,
-            )
-            self._mic_stream.start()
+            # Transactional: the recorder only becomes "recording" AFTER
+            # the mic stream is fully open and started. On any failure we
+            # close a partially created stream and leave ``_recording``
+            # False so stop()/subsequent starts see a clean state.
+            stream = None
+            try:
+                stream, effective_rate = _open_input_stream(
+                    device=mic_device,
+                    target_samplerate=self.sample_rate,
+                    channels=1,
+                    dtype="float32",
+                    callback=self._mic_callback,
+                )
+                stream.start()
+            except Exception:
+                if stream is not None:
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
+                raise
+
+            self._mic_stream = stream
+            self._mic_effective_rate = effective_rate
+            # Precompute the resample ratio once per session.
+            if effective_rate != self.sample_rate:
+                g = gcd(self.sample_rate, effective_rate)
+                self._mic_resample_up = self.sample_rate // g
+                self._mic_resample_down = effective_rate // g
+            else:
+                self._mic_resample_up = 1
+                self._mic_resample_down = 1
+            self._recording = True
 
             if speaker_device is not None:
                 self._start_speaker_loopback()
@@ -231,11 +349,20 @@ class AudioRecorder:
         Args:
             mic_path: Path for mic WAV file.
             speaker_path: Optional path for speaker WAV file.
-            disk_only: If True, skip RAM accumulation — audio lives only on disk.
+            disk_only: If True, skip RAM accumulation -- audio lives only on disk.
                 Use for long meetings to prevent MemoryError.
+
+        Transactional: if ``StreamingWavWriter`` raises (e.g. unwritable
+        disk), the ``_disk_only`` flag is NOT flipped, so the callback
+        continues to accumulate into RAM and the meeting is still usable.
         """
+        writer = StreamingWavWriter(mic_path, channels=1, rate=self.sample_rate)
+        # Only commit state after the writer is successfully opened. The
+        # old ordering flipped _disk_only first; a writer-open failure
+        # then left the callback skipping BOTH RAM and disk and the
+        # meeting silently captured nothing.
+        self._mic_writer = writer
         self._disk_only = disk_only
-        self._mic_writer = StreamingWavWriter(mic_path, channels=1, rate=self.sample_rate)
 
     def stop_streaming(self):
         """Close and finalize streaming WAV writers."""
@@ -247,16 +374,30 @@ class AudioRecorder:
             self._speaker_writer = None
 
     def discard_streaming(self):
-        """Close writers and delete the temp files."""
+        """Close writers and delete the temp files.
+
+        Logs each discarded channel (path + size) so the forensic record
+        shows exactly which recording was dropped when the user aborts
+        the meeting-name dialog or the app decides to discard.
+        """
         from .streaming_wav import cleanup_temp_files
         parent = None
-        for w in (self._mic_writer, self._speaker_writer):
-            if w is not None:
-                parent = w.path.parent
-                try:
-                    w.close()
-                except Exception:
-                    pass
+        for label, w in (("mic", self._mic_writer), ("speaker", self._speaker_writer)):
+            if w is None:
+                continue
+            parent = w.path.parent
+            try:
+                size = w.path.stat().st_size
+            except OSError:
+                size = 0
+            logger.info(
+                "discard_streaming: channel=%s path=%s size=%d",
+                label, w.path, size,
+            )
+            try:
+                w.close()
+            except Exception:
+                logger.debug("discard_streaming: close failed for %s", label, exc_info=True)
         self._mic_writer = None
         self._speaker_writer = None
         if parent is not None:

--- a/whisper_sync/crash_diagnostics.py
+++ b/whisper_sync/crash_diagnostics.py
@@ -1,14 +1,78 @@
-"""Crash diagnostics — exception hooks and Windows Event Log check.
+"""Crash diagnostics - exception hooks and Windows Event Log check.
 
 Zero runtime cost: excepthook is a passive function pointer,
 Event Log is queried once at startup.
 """
 
+import faulthandler
 import logging
 import subprocess
 import sys
 import threading
 import traceback
+from pathlib import Path
+
+# Module-level reference to the faulthandler log file. Without a strong ref,
+# the FileIO can be garbage-collected, its fd closes, and later native crash
+# dumps are silently lost, which is exactly what produced the historic
+# silent-death logs with no forensic trace. Both the main tray process and
+# the worker subprocess install their faulthandler via this module so the
+# fix applies uniformly.
+_FAULTHANDLER_FILE = None
+
+
+def _reset_faulthandler_for_tests() -> None:
+    """Test-only: close and drop the retained faulthandler file."""
+    global _FAULTHANDLER_FILE
+    try:
+        if _FAULTHANDLER_FILE is not None and not _FAULTHANDLER_FILE.closed:
+            _FAULTHANDLER_FILE.close()
+    except Exception:
+        pass
+    _FAULTHANDLER_FILE = None
+
+
+def install_faulthandler(log_path) -> "object | None":
+    """Enable ``faulthandler`` with a retained log file.
+
+    Opens ``log_path`` in line-buffered append mode, stores the handle at
+    module scope so CPython cannot GC it, then registers the handle with
+    ``faulthandler.enable``. On any failure (path not writable, enable
+    raising), closes the file, clears the retained ref, and best-effort
+    falls back to the stderr default with ``all_threads=True`` so thread
+    crashes are still captured.
+
+    Returns the open file object on success, ``None`` if the file-backed
+    install failed (stderr fallback may still be active).
+    """
+    global _FAULTHANDLER_FILE
+
+    def _fallback_to_stderr():
+        try:
+            faulthandler.enable(all_threads=True)
+        except Exception:
+            pass
+
+    try:
+        f = open(Path(log_path), "a", buffering=1, encoding="utf-8")
+    except (OSError, ValueError):
+        _fallback_to_stderr()
+        return None
+
+    _FAULTHANDLER_FILE = f
+    try:
+        faulthandler.enable(file=f, all_threads=True)
+    except Exception:
+        # enable() failed with the file. Release the file and fall back
+        # to stderr so thread crashes are still captured.
+        try:
+            f.close()
+        except Exception:
+            pass
+        _FAULTHANDLER_FILE = None
+        _fallback_to_stderr()
+        return None
+    return f
 
 
 def install_excepthook(log: logging.Logger) -> None:
@@ -52,9 +116,13 @@ def install_excepthook(log: logging.Logger) -> None:
 def check_previous_crash(log: logging.Logger) -> str | None:
     """Query Windows Event Log for recent python.exe crashes.
 
-    Looks for 'Application Error' events from the last 24 hours
-    matching our venv's python.exe path. Returns a summary string
-    if found, or None.
+    Looks for 'Application Error' events from the last 24 hours matching
+    our venv's python.exe path. Now pulls a larger slice of each event
+    message (the first ~12 lines) so the faulting module name and offset
+    are surfaced — without that detail we can't tell a Tcl/Tk crash from
+    a torch-DLL crash from a Python runtime crash.
+
+    Returns the summary string if any events were found, else None.
     """
     python_exe = sys.executable.replace("\\", "\\\\")
 
@@ -66,8 +134,11 @@ def check_previous_crash(log: logging.Logger) -> str | None:
         "} -ErrorAction SilentlyContinue "
         f"| Where-Object {{ $_.Message -like '*{python_exe}*' }} "
         "| Select-Object -First 3 "
-        "| ForEach-Object { $_.TimeCreated.ToString('HH:mm:ss') + ' | ' + "
-        "($_.Message -split \"`n\" | Select-Object -First 2) -join ' ' }"
+        "| ForEach-Object { "
+        "  $ts = $_.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss'); "
+        "  $msg = ($_.Message -split \"`n\" | Select-Object -First 12) -join ' | '; "
+        "  \"$ts -- $msg\" "
+        "}"
     )
 
     try:
@@ -79,9 +150,26 @@ def check_previous_crash(log: logging.Logger) -> str | None:
         )
         output = result.stdout.strip()
         if output:
-            log.warning(f"Previous crash detected in Windows Event Log:\n{output}")
+            log.warning("Previous crash(es) in Windows Event Log:\n%s", output)
+            faulting_module = _extract_faulting_module(output)
+            if faulting_module:
+                log.warning(
+                    "Previous crash faulting module: %s (common culprits: "
+                    "tcl86t.dll/tk86t.dll=Tk GUI thread issue; "
+                    "torch_*.dll=CUDA/DLL load; python3*.dll=Python runtime)",
+                    faulting_module,
+                )
             return output
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         log.debug(f"Event Log check skipped: {e}")
 
+    return None
+
+
+def _extract_faulting_module(message: str) -> str | None:
+    """Pull 'Faulting module name: X.dll' out of an Application Error message."""
+    import re
+    match = re.search(r"Faulting module name:\s*([^\s,|]+)", message, re.IGNORECASE)
+    if match:
+        return match.group(1)
     return None

--- a/whisper_sync/crash_diagnostics.py
+++ b/whisper_sync/crash_diagnostics.py
@@ -53,6 +53,17 @@ def install_faulthandler(log_path) -> "object | None":
         except Exception:
             pass
 
+    # Close any previously retained file. If install_faulthandler is ever
+    # called twice in the same process (log rotation, re-init, long session
+    # scenarios), leaving the old file open leaks a descriptor.
+    if _FAULTHANDLER_FILE is not None:
+        try:
+            if not _FAULTHANDLER_FILE.closed:
+                _FAULTHANDLER_FILE.close()
+        except Exception:
+            pass
+        _FAULTHANDLER_FILE = None
+
     try:
         f = open(Path(log_path), "a", buffering=1, encoding="utf-8")
     except (OSError, ValueError):

--- a/whisper_sync/heartbeat.py
+++ b/whisper_sync/heartbeat.py
@@ -1,0 +1,53 @@
+"""Periodic heartbeat log line.
+
+A background daemon thread writes a short DEBUG line every ``interval``
+seconds. The purpose is forensic: if the app dies silently, the gap between
+the last heartbeat and the next restart banner pins down the time-of-death.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+
+
+class Heartbeat:
+    """Periodic heartbeat emitter. Start/stop are idempotent."""
+
+    def __init__(self, logger: logging.Logger, interval: float = 60.0):
+        self._logger = logger
+        self._interval = float(interval)
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_at: float | None = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._started_at = time.monotonic()
+        self._thread = threading.Thread(
+            target=self._run, name="whisper-sync-heartbeat", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float | None = 2.0) -> None:
+        self._stop.set()
+        t = self._thread
+        if t is not None:
+            t.join(timeout=timeout)
+        self._thread = None
+
+    def _run(self) -> None:
+        pid = os.getpid()
+        while not self._stop.wait(self._interval):
+            start = self._started_at if self._started_at is not None else time.monotonic()
+            uptime = time.monotonic() - start
+            self._logger.debug(
+                "heartbeat pid=%d uptime=%.1fs threads=%d",
+                pid,
+                uptime,
+                threading.active_count(),
+            )

--- a/whisper_sync/lifecycle.py
+++ b/whisper_sync/lifecycle.py
@@ -40,15 +40,19 @@ _state_lock = threading.Lock()
 _exit_reason: str = REASON_UNKNOWN
 _exit_extra: dict = {}
 _installed: bool = False
+# Ensures exactly one exit banner per process even when multiple emitters
+# race (e.g. quit() logs explicitly AND the atexit hook fires on shutdown).
+_banner_emitted: bool = False
 
 
 def _reset_for_tests() -> None:
     """Reset module state. Test-only."""
-    global _exit_reason, _exit_extra, _installed
+    global _exit_reason, _exit_extra, _installed, _banner_emitted
     with _state_lock:
         _exit_reason = REASON_UNKNOWN
         _exit_extra = {}
         _installed = False
+        _banner_emitted = False
 
 
 def record_exit_reason(reason: str, extra: dict | None = None) -> None:
@@ -104,7 +108,17 @@ def log_startup_banner(logger: logging.Logger) -> None:
 
 
 def log_exit_banner(logger: logging.Logger) -> None:
-    """Emit the exit banner using the currently-recorded reason."""
+    """Emit the exit banner. Idempotent across callers.
+
+    Guards against duplicate banners when both an explicit caller (e.g.
+    ``quit()``) AND the atexit hook run on the same shutdown. The first
+    call wins; subsequent calls are silent no-ops.
+    """
+    global _banner_emitted
+    with _state_lock:
+        if _banner_emitted:
+            return
+        _banner_emitted = True
     reason, extra = get_exit_reason()
     logger.info(
         "=== WhisperSync exiting === reason=%s%s",

--- a/whisper_sync/lifecycle.py
+++ b/whisper_sync/lifecycle.py
@@ -1,0 +1,163 @@
+"""Process lifecycle logging.
+
+Every process start and end should produce an identifiable log line so that
+silent deaths can be distinguished from clean quits. This module owns the
+startup/exit banners and the exit-reason state.
+
+Design:
+    * The first call to ``record_exit_reason`` wins. Later calls are ignored
+      so that a late-firing atexit callback can't mask the real cause
+      (e.g. an unhandled exception that already recorded ``exception``).
+    * ``install`` wires up atexit + signal handlers. On any exit path we
+      emit a single ``=== WhisperSync exiting (reason=..., ...) ===`` line
+      so grep-for-gaps analysis can tell crashes from clean exits.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import platform
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+# Canonical exit-reason strings. Greppable log markers; callers should
+# import these constants rather than pass raw strings so the labels stay
+# stable across the codebase.
+REASON_UNKNOWN = "unknown"
+REASON_USER_QUIT = "user_quit"
+REASON_USER_RESTART = "user_restart"
+REASON_ATEXIT = "atexit"
+REASON_SIGNAL = "signal"
+REASON_EXCEPTION = "exception"
+REASON_SYSTEM_EXIT = "system_exit"
+
+_state_lock = threading.Lock()
+_exit_reason: str = REASON_UNKNOWN
+_exit_extra: dict = {}
+_installed: bool = False
+
+
+def _reset_for_tests() -> None:
+    """Reset module state. Test-only."""
+    global _exit_reason, _exit_extra, _installed
+    with _state_lock:
+        _exit_reason = REASON_UNKNOWN
+        _exit_extra = {}
+        _installed = False
+
+
+def record_exit_reason(reason: str, extra: dict | None = None) -> None:
+    """Record why the process is about to exit. First caller wins."""
+    global _exit_reason, _exit_extra
+    with _state_lock:
+        if _exit_reason != REASON_UNKNOWN:
+            return
+        _exit_reason = reason
+        _exit_extra = dict(extra) if extra else {}
+
+
+def get_exit_reason() -> tuple[str, dict]:
+    """Return the currently-recorded exit reason + extras."""
+    with _state_lock:
+        return _exit_reason, dict(_exit_extra)
+
+
+def _git_sha() -> str:
+    """Best-effort short git SHA for this checkout. 'unknown' on failure."""
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        sha = result.stdout.strip()
+        if sha:
+            return sha
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return "unknown"
+
+
+def _format_extra(extra: dict) -> str:
+    """Render extras as ``k1=v1 k2=v2`` for grep-friendly logs."""
+    if not extra:
+        return ""
+    return " " + " ".join(f"{k}={v}" for k, v in extra.items())
+
+
+def log_startup_banner(logger: logging.Logger) -> None:
+    """Emit the startup banner with PID, Python/OS/git identifiers."""
+    logger.info(
+        "=== WhisperSync starting === pid=%d python=%s os=%s git=%s",
+        os.getpid(),
+        platform.python_version(),
+        platform.platform(terse=True),
+        _git_sha(),
+    )
+
+
+def log_exit_banner(logger: logging.Logger) -> None:
+    """Emit the exit banner using the currently-recorded reason."""
+    reason, extra = get_exit_reason()
+    logger.info(
+        "=== WhisperSync exiting === reason=%s%s",
+        reason,
+        _format_extra(extra),
+    )
+    for handler in logger.handlers:
+        try:
+            handler.flush()
+        except Exception:
+            pass
+
+
+def install(logger: logging.Logger) -> None:
+    """Register atexit + signal handlers that emit the exit banner.
+
+    Safe to call multiple times; the second call is a no-op.
+    """
+    global _installed
+    with _state_lock:
+        if _installed:
+            return
+        _installed = True
+
+    def _atexit():
+        record_exit_reason(REASON_ATEXIT)
+        log_exit_banner(logger)
+
+    atexit.register(_atexit)
+
+    def _signal_handler(signum, _frame):
+        try:
+            name = signal.Signals(signum).name
+        except ValueError:
+            name = str(signum)
+        # Only record the reason here. The atexit hook emits the single
+        # exit banner during normal interpreter shutdown — doing logging
+        # inside a signal handler is both risky (async-signal-safety) and
+        # duplicates the atexit banner once sys.exit() runs.
+        record_exit_reason(REASON_SIGNAL, {"signal": name})
+        try:
+            signal.signal(signum, signal.SIG_DFL)
+        except Exception:
+            pass
+        sys.exit(128 + signum)
+
+    # SIGTERM + SIGBREAK (Windows) + SIGINT (Ctrl+C) are the common paths.
+    for sig_name in ("SIGTERM", "SIGBREAK", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, _signal_handler)
+        except (ValueError, OSError):
+            # Some signals are not settable on every platform/thread.
+            pass

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -98,7 +98,10 @@ class MeetingJob:
             step()
         except Exception:
             elapsed = _time.monotonic() - started
-            logger.error(
+            # logger.exception emits the full traceback at the point of
+            # failure so forensic logs pin which step failed AND why,
+            # even if the outer handler only catches and re-labels.
+            logger.exception(
                 "step failed: %s job=%s elapsed=%.2fs",
                 step_name, job_label, elapsed,
             )

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -79,11 +79,35 @@ class MeetingJob:
         return self._steps[self._current_step].__name__
 
     def execute_next_step(self):
-        """Execute the next step. Returns True if more steps remain."""
+        """Execute the next step. Returns True if more steps remain.
+
+        Logs the step name at INFO before and after execution so a silent
+        death mid-step can be pinpointed from the log. The step index is
+        advanced only on successful completion so a failed step is not
+        silently 'consumed' if any caller inspects/retries the job.
+        """
+        import time as _time
         if self.is_complete:
             return False
         step = self._steps[self._current_step]
-        step()
+        step_name = step.__name__
+        job_label = self.name or "meeting"
+        logger.info("step start: %s job=%s", step_name, job_label)
+        started = _time.monotonic()
+        try:
+            step()
+        except Exception:
+            elapsed = _time.monotonic() - started
+            logger.error(
+                "step failed: %s job=%s elapsed=%.2fs",
+                step_name, job_label, elapsed,
+            )
+            raise
+        elapsed = _time.monotonic() - started
+        logger.info(
+            "step done: %s job=%s elapsed=%.2fs",
+            step_name, job_label, elapsed,
+        )
         self._current_step += 1
         return not self.is_complete
 
@@ -296,10 +320,21 @@ class MeetingJob:
             logger.warning("Index rebuild failed (non-fatal): %s", e)
 
     def step_notify(self):
-        """Show toast notification with meeting stats and Open Folder button."""
-        from .notifications import notify
+        """Show toast notification with meeting stats and Open Folder button.
+
+        Honors the user's ``toast_events`` config (tray menu toggle). This
+        toast is dispatched directly rather than through the TOAST_REGISTRY
+        template so it can attach an Open Folder button, but it still must
+        respect the configurable toggle — otherwise disabling 'Meeting
+        Complete' in the tray menu has no effect.
+        """
+        from .notifications import notify, is_toast_enabled
 
         try:
+            cfg = getattr(self.app, "cfg", None)
+            if not is_toast_enabled("meeting_completed", cfg):
+                return
+
             words = self.transcript_result.get("word_count", 0) if self.transcript_result else 0
             speakers = self.transcript_result.get("num_speakers", 0) if self.transcript_result else 0
             body = f"{words} words, {speakers} speakers"

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -229,10 +229,11 @@ def has_input_text_box():
 # Toast templates keyed by event type.  Only events listed here AND enabled
 # in config["toast_events"] will trigger a toast.
 TOAST_REGISTRY: dict[str, dict] = {
-    "meeting_completed": {
-        "title": "Meeting transcribed",
-        "body": "{words} words, {speakers} speakers",
-    },
+    # NOTE: meeting_completed toasts are fired directly from
+    # MeetingJob.step_notify so the toast can attach an "Open Folder"
+    # button. A template entry here would double-fire and the
+    # MEETING_COMPLETED state event does not carry words/speakers,
+    # so it produced a DEBUG-level KeyError every meeting.
     "dictation_completed": {
         "title": "Dictation complete",
         "body": "",
@@ -251,6 +252,20 @@ TOAST_REGISTRY: dict[str, dict] = {
 DEFAULT_TOAST_EVENTS = ["meeting_completed", "error", "pr_status_changed"]
 
 
+def is_toast_enabled(event_type: str, cfg: dict | None) -> bool:
+    """Return True if ``event_type`` should fire a toast per ``cfg``.
+
+    Shared between ``ToastListener`` and direct-dispatch call sites such as
+    ``MeetingJob.step_notify`` so both respect the same user toggle and
+    the same config-validation rules (garbage values fall back to
+    ``DEFAULT_TOAST_EVENTS``).
+    """
+    raw = (cfg or {}).get("toast_events", DEFAULT_TOAST_EVENTS)
+    if not isinstance(raw, (list, tuple, set)):
+        raw = DEFAULT_TOAST_EVENTS
+    return event_type in raw
+
+
 class ToastListener:
     """State event subscriber that shows configurable Windows toasts.
 
@@ -263,15 +278,7 @@ class ToastListener:
         self._config = config
 
     def __call__(self, event) -> None:
-        raw_events = self._config.get("toast_events", DEFAULT_TOAST_EVENTS)
-        if not isinstance(raw_events, (list, tuple, set)):
-            _logger.debug(
-                "Invalid toast_events config (%r); falling back to defaults",
-                raw_events,
-            )
-            raw_events = DEFAULT_TOAST_EVENTS
-        enabled = set(raw_events)
-        if event.type not in enabled:
+        if not is_toast_enabled(event.type, self._config):
             return
 
         template = TOAST_REGISTRY.get(event.type)

--- a/whisper_sync/worker.py
+++ b/whisper_sync/worker.py
@@ -88,8 +88,19 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
         preload_model_name: Model to preload at startup. None = skip preload
             (model loads on first request instead).
     """
-    # Enable faulthandler in child so segfaults are logged to stderr
-    faulthandler.enable()
+    # Enable faulthandler in the worker subprocess. Use the shared helper
+    # so the file handle is retained module-scope; otherwise CPython can
+    # GC it and native crash dumps from CTranslate2/CUDA vanish. The log
+    # path mirrors the main process so both streams land in the same
+    # dated file.
+    try:
+        from .crash_diagnostics import install_faulthandler
+        from .logger import get_log_path
+        install_faulthandler(get_log_path())
+    except Exception:
+        # Thread crashes in native libs (CTranslate2, CUDA) are common here;
+        # all_threads=True is essential so they are captured.
+        faulthandler.enable(all_threads=True)  # best-effort fallback to stderr
 
     # Suppress known harmless warnings before any imports trigger them
     import warnings


### PR DESCRIPTION
## Summary

Un-reverts PR #126. Brings the reliability/mic/scroll work back on `dev`.

## Context

Earlier today the user hit `sounddevice.PortAudioError: MME error 32` and suspected PRs #123/#124/#125 caused it. PR #126 was opened to revert all three. After further investigation the root cause turned out to be an OBSBOT mic driver quirk in Windows Sound settings (two near-identical entries where only one opens cleanly) likely triggered by a recent Windows/driver update. The user has since resolved it at the Windows level.

With the mic error no longer a confound, the user asked for the reliability work to be restored so they can run on the fixed version going forward.

## What this PR does

A single `git revert dc0733e` — the squash commit of PR #126. Net effect: `dev` state matches `7405adc` (the tip of `dev` immediately before PR #126 merged) with `dc0733e` still in the history.

Restored on `dev`:
- **PR #123** — lifecycle module, heartbeat, faulthandler retention, step logging, dialog fixes
- **PR #124** — scrollable speaker dialog, exit-reason constants, is_toast_enabled helper, install_faulthandler helper, worker.py fix
- **PR #125** — `_open_input_stream` retry ladder, WASAPI mic routing, hotkey dispatcher guards, transactional recorder state

No new code. All history preserved. The original merged commits of #123/#124/#125 remain in the object graph unchanged.

## Test plan

- [x] `python -m unittest discover tests` — 40/40 passing
- [x] `import whisper_sync.__main__` + helpers smoke-test OK
- [ ] Manual: user relaunches whisper-sync, runs dictation + a meeting, confirms behavior matches what they had at commit `7405adc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)