### PR TITLE
fix: run all tkinter dialogs on dedicated dispatcher thread

### DIFF
--- a/tests/test_dialog_dispatcher.py
+++ b/tests/test_dialog_dispatcher.py
@@ -1,0 +1,133 @@
+"""Unit tests for whisper_sync.dialog_dispatcher.
+
+These tests do not touch tkinter. They just verify the threading and
+return/exception contract that dialog code relies on.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+
+from whisper_sync.dialog_dispatcher import DialogDispatcher
+
+
+class DialogDispatcherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.d = DialogDispatcher(name="test-dispatcher")
+        self.d.start()
+
+    def tearDown(self) -> None:
+        self.d.shutdown(timeout=2.0)
+
+    def test_run_returns_callable_result(self) -> None:
+        result = self.d.run(lambda: 42, label="answer")
+        self.assertEqual(result, 42)
+
+    def test_run_propagates_exceptions(self) -> None:
+        class Boom(RuntimeError):
+            pass
+
+        def fn():
+            raise Boom("kaboom")
+
+        with self.assertRaises(Boom):
+            self.d.run(fn, label="boom")
+
+    def test_callable_runs_on_dispatcher_thread(self) -> None:
+        thread_id_holder: dict[str, int] = {}
+
+        def fn():
+            thread_id_holder["tid"] = threading.get_ident()
+            return None
+
+        # Two calls back to back must hit the SAME thread. This is the
+        # property tkinter on Windows depends on.
+        self.d.run(fn, label="first")
+        first = thread_id_holder["tid"]
+        thread_id_holder.clear()
+        self.d.run(fn, label="second")
+        second = thread_id_holder["tid"]
+
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, threading.get_ident())
+
+    def test_calls_are_serialized(self) -> None:
+        # If the dispatcher accidentally ran callables in parallel, the
+        # sleeps below would overlap and total elapsed time would be ~0.1s.
+        # Serialized execution makes it ~0.3s.
+        per_call = 0.1
+        n = 3
+
+        def fn():
+            time.sleep(per_call)
+            return time.monotonic()
+
+        start = time.monotonic()
+        results = []
+        # Submit from multiple worker threads. They should still run one at
+        # a time on the dispatcher.
+        threads = []
+        bucket: list = []
+        lock = threading.Lock()
+
+        def submit():
+            r = self.d.run(fn, label="parallel")
+            with lock:
+                bucket.append(r)
+
+        for _ in range(n):
+            t = threading.Thread(target=submit)
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+        elapsed = time.monotonic() - start
+        self.assertEqual(len(bucket), n)
+        self.assertGreaterEqual(elapsed, per_call * n * 0.8)
+
+        # Returned timestamps must be strictly monotonically increasing
+        # (within tolerance) since the calls were serial.
+        sorted_bucket = sorted(bucket)
+        for a, b in zip(sorted_bucket, sorted_bucket[1:]):
+            self.assertGreaterEqual(b - a, per_call * 0.8)
+
+    def test_lazy_start_when_run_called_first(self) -> None:
+        d = DialogDispatcher(name="lazy")
+        # Don't call .start(); .run() should auto-start.
+        try:
+            self.assertEqual(d.run(lambda: "ok"), "ok")
+        finally:
+            d.shutdown(timeout=2.0)
+
+    def test_shutdown_is_idempotent(self) -> None:
+        d = DialogDispatcher(name="shutdown")
+        d.start()
+        d.shutdown(timeout=2.0)
+        # Second shutdown must not raise or hang.
+        d.shutdown(timeout=2.0)
+
+    def test_reentrant_call_runs_inline(self) -> None:
+        # If a dialog callback wants to invoke another dialog, that nested
+        # call must NOT be re-queued (it would deadlock waiting on itself).
+        # The dispatcher should detect same-thread calls and run inline.
+        outer_thread: dict[str, int] = {}
+        inner_thread: dict[str, int] = {}
+
+        def inner():
+            inner_thread["tid"] = threading.get_ident()
+            return "inner-result"
+
+        def outer():
+            outer_thread["tid"] = threading.get_ident()
+            return self.d.run(inner, label="inner")
+
+        result = self.d.run(outer, label="outer")
+        self.assertEqual(result, "inner-result")
+        self.assertEqual(outer_thread["tid"], inner_thread["tid"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -67,6 +67,7 @@ from .state_manager import (
 from .meeting_job import MeetingJob
 from .rebuild_index import rebuild_root_index
 from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
+from .dialog_dispatcher import DialogDispatcher
 
 HOTKEY_OPTIONS = [
     "ctrl+shift+space",
@@ -152,6 +153,12 @@ class WhisperSync:
         self._feature_suggest_active = False  # routes dictation output to feature log
         self._post_queue = queue.Queue()  # Post-processing queue for completed meetings
         self._post_worker_thread = None  # Started in run()
+        # Single long-lived thread for ALL tkinter dialogs. tk.Tk() must not
+        # be created on rotating worker threads; doing so corrupts Win32 heap
+        # state and crashes the next GC cycle (fatal exception 0x80000003).
+        # See whisper_sync/dialog_dispatcher.py for the rationale.
+        self._dialog_dispatcher = DialogDispatcher()
+        self._dialog_dispatcher.start()
         self._cpu_name = _get_cpu_name()
         # Session stats
         self._stats = {
@@ -964,7 +971,6 @@ class WhisperSync:
     def _ask_recovery_name(self, wav_path: str, duration_str: str):
         """Show a dialog to name a recovered meeting. Returns name string or _ABORT."""
         result = [self._ABORT]
-        event = threading.Event()
 
         def _show():
             import tkinter as tk
@@ -1007,11 +1013,12 @@ class WhisperSync:
 
             root.protocol("WM_DELETE_WINDOW", _skip)
             root.mainloop()
-            event.set()
 
-        t = threading.Thread(target=_show, daemon=True)
-        t.start()
-        event.wait(timeout=120)
+        try:
+            self._dialog_dispatcher.run(_show, label="ask_recovery_name")
+        except Exception:
+            logger.exception("dialog crashed: _ask_recovery_name")
+            return self._ABORT
 
         if result[0] is self._ABORT:
             return self._ABORT
@@ -1143,7 +1150,6 @@ class WhisperSync:
         dialog_started = _time.monotonic()
         logger.info("dialog open: _ask_meeting_name")
         result = [self._ABORT]
-        event = threading.Event()
 
         def _show_dialog():
             import tkinter as tk
@@ -1252,27 +1258,16 @@ class WhisperSync:
             root.protocol("WM_DELETE_WINDOW", _abort)
             root.mainloop()
 
-        def _show_dialog_guarded():
-            # Guarantees event.set() + a well-defined outcome even if
-            # _show_dialog raises before root.mainloop() returns. Without
-            # this, _save_and_enqueue's event.wait() blocks forever and the
-            # tray stays stuck in mode="saving" with the recording neither
-            # saved nor discarded.
-            try:
-                _show_dialog()
-            except Exception:
-                logger.exception("dialog crashed: _ask_meeting_name")
-                result[0] = self._ABORT
-            finally:
-                event.set()
-
-        t = threading.Thread(target=_show_dialog_guarded, daemon=True)
-        t.start()
-        # Previously this used a 60s timeout that silently returned _ABORT
-        # while the dialog was still on screen — discarding the recording
-        # while the user thought they were still naming it. The dialog
-        # itself has no auto-close timer, so we wait as long as it's open.
-        event.wait()
+        # Run on the shared dialog dispatcher thread. The dispatcher catches
+        # exceptions and re-raises them in our thread, so we mirror the prior
+        # "abort on crash" behavior with a try/except here. This preserves
+        # the prior contract: _save_and_enqueue's caller never sees a hang
+        # if Tk init or geometry blows up mid-dialog.
+        try:
+            self._dialog_dispatcher.run(_show_dialog, label="ask_meeting_name")
+        except Exception:
+            logger.exception("dialog crashed: _ask_meeting_name")
+            result[0] = self._ABORT
 
         # Report dialog outcome with the actual returned value so forensic
         # logs can distinguish ABORT vs save vs timeout vs garbage.
@@ -1388,7 +1383,6 @@ class WhisperSync:
     def _show_llm_unavailable(self):
         """Show a dialog when Claude CLI is not available. Returns True if user checked 'don't show again'."""
         result = [False]
