### PR TITLE
fix: continue pipeline when speaker_id fails or crashes

### DIFF
--- a/tests/test_meeting_job.py
+++ b/tests/test_meeting_job.py
@@ -5,12 +5,22 @@ implementations touch the worker subprocess / filesystem / state manager
 and are out of scope.
 """
 
+import sys
+import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 class _StubApp:
     """Minimal stand-in for the WhisperSync application object."""
+
+    def __init__(self):
+        self._current_meeting_json_path = None
+
+    def _ask_speaker_confirmation(self, id_result):
+        # Default: skip confirmation (user clicked cancel).
+        return None
 
 
 def _make_job(steps):
@@ -65,6 +75,145 @@ class ExecuteNextStepTests(unittest.TestCase):
     def test_returns_false_when_complete(self):
         job = _make_job([lambda: None])
         self.assertFalse(job.execute_next_step())
+
+
+def _make_speaker_id_job(app=None):
+    """Build a MeetingJob suitable for exercising step_speaker_id.
+
+    Sets transcript_result so step_speaker_id has a json_path and llm_ok=True
+    so identify_speakers gets called.
+    """
+    from whisper_sync.meeting_job import MeetingJob
+
+    job = MeetingJob(
+        app=app or _StubApp(),
+        wav_path=Path("/tmp/x.wav"),
+        meeting_dir=Path("/tmp/x"),
+        name="speaker-id-test",
+        summarize=False,
+        date_time_str="0101_0000",
+        week_dir="01-w1",
+        folder_name="0101_0000_speaker-id-test",
+    )
+    job.transcript_result = {"json_path": "/tmp/x/transcript.json"}
+    job.llm_ok = True
+    return job
+
+
+def _install_fake_speakers_module(
+    identify_side_effect=None,
+    build_stub_returns=None,
+    write_side_effect=None,
+):
+    """Install a fake whisper_sync.speakers module and return the writes list.
+
+    Returns a dict with 'writes' (list of (path, map) tuples for successful
+    write_speaker_map calls) and the patcher context manager.
+    """
+    fake = types.ModuleType("whisper_sync.speakers")
+    writes = []
+
+    def _identify_speakers(json_path, cfg_path, folder_name):
+        if identify_side_effect is not None:
+            raise identify_side_effect
+        return {"speaker_map": {"SPEAKER_00": "Alice"}}
+
+    def _write_speaker_map(json_path, speaker_map):
+        if write_side_effect is not None:
+            raise write_side_effect
+        writes.append((json_path, dict(speaker_map)))
+
+    def _update_config(cfg_path, speaker_map, config_updates=None):
+        return None
+
+    def _get_config_path():
+        return Path("/tmp/cfg.json")
+
+    def _build_manual_stub(json_path, reason):
+        if build_stub_returns is not None:
+            return build_stub_returns
+        return {"speaker_map": {"SPEAKER_00": "", "SPEAKER_01": ""}}
+
+    fake.identify_speakers = _identify_speakers
+    fake.write_speaker_map = _write_speaker_map
+    fake.update_config = _update_config
+    fake.get_config_path = _get_config_path
+    fake.build_manual_stub = _build_manual_stub
+
+    return fake, writes
+
+
+class StepSpeakerIdFailsafeTests(unittest.TestCase):
+    """Regression coverage for the step_speaker_id failsafe path.
+
+    These confirm that the step does not propagate exceptions from the
+    speaker identification or confirmation dialog, and that placeholders
+    are applied (and persisted via write_speaker_map) so downstream steps
+    have a usable speaker map.
+    """
+
+    def test_step_speaker_id_does_not_raise_when_identify_fails(self):
+        # identify_speakers raises - failsafe should kick in, dialog is
+        # bypassed (build_manual_stub provides id_result), confirmation
+        # returns None, placeholder map is written.
+        fake, writes = _install_fake_speakers_module(
+            identify_side_effect=RuntimeError("claude exploded"),
+        )
+        with mock.patch.dict(sys.modules, {"whisper_sync.speakers": fake}):
+            job = _make_speaker_id_job()
+            # Should NOT raise.
+            job.step_speaker_id()
+
+        # Placeholder map should be applied and persisted.
+        self.assertIsNotNone(
+            job.speakers_confirmed,
+            "speakers_confirmed should be set to a placeholder map",
+        )
+        self.assertIsInstance(job.speakers_confirmed, dict)
+        self.assertTrue(len(job.speakers_confirmed) >= 1)
+        # The placeholder write should have hit write_speaker_map at least once.
+        self.assertTrue(
+            any(w[1] == job.speakers_confirmed for w in writes),
+            f"placeholder map should have been written; writes={writes}",
+        )
+
+    def test_step_speaker_id_does_not_raise_when_dialog_fails(self):
+        # identify_speakers succeeds, but the confirmation dialog raises.
+        # The step must still complete; placeholder map should be applied
+        # since speakers_confirmed never got set by the confirmation path.
+        class _BoomApp(_StubApp):
+            def _ask_speaker_confirmation(self, id_result):
+                raise RuntimeError("tkinter heap corruption")
+
+        fake, writes = _install_fake_speakers_module()
+        with mock.patch.dict(sys.modules, {"whisper_sync.speakers": fake}):
+            job = _make_speaker_id_job(app=_BoomApp())
+            # Should NOT raise.
+            job.step_speaker_id()
+
+        self.assertIsNotNone(
+            job.speakers_confirmed,
+            "speakers_confirmed should be set to a placeholder map after dialog failure",
+        )
+        self.assertIsInstance(job.speakers_confirmed, dict)
+
+    def test_step_speaker_id_leaves_speakers_unset_when_write_fails(self):
+        # If even the placeholder write fails, speakers_confirmed should
+        # remain None so downstream steps see the same state as before
+        # the failsafe existed (rather than logs/memory claiming a map
+        # exists when transcript.json was never updated).
+        fake, _writes = _install_fake_speakers_module(
+            identify_side_effect=RuntimeError("claude exploded"),
+            write_side_effect=OSError("disk full"),
+        )
+        with mock.patch.dict(sys.modules, {"whisper_sync.speakers": fake}):
+            job = _make_speaker_id_job()
+            job.step_speaker_id()
+
+        self.assertIsNone(
+            job.speakers_confirmed,
+            "speakers_confirmed must remain unset when write_speaker_map fails",
+        )
 
 
 if __name__ == "__main__":

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -179,16 +179,20 @@ class MeetingJob:
         re-edit speakers later via the existing Meetings tray menu recovery
         flow (see __main__.py recovery handlers).
         """