-        event = threading.Event()
 
         def _show():
             import tkinter as tk
@@ -1422,11 +1416,11 @@ class WhisperSync:
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _ok)
             root.mainloop()
-            event.set()
 
-        t = threading.Thread(target=_show, daemon=True)
-        t.start()
-        event.wait(timeout=30)
+        try:
+            self._dialog_dispatcher.run(_show, label="show_llm_unavailable")
+        except Exception:
+            logger.exception("dialog crashed: _show_llm_unavailable")
 
         return result[0]
 
@@ -1453,7 +1447,6 @@ class WhisperSync:
                 return speaker_map
 
         result = [None]
-        event = threading.Event()
 
         # Store json_path for deep identify button access
         self._deep_id_json_path = getattr(self, '_current_meeting_json_path', None)
@@ -1838,24 +1831,16 @@ class WhisperSync:
             root.protocol("WM_DELETE_WINDOW", _skip)
             root.mainloop()
 
-        def _show_guarded():
-            # Guarantees event.set() fires even if Tk init/geometry raises.
-            # Without this, a crash in _show would hang the meeting
-            # post-processing pipeline indefinitely waiting on the event.
-            try:
-                _show()
-            except Exception:
-                logger.exception("speaker dialog crashed")
-                result[0] = None
-            finally:
-                event.set()
-
-        t = threading.Thread(target=_show_guarded, daemon=True)
-        t.start()
-        # Wait as long as the user needs. A 2-minute timeout would silently
-        # skip speaker confirmation while the dialog was still on screen:
-        # data loss with no log.
-        event.wait()
+        # Run on the shared dialog dispatcher thread. Previously this method
+        # spawned a fresh daemon thread per call and ran tk.Tk() there. That
+        # short-lived-thread pattern corrupted Win32/heap state and surfaced
+        # later as STATUS_BREAKPOINT (0x80000003) at speakers.py:541 inside
+        # json.load, on the post-processing worker thread.
+        try:
+            self._dialog_dispatcher.run(_show, label="ask_speaker_confirmation")
+        except Exception:
+            logger.exception("speaker dialog crashed")
+            result[0] = None
 
         return result[0]
 