-        from .speakers import (
-            identify_speakers, write_speaker_map, update_config,
-            get_config_path, build_manual_stub,
-        )
-
         json_path = self.transcript_result.get(
             "json_path", str(self.meeting_dir / "transcript.json")
         ) if self.transcript_result else str(self.meeting_dir / "transcript.json")
 
+        # Imports are inside the try/except so an import-time failure in
+        # .speakers (or its transitive imports) also triggers the failsafe
+        # path rather than aborting the pipeline before the catch-all.
+        write_speaker_map = None
         try:
+            from .speakers import (
+                identify_speakers, write_speaker_map, update_config,
+                get_config_path, build_manual_stub,
+            )
+
             id_result = None
             if self.llm_ok:
                 try:
@@ -266,17 +270,39 @@ class MeetingJob:
         if not self.speakers_confirmed:
             placeholder_map = self._build_placeholder_speaker_map(json_path)
             if placeholder_map:
-                try:
-                    write_speaker_map(json_path, placeholder_map)
-                except Exception as e:
-                    logger.warning("Could not write placeholder speaker map: %s", e)
-                self.speakers_confirmed = placeholder_map
-                logger.warning(
-                    "Placeholder speakers applied: %s. Re-edit via Meetings tray menu recovery flow.",
-                    placeholder_map,
-                )
+                # Resolve write_speaker_map lazily here too in case the
+                # earlier import inside the try block failed.
+                _write_speaker_map = write_speaker_map
+                if _write_speaker_map is None:
+                    try:
+                        from .speakers import write_speaker_map as _wsm
+                        _write_speaker_map = _wsm
+                    except Exception as e:
+                        logger.warning(
+                            "Could not import write_speaker_map for placeholder write: %s",
+                            e,
+                        )
+                if _write_speaker_map is None:
+                    logger.warning(
+                        "Placeholder speakers NOT applied: speakers module unavailable. "
+                        "Downstream steps will see speakers_confirmed unset."
+                    )
+                else:
+                    try:
+                        _write_speaker_map(json_path, placeholder_map)
+                    except Exception as e:
+                        logger.warning(
+                            "Could not write placeholder speaker map (leaving speakers_confirmed unset): %s",
+                            e,
+                        )
+                    else:
+                        self.speakers_confirmed = placeholder_map
+                        logger.warning(
+                            "Placeholder speakers applied: %s. Re-edit via Meetings tray menu recovery flow.",
+                            placeholder_map,
+                        )
 