@@ -2814,7 +2799,13 @@ class WhisperSync:
             logger.warning(f"PR merge error: {e}")
 
     def _show_error_popup(self, title: str, message: str):
-        """Show a tkinter error dialog with the given message."""
+        """Show a tkinter error dialog with the given message.
+
+        Fire-and-forget: callers don't wait for the popup to close. We still
+        run on the dispatcher thread to keep all tk.Tk() creation on a single
+        consistent thread; we just don't block our caller. A small worker
+        thread bridges the call so this method returns immediately as before.
+        """
         def _show():
             import tkinter as tk
             from tkinter import messagebox
@@ -2822,7 +2813,14 @@ class WhisperSync:
             root.withdraw()
             messagebox.showerror(f"WhisperSync: {title}", message)
             root.destroy()
-        threading.Thread(target=_show, daemon=True).start()
+
+        def _dispatch():
+            try:
+                self._dialog_dispatcher.run(_show, label="error_popup")
+            except Exception:
+                logger.exception("error popup failed: %s", title)
+
+        threading.Thread(target=_dispatch, daemon=True).start()
 
     def _open_output_folder(self):
         import subprocess
@@ -2836,7 +2834,6 @@ class WhisperSync:
 
         current = self._output_dir()
         result = [None]  # None=cancelled, (Path, bool)=(new_path, move_files)
-        event = threading.Event()
 
         def _show():
             import tkinter as tk
@@ -2853,7 +2850,6 @@ class WhisperSync:
             root.destroy()
 
             if not new_dir or Path(new_dir) == current:
-                event.set()
                 return
 
             new_path = Path(new_dir)
@@ -2862,12 +2858,12 @@ class WhisperSync:
 
             if not has_files:
                 result[0] = (new_path, False)
-                event.set()
                 return
 
-            # Ask about moving files
+            # Ask about moving files. Run inline (we are already on the
+            # dispatcher thread, so the dispatcher's reentrancy guard makes
+            # this a same-thread call rather than a deadlock).
             move_result = [None]
-            move_event = threading.Event()
 
             def _show_move_dialog():
                 dlg = tk.Tk()
@@ -2916,22 +2912,24 @@ class WhisperSync:
                 self._center_window(dlg)
                 dlg.protocol("WM_DELETE_WINDOW", _cancel)
                 dlg.mainloop()
-                move_event.set()
 
-            t2 = threading.Thread(target=_show_move_dialog, daemon=True)
-            t2.start()
-            move_event.wait(timeout=60)
+            # Same-thread call via dispatcher (reentrancy guard runs inline).
+            try:
+                self._dialog_dispatcher.run(_show_move_dialog, label="change_output_move_dialog")
+            except Exception:
+                logger.exception("change-output move dialog crashed")
+                move_result[0] = None
 
             if move_result[0] is None:
-                event.set()
                 return
 
             result[0] = (new_path, move_result[0])
-            event.set()
 
-        t = threading.Thread(target=_show, daemon=True)
-        t.start()
-        event.wait(timeout=120)
+        try:
+            self._dialog_dispatcher.run(_show, label="change_output_folder")
+        except Exception:
+            logger.exception("change-output dialog crashed")
+            return
 
         if result[0] is None:
             return
@@ -3380,11 +3378,9 @@ class WhisperSync:
             lifecycle.log_exit_banner(logger)
         threading.Thread(target=_do_quit, daemon=True).start()
 
-    @staticmethod
-    def _prompt_large_download(model_name: str, size: str) -> bool:
+    def _prompt_large_download(self, model_name: str, size: str) -> bool:
         """Show a tkinter dialog asking if user wants to download a large model."""
         result = [False]
-        event = threading.Event()
 
         def _show():
             import tkinter as tk
@@ -3400,11 +3396,12 @@ class WhisperSync:
             )
             result[0] = answer
             root.destroy()
-            event.set()
 
-        t = threading.Thread(target=_show, daemon=True)
-        t.start()
-        event.wait(timeout=120)
+        try:
+            self._dialog_dispatcher.run(_show, label="prompt_large_download")
+        except Exception:
+            logger.exception("dialog crashed: _prompt_large_download")
+
         return result[0]
 
     def run(self):
@@ -3595,6 +3592,10 @@ class WhisperSync:
             self._backup.stop()
             if self._github_poller:
                 self._github_poller.stop()
+            try:
+                self._dialog_dispatcher.shutdown(timeout=2.0)
+            except Exception:
+                pass
 
 
 def main():

--- a/whisper_sync/dialog_dispatcher.py
+++ b/whisper_sync/dialog_dispatcher.py
@@ -1,0 +1,144 @@
+"""Single-thread dialog dispatcher for tkinter UI calls.
+
+Tkinter on Windows is not safe to use across short-lived rotating threads.
+Creating ``tk.Tk()`` on a fresh worker thread, running ``mainloop()``, and
+letting the thread exit corrupts heap/Win32 state in subtle ways that crash
+the next garbage collection cycle in whichever thread happens to allocate
+next. We saw this surface as Windows fatal exception ``0x80000003``
+(``STATUS_BREAKPOINT``) at ``speakers.py:541`` during ``json.load`` inside
+the meeting post-processing worker thread.
+
+The fix here is to funnel all tkinter dialog work through ONE long-lived
+thread (the dispatcher). Worker threads submit a callable, block on a
+per-request ``Event``, and read back the result. Because every dialog runs
+on the same thread, tkinter's thread-local state stays consistent across
+dialogs and never gets orphaned.
+
+This module deliberately knows nothing about the dialog implementations.
+Callers pass a no-arg callable that performs the full ``tk.Tk()`` /
+``mainloop()`` / ``root.destroy()`` cycle and returns whatever value the
+dialog produced (or raises). The dispatcher captures the return value or
+exception and hands it back to the caller's thread.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class _DialogRequest:
+    """Internal: a single dialog call queued for the dispatcher thread."""
+
+    __slots__ = ("fn", "label", "result", "exc", "done")
+
+    def __init__(self, fn: Callable[[], Any], label: str):
+        self.fn = fn
+        self.label = label
+        self.result: Any = None
+        self.exc: BaseException | None = None
+        self.done = threading.Event()
+
+
+class DialogDispatcher:
+    """Runs tkinter dialog callables serially on a single dedicated thread.
+
+    Lifecycle:
+        d = DialogDispatcher()
+        d.start()
+        ...
+        result = d.run(my_dialog_fn, label="ask_meeting_name")
+        ...
+        d.shutdown()
+
+    The dispatcher thread is a daemon, so the process can exit without an
+    explicit ``shutdown()`` call. ``shutdown()`` is provided for clean
+    teardown in tests and for graceful application shutdown.
+    """
+
+    _SENTINEL = object()
+
+    def __init__(self, name: str = "dialog-dispatcher"):
+        self._name = name
+        self._queue: "queue.Queue[Any]" = queue.Queue()
+        self._thread: threading.Thread | None = None
+        self._started = False
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        """Start the dispatcher thread. Idempotent."""
+        with self._lock:
+            if self._started:
+                return
+            self._thread = threading.Thread(
+                target=self._run_loop,
+                name=self._name,
+                daemon=True,
+            )
+            self._thread.start()
+            self._started = True
+            logger.debug("DialogDispatcher started")
+
+    def shutdown(self, timeout: float | None = 5.0) -> None:
+        """Signal the dispatcher to stop and wait for it to exit."""
+        with self._lock:
+            if not self._started:
+                return
+            self._queue.put(self._SENTINEL)
+        t = self._thread
+        if t is not None:
+            t.join(timeout=timeout)
+        with self._lock:
+            self._started = False
+            self._thread = None
+
+    def run(self, fn: Callable[[], Any], label: str = "dialog") -> Any:
+        """Submit a dialog callable to the dispatcher and wait for its result.
+
+        The callable runs on the dispatcher thread. It must perform its own
+        tkinter setup, mainloop, and teardown. Whatever it returns becomes
+        the return value of ``run``. If it raises, the exception is
+        re-raised in the caller's thread.
+
+        ``label`` is used for diagnostic logging only.
+        """
+        if not self._started:
+            # Lazy auto-start so callers don't have to remember to call
+            # start() before the first dialog.
+            self.start()
+
+        # Reentrancy guard: if the caller IS the dispatcher thread (e.g. a
+        # nested dialog request from within a dialog callback), just run
+        # inline. Submitting to our own queue would deadlock.
+        if threading.current_thread() is self._thread:
+            return fn()
+
+        req = _DialogRequest(fn, label)
+        self._queue.put(req)
+        # No timeout: dialogs intentionally have no hard cap. The user may
+        # take as long as they need to fill in a meeting name or confirm
+        # speakers. This matches the prior behavior of ``event.wait()``
+        # without an argument.
+        req.done.wait()
+        if req.exc is not None:
+            raise req.exc
+        return req.result
+
+    def _run_loop(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is self._SENTINEL:
+                logger.debug("DialogDispatcher received shutdown sentinel")
+                return
+            req: _DialogRequest = item
+            try:
+                req.result = req.fn()
+            except BaseException as e:  # noqa: BLE001 - hand exception to caller
+                req.exc = e
+                logger.exception("DialogDispatcher: %r raised", req.label)
+            finally:
+                req.done.set()


### PR DESCRIPTION
## Summary
- Add DialogDispatcher: single long-lived thread that serially runs tkinter dialogs
- Refactor all _ask_X / _show_X dialog methods to dispatch via this thread
- Fixes Windows heap corruption (fatal exception 0x80000003) during meeting post-processing

## Problem
tk.Tk() was being created on rotating short-lived daemon threads. Tkinter on Windows is not thread-safe across thread lifetimes; the heap state gets corrupted and surfaces during the next GC cycle in the same thread that called the dialog code. This caused crashes at speakers.py:541 during json.load in 14 meetings since 2026-04-28.

## Fix
A new `whisper_sync/dialog_dispatcher.py` module owns one long-lived dispatcher thread. Worker threads (e.g. the post-processing worker) submit a no-arg callable that creates `tk.Tk()`, runs `mainloop()`, and returns. The dispatcher serializes calls onto the same thread, captures return values and exceptions, and hands them back. Dialog visual behavior, button flow, and return contracts are unchanged.

Refactored sites:
- `_ask_meeting_name`
- `_ask_recovery_name`
- `_ask_speaker_confirmation` (the hot path that crashes)
- `_show_llm_unavailable`
- `_show_error_popup` (fire-and-forget bridge thread submits to dispatcher)
- `_change_output_folder` (outer + nested move dialog, both via dispatcher; reentrancy guard handles the same-thread nested call)
- `_prompt_large_download`

## This PR (Fix #1 of 4)
This is the root-cause fix. PR #128 already added the failsafe layer that lets the pipeline continue if speaker_id fails. With both PRs merged, speaker_id should no longer crash AND the pipeline degrades gracefully if it ever does.

## Test plan
- [x] `tests/test_dialog_dispatcher.py` (7 tests) covers serialization, thread-identity, exception propagation, lazy start, idempotent shutdown, reentrant inline calls
- [x] Existing non-numpy test suite passes (the 5 numpy-import errors are pre-existing environmental, not touched by this PR)
- [ ] Manual smoke test: complete a real meeting end-to-end without crash
- [ ] Manual smoke test: speaker confirmation dialog opens, confirms, writes map
- [ ] Manual smoke test: change output folder dialog (nested move dialog)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>