-    def _build_placeholder_speaker_map(self, json_path: str) -> dict | None:
+    def _build_placeholder_speaker_map(self, json_path: str) -> dict[str, str]:
         """Read SPEAKER_XX labels from transcript and produce a placeholder map.
 
         Tries build_manual_stub first (preferred path). Falls back to a

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -171,73 +171,137 @@ class MeetingJob:
 
         If Claude times out or fails, still shows the dialog with empty names
         so the user can manually enter speaker names.
+
+        FAILSAFE: Any failure in this step (Claude error, tkinter heap
+        corruption, dialog crash, user skip, unexpected exception) results
+        in placeholder speaker assignment so subsequent steps (flatten,
+        minutes, rename, index, notify, complete) still run. The user can
+        re-edit speakers later via the existing Meetings tray menu recovery
+        flow (see __main__.py recovery handlers).
         """
-        from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path, build_manual_stub
+        from .speakers import (
+            identify_speakers, write_speaker_map, update_config,
+            get_config_path, build_manual_stub,
+        )
 
         json_path = self.transcript_result.get(
             "json_path", str(self.meeting_dir / "transcript.json")
-        )
+        ) if self.transcript_result else str(self.meeting_dir / "transcript.json")
 
-        id_result = None
-        if self.llm_ok:
-            try:
-                cfg_path = get_config_path()
-                id_result = identify_speakers(json_path, cfg_path, self.folder_name)
-            except Exception as e:
-                logger.warning("Speaker identification failed (non-fatal): %s", e)
-
-        if not id_result or not id_result.get("speaker_map"):
-            # Tailor reasoning and notification based on cause
+        try:
+            id_result = None
             if self.llm_ok:
-                reason = "Auto-identification failed - enter name manually"
-                toast_title = "Speaker ID Failed"
-                toast_body = "Automatic speaker identification failed; enter names manually in the dialog."
-            else:
-                reason = "Auto-identification unavailable (Claude CLI not available) - enter name manually"
-                toast_title = "Speaker ID Unavailable"
-                toast_body = "Speaker identification requires Claude CLI, which is not available. Enter speaker names manually in the dialog."
-
-            id_result = build_manual_stub(json_path, reason)
-            if id_result:
                 try:
-                    from .notifications import notify
-                    notify(toast_title, toast_body)
-                except Exception:
-                    pass
-                logger.warning("Speaker ID not applied, showing manual entry dialog")
-
-        if id_result and id_result.get("speaker_map"):
-            try:
-                self.app._current_meeting_json_path = json_path
-                confirmation = self.app._ask_speaker_confirmation(id_result)
-                if confirmation:
-                    if isinstance(confirmation, tuple):
-                        confirmed_map, boundaries = confirmation
-                    else:
-                        confirmed_map = confirmation
-                        boundaries = None
-
-                    write_speaker_map(json_path, confirmed_map)
                     cfg_path = get_config_path()
-                    # config_updates from initial (light) identification.
-                    # Deep mode config_updates are applied via the Meetings recovery flow.
-                    update_config(
-                        cfg_path, confirmed_map, id_result.get("config_updates")
-                    )
-                    logger.info("Speakers confirmed: %s", confirmed_map)
-                    self.speakers_confirmed = confirmed_map
+                    id_result = identify_speakers(json_path, cfg_path, self.folder_name)
+                except Exception as e:
+                    logger.warning("Speaker identification failed (non-fatal): %s", e)
 
-                    if boundaries:
-                        logger.info(f"Meeting boundaries detected: {boundaries}")
-                        self._detected_boundaries = boundaries
-                        # Boundaries are informational - user can split via Meetings tray menu.
-                        # Automatic splitting will be added in a future update.
+            if not id_result or not id_result.get("speaker_map"):
+                # Tailor reasoning and notification based on cause
+                if self.llm_ok:
+                    reason = "Auto-identification failed - enter name manually"
+                    toast_title = "Speaker ID Failed"
+                    toast_body = "Automatic speaker identification failed; enter names manually in the dialog."
                 else:
-                    logger.info("Speaker identification skipped by user")
-            except Exception as e:
-                logger.warning("Speaker confirmation dialog failed: %s", e)
-        else:
-            logger.info("No speakers found in transcript")
+                    reason = "Auto-identification unavailable (Claude CLI not available) - enter name manually"
+                    toast_title = "Speaker ID Unavailable"
+                    toast_body = "Speaker identification requires Claude CLI, which is not available. Enter speaker names manually in the dialog."
+
+                id_result = build_manual_stub(json_path, reason)
+                if id_result:
+                    try:
+                        from .notifications import notify
+                        notify(toast_title, toast_body)
+                    except Exception:
+                        pass
+                    logger.warning("Speaker ID not applied, showing manual entry dialog")
+
+            if id_result and id_result.get("speaker_map"):
+                try:
+                    self.app._current_meeting_json_path = json_path
+                    confirmation = self.app._ask_speaker_confirmation(id_result)
+                    if confirmation:
+                        if isinstance(confirmation, tuple):
+                            confirmed_map, boundaries = confirmation
+                        else:
+                            confirmed_map = confirmation
+                            boundaries = None
+
+                        write_speaker_map(json_path, confirmed_map)
+                        cfg_path = get_config_path()
+                        # config_updates from initial (light) identification.
+                        # Deep mode config_updates are applied via the Meetings recovery flow.
+                        update_config(
+                            cfg_path, confirmed_map, id_result.get("config_updates")
+                        )
+                        logger.info("Speakers confirmed: %s", confirmed_map)
+                        self.speakers_confirmed = confirmed_map
+
+                        if boundaries:
+                            logger.info(f"Meeting boundaries detected: {boundaries}")
+                            self._detected_boundaries = boundaries
+                            # Boundaries are informational - user can split via Meetings tray menu.
+                            # Automatic splitting will be added in a future update.
+                    else:
+                        logger.info("Speaker identification skipped by user")
+                except Exception as e:
+                    logger.warning("Speaker confirmation dialog failed: %s", e)
+            else:
+                logger.info("No speakers found in transcript")
+        except Exception as e:
+            # Top-level catch: never let speaker_id failures break the
+            # pipeline. tkinter heap corruption (speakers.py:541) and other
+            # crashes have prevented steps 3-8 from running, leaving meetings
+            # without minutes.md. Fail open: log, apply placeholders, move on.
+            logger.warning(
+                "Speaker ID failed/skipped - using placeholders, edit later via Meetings tray menu: %s",
+                e,
+            )
+
+        # Failsafe: ensure placeholder speakers are assigned if confirmation
+        # did not complete. This guarantees later steps have something to
+        # work with and that transcript.json has a speaker_map written so
+        # downstream consumers (flatten, minutes) behave consistently.
+        if not self.speakers_confirmed:
+            placeholder_map = self._build_placeholder_speaker_map(json_path)
+            if placeholder_map:
+                try:
+                    write_speaker_map(json_path, placeholder_map)
+                except Exception as e:
+                    logger.warning("Could not write placeholder speaker map: %s", e)
+                self.speakers_confirmed = placeholder_map
+                logger.warning(
+                    "Placeholder speakers applied: %s. Re-edit via Meetings tray menu recovery flow.",
+                    placeholder_map,
+                )
+
+    def _build_placeholder_speaker_map(self, json_path: str) -> dict | None:
+        """Read SPEAKER_XX labels from transcript and produce a placeholder map.
+
+        Tries build_manual_stub first (preferred path). Falls back to a
+        minimal hard-coded map if even that fails (e.g., transcript.json
+        missing or unreadable). Never raises.
+        """
+        try:
+            from .speakers import build_manual_stub
+            stub = build_manual_stub(
+                json_path,
+                "Auto-applied placeholder - edit via Meetings tray menu",
+            )
+            if stub and stub.get("speaker_map"):
+                # Convert empty-name stub to "Speaker N" placeholders so
+                # downstream rendering has readable labels.
+                spk_map = stub["speaker_map"]
+                return {
+                    spk: f"Speaker {i + 1}"
+                    for i, spk in enumerate(sorted(spk_map.keys()))
+                }
+        except Exception as e:
+            logger.warning("build_manual_stub failed for placeholder map: %s", e)
+
+        # Minimal fallback if transcript could not be read at all.
+        return {"SPEAKER_00": "Speaker 1", "SPEAKER_01": "Speaker 2"}
 
     def step_flatten(self):
         """Flatten transcript JSON to readable text."""


### PR DESCRIPTION
## Summary
- Wrap step_speaker_id so any failure produces placeholder speakers
- Pipeline always produces transcript-readable.txt and minutes.md
- User can re-edit speakers via existing Meetings tray menu recovery

## Problem
tkinter heap corruption crash at speakers.py:541 has affected 14 meetings since 2026-04-28. When step_speaker_id crashes, steps 3-8 never run, leaving meetings without minutes.md and sometimes without transcript-readable.txt.

## This PR (Fix #3 of 4)
This is the failsafe layer only. The actual tkinter fix is in a separate PR.

## Test plan
- [ ] Existing tests pass
- [ ] Verify step still completes when speaker_map is empty
- [ ] Verify subsequent steps run with placeholder speakers

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>