### PR TITLE
fix: avoid json.load on bg thread in flatten and minutes

### DIFF
--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,0 +1,61 @@
+"""Tests for whisper_sync.flatten.
+
+Covers the in-memory ``transcript_data`` argument that lets the
+post-processing pipeline avoid a second ``json.load`` on the background
+thread (root cause of the 0x80000003 crash mode).
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SAMPLE_TRANSCRIPT = {
+    "speaker_map": {"SPEAKER_00": "Alice", "SPEAKER_01": "Bob"},
+    "segments": [
+        {"speaker": "SPEAKER_00", "text": "Hello there.", "start": 0.0, "end": 2.0},
+        {"speaker": "SPEAKER_01", "text": "Hi Alice.", "start": 2.5, "end": 4.0},
+        {"speaker": "SPEAKER_00", "text": "How are you?", "start": 4.5, "end": 6.0},
+    ],
+}
+
+
+class FlattenTests(unittest.TestCase):
+    def test_flatten_uses_transcript_data_when_provided(self):
+        from whisper_sync.flatten import flatten
+
+        with tempfile.TemporaryDirectory() as tmp:
+            json_path = Path(tmp) / "transcript.json"
+            # Intentionally write garbage to disk to prove the in-memory dict
+            # was used (no json.load happened on the file).
+            json_path.write_text("{not valid json", encoding="utf-8")
+
+            out_path = flatten(str(json_path), transcript_data=SAMPLE_TRANSCRIPT)
+
+            self.assertTrue(out_path)
+            content = Path(out_path).read_text(encoding="utf-8")
+            self.assertIn("[Alice]", content)
+            self.assertIn("[Bob]", content)
+            self.assertIn("Hello there.", content)
+
+    def test_flatten_falls_back_to_disk_when_no_transcript_data(self):
+        # Default behavior (CLI / recovery flow) still needs to work.
+        from whisper_sync.flatten import flatten
+
+        with tempfile.TemporaryDirectory() as tmp:
+            json_path = Path(tmp) / "transcript.json"
+            json_path.write_text(
+                json.dumps(SAMPLE_TRANSCRIPT), encoding="utf-8"
+            )
+
+            out_path = flatten(str(json_path))
+
+            self.assertTrue(out_path)
+            content = Path(out_path).read_text(encoding="utf-8")
+            self.assertIn("[Alice]", content)
+            self.assertIn("[Bob]", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meeting_job.py
+++ b/tests/test_meeting_job.py
@@ -197,10 +197,11 @@ class StepSpeakerIdFailsafeTests(unittest.TestCase):
         )
         self.assertIsInstance(job.speakers_confirmed, dict)
 
-    def test_step_speaker_id_clears_transcript_data_on_confirmed_path(self):
-        # Regression for Copilot review on PR #131: the large transcript dict
-        # held on the post-processing thread must be released for GC after
-        # write_speaker_map. Confirmed-write path.
+    def test_step_speaker_id_retains_transcript_data_for_downstream_steps(self):
+        # Regression: step_flatten and step_minutes must reuse the in-memory
+        # transcript dict to avoid background-thread json.load (0x80000003
+        # crash). Therefore step_speaker_id must NOT release the dict.
+        # Confirmed-write path.
         class _AcceptApp(_StubApp):
             def _ask_speaker_confirmation(self, id_result):
                 return {"SPEAKER_00": "Alice"}
@@ -208,32 +209,34 @@ class StepSpeakerIdFailsafeTests(unittest.TestCase):
         fake, writes = _install_fake_speakers_module()
         with mock.patch.dict(sys.modules, {"whisper_sync.speakers": fake}):
             job = _make_speaker_id_job(app=_AcceptApp())
-            job.transcript_data = {"segments": [{"speaker": "SPEAKER_00"}]}
+            tdata = {"segments": [{"speaker": "SPEAKER_00"}]}
+            job.transcript_data = tdata
             job.step_speaker_id()
 
         self.assertEqual(
             job.speakers_confirmed, {"SPEAKER_00": "Alice"},
             "confirmed map should be applied",
         )
-        self.assertIsNone(
-            job.transcript_data,
-            "transcript_data should be cleared after confirmed write",
+        self.assertIs(
+            job.transcript_data, tdata,
+            "transcript_data must persist past speaker_id for flatten/minutes",
         )
 
-    def test_step_speaker_id_clears_transcript_data_on_placeholder_path(self):
+    def test_step_speaker_id_retains_transcript_data_on_placeholder_path(self):
         # Same regression, placeholder-write path (dialog skipped).
         fake, _writes = _install_fake_speakers_module(
             identify_side_effect=RuntimeError("claude exploded"),
         )
         with mock.patch.dict(sys.modules, {"whisper_sync.speakers": fake}):
             job = _make_speaker_id_job()
-            job.transcript_data = {"segments": [{"speaker": "SPEAKER_00"}]}
+            tdata = {"segments": [{"speaker": "SPEAKER_00"}]}
+            job.transcript_data = tdata
             job.step_speaker_id()
 
         self.assertIsNotNone(job.speakers_confirmed)
-        self.assertIsNone(
-            job.transcript_data,
-            "transcript_data should be cleared after placeholder write",
+        self.assertIs(
+            job.transcript_data, tdata,
+            "transcript_data must persist past placeholder write",
         )
 
     def test_step_speaker_id_leaves_speakers_unset_when_write_fails(self):
@@ -252,6 +255,69 @@ class StepSpeakerIdFailsafeTests(unittest.TestCase):
         self.assertIsNone(
             job.speakers_confirmed,
             "speakers_confirmed must remain unset when write_speaker_map fails",
+        )
+
+
+class StepFlattenAndCompleteTests(unittest.TestCase):
+    """Regression coverage: step_flatten must pass the in-memory transcript
+    dict through to ``flatten`` (avoids 0x80000003), and step_complete must
+    release the dict at the end of the pipeline.
+    """
+
+    def test_step_flatten_passes_transcript_data(self):
+        fake = types.ModuleType("whisper_sync.flatten")
+        captured = {}
+
+        def _flatten(json_path, transcript_data=None):
+            captured["json_path"] = json_path
+            captured["transcript_data"] = transcript_data
+            return "/tmp/x/transcript-readable.txt"
+
+        fake.flatten = _flatten
+
+        with mock.patch.dict(sys.modules, {"whisper_sync.flatten": fake}):
+            job = _make_speaker_id_job()
+            tdata = {"segments": [{"speaker": "SPEAKER_00"}]}
+            job.transcript_data = tdata
+            job.step_flatten()
+
+        self.assertEqual(captured["json_path"], "/tmp/x/transcript.json")
+        self.assertIs(
+            captured["transcript_data"], tdata,
+            "step_flatten must forward in-memory transcript dict to flatten",
+        )
+
+    def test_step_complete_releases_transcript_data(self):
+        # Build a minimal stub app with the surface step_complete needs.
+        class _CompleteApp(_StubApp):
+            def __init__(self):
+                super().__init__()
+                self.recorder = types.SimpleNamespace(is_recording=False)
+                self.state = types.SimpleNamespace(
+                    current=types.SimpleNamespace(mode="meeting"),
+                    emit=lambda *a, **kw: None,
+                )
+
+            def _schedule_idle(self, *a, **kw):
+                return None
+
+        from whisper_sync.meeting_job import MeetingJob
+
+        job = MeetingJob(
+            app=_CompleteApp(),
+            wav_path=Path("/tmp/x.wav"),
+            meeting_dir=Path("/tmp/x"),
+            name="complete-test",
+            summarize=False,
+            date_time_str="0101_0000",
+            week_dir="01-w1",
+            folder_name="0101_0000_complete-test",
+        )
+        job.transcript_data = {"segments": []}
+        job.step_complete()
+        self.assertIsNone(
+            job.transcript_data,
+            "step_complete must release transcript_data so the dict can be GC'd",
         )
 
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -2069,8 +2069,21 @@ class WhisperSync:
             p = get_install_root() / p
         return p
 
-    def _generate_minutes(self, meeting_dir: Path, readable_file: Path, minutes_file: Path):
-        """Generate minutes.md via Claude CLI (claude -p) using the shared prompt template."""
+    def _generate_minutes(
+        self,
+        meeting_dir: Path,
+        readable_file: Path,
+        minutes_file: Path,
+        transcript_data: dict | None = None,
+    ):
+        """Generate minutes.md via Claude CLI (claude -p) using the shared prompt template.
+
+        When ``transcript_data`` is provided, the parsed dict is used for the
+        speaker_map lookup and ``json.load`` is skipped. This avoids a Windows
+        fatal exception (``0x80000003``) that fires when ``json.load`` runs on
+        a background thread (the post-processing pipeline thread) and CPython's
+        GC interleaves with the C-level decoder.
+        """
         import json
         import subprocess as _sp
 
@@ -2082,28 +2095,36 @@ class WhisperSync:
         prompt_text = prompt_file.read_text(encoding="utf-8")
         transcript_text = readable_file.read_text(encoding="utf-8")
 
-        # Build speaker context from transcript.json speaker_map + config roles
+        # Build speaker context from transcript.json speaker_map + config roles.
+        # Use the in-memory dict when supplied; otherwise fall back to a disk
+        # read (e.g., when called from the recovery flow on a fresh thread).
         speaker_context = ""
         try:
-            json_path = meeting_dir / "transcript.json"
-            if json_path.exists():
-                with open(json_path) as f:
-                    tdata = json.load(f)
+            if transcript_data is not None:
+                tdata = transcript_data
                 smap = tdata.get("speaker_map", {})
-                if smap:
-                    cfg_path = Path(get_config_path())
-                    roles = {}
-                    if cfg_path.exists():
-                        for line in cfg_path.read_text(encoding="utf-8").splitlines():
-                            if line.startswith("| ") and " | " in line and "ID" not in line and "---" not in line:
-                                parts = [p.strip() for p in line.split("|") if p.strip()]
-                                if len(parts) >= 3:
-                                    roles[parts[1].lower()] = parts[2]
-                    ctx_lines = []
-                    for spk_id, name in smap.items():
-                        role = roles.get(name.lower(), "")
-                        ctx_lines.append(f"  {spk_id} = {name}" + (f" ({role})" if role else ""))
-                    speaker_context = "\n".join(ctx_lines)
+            else:
+                json_path = meeting_dir / "transcript.json"
+                if json_path.exists():
+                    with open(json_path) as f:
+                        tdata = json.load(f)
+                    smap = tdata.get("speaker_map", {})
+                else:
+                    smap = {}
+            if smap:
+                cfg_path = Path(get_config_path())
+                roles = {}
+                if cfg_path.exists():
+                    for line in cfg_path.read_text(encoding="utf-8").splitlines():
+                        if line.startswith("| ") and " | " in line and "ID" not in line and "---" not in line:
+                            parts = [p.strip() for p in line.split("|") if p.strip()]
+                            if len(parts) >= 3:
+                                roles[parts[1].lower()] = parts[2]
+                ctx_lines = []
+                for spk_id, name in smap.items():
+                    role = roles.get(name.lower(), "")
+                    ctx_lines.append(f"  {spk_id} = {name}" + (f" ({role})" if role else ""))
+                speaker_context = "\n".join(ctx_lines)
         except Exception:
             pass
 

--- a/whisper_sync/flatten.py
+++ b/whisper_sync/flatten.py
@@ -19,14 +19,24 @@ from pathlib import Path
 PAUSE_THRESHOLD = 2.0
 
 
-def flatten(json_path: str) -> str:
+def flatten(json_path: str, transcript_data: dict | None = None) -> str:
     """Flatten transcript JSON into readable speaker-attributed text.
 
     Returns the output file path.
+
+    When ``transcript_data`` is provided, the parsed dict is used directly
+    and ``json.load`` is skipped. This avoids a Windows fatal exception
+    (``0x80000003``) that fires when ``json.load`` runs on a background
+    thread and CPython's GC interleaves with the C-level decoder. The
+    post-processing pipeline thread keeps the dict in memory across stages
+    for exactly this reason.
     """
     path = Path(json_path)
-    with open(path) as f:
-        data = json.load(f)
+    if transcript_data is not None:
+        data = transcript_data
+    else:
+        with open(path) as f:
+            data = json.load(f)
 
     speaker_map = data.get("speaker_map", {})
     segments = data.get("segments", [])

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -247,11 +247,10 @@ class MeetingJob:
                             confirmed_map,
                             transcript_data=self.transcript_data,
                         )
-                        # Release the large transcript dict for GC. After
-                        # write_speaker_map returns, no other step in the job
-                        # reads self.transcript_data, so keeping it alive only
-                        # adds GC pressure on the post-processing thread.
-                        self.transcript_data = None
+                        # NOTE: do not release self.transcript_data here.
+                        # step_flatten and step_minutes also need it to avoid
+                        # background-thread json.load (0x80000003 crash). The
+                        # dict is released in step_complete.
                         cfg_path = get_config_path()
                         # config_updates from initial (light) identification.
                         # Deep mode config_updates are applied via the Meetings recovery flow.
@@ -324,11 +323,9 @@ class MeetingJob:
                             "Placeholder speakers applied: %s. Re-edit via Meetings tray menu recovery flow.",
                             placeholder_map,
                         )
-                    finally:
-                        # Release the transcript dict regardless of success.
-                        # Downstream steps do not consume self.transcript_data;
-                        # holding it just inflates the post-processing thread.
-                        self.transcript_data = None
+                    # NOTE: do not release self.transcript_data here.
+                    # step_flatten and step_minutes still need it. The dict
+                    # is released in step_complete.
 
     def _build_placeholder_speaker_map(self, json_path: str) -> dict[str, str]:
         """Read SPEAKER_XX labels from transcript and produce a placeholder map.
@@ -358,13 +355,20 @@ class MeetingJob:
         return {"SPEAKER_00": "Speaker 1", "SPEAKER_01": "Speaker 2"}
 
     def step_flatten(self):
-        """Flatten transcript JSON to readable text."""
+        """Flatten transcript JSON to readable text.
+
+        Passes the in-memory transcript dict to ``flatten`` so it does not
+        re-read transcript.json on this background thread (avoids the
+        0x80000003 crash where CPython GC interleaves with json.load).
+        """
         from .flatten import flatten as flatten_transcript
 
         try:
             json_path = self.transcript_result.get("json_path") if self.transcript_result else None
             if json_path:
-                readable_path = flatten_transcript(json_path)
+                readable_path = flatten_transcript(
+                    json_path, transcript_data=self.transcript_data
+                )
                 if readable_path:
                     logger.info("Flattened transcript: %s", readable_path)
         except Exception as e:
@@ -392,8 +396,14 @@ class MeetingJob:
             readable_file = self.meeting_dir / "transcript-readable.txt"
             minutes_file = self.meeting_dir / "minutes.md"
             if readable_file.exists() and not minutes_file.exists():
+                # Pass in-memory transcript dict to avoid background-thread
+                # json.load (0x80000003 crash). See speakers.write_speaker_map
+                # for the same rationale.
                 self.app._generate_minutes(
-                    self.meeting_dir, readable_file, minutes_file
+                    self.meeting_dir,
+                    readable_file,
+                    minutes_file,
+                    transcript_data=self.transcript_data,
                 )
         except Exception as e:
             logger.warning("Auto-minutes failed (non-fatal): %s", e)
@@ -501,3 +511,8 @@ class MeetingJob:
                 MEETING_COMPLETED, meeting_transcribing=False, mode="done"
             )
             self.app._schedule_idle(3, blink=True)
+
+        # Release the in-memory transcript dict now that all stages have run.
+        # It was retained across speaker_id, flatten, and minutes to avoid
+        # background-thread json.load (the 0x80000003 crash mode).
+        self.transcript_data = None


### PR DESCRIPTION
## Summary

PR #131 patched ``write_speaker_map`` but the Windows fatal exception
(``0x80000003`` / STATUS_BREAKPOINT) is still hitting on every meeting -
just one step later. Same root cause, different file.

Latest crash from ``whisper-sync-2026-05-06.log`` (two meetings today):

```
Step 3/8: step_flatten for Aloop-Syncup--domain-research...
Windows fatal exception: code 0x80000003
Current thread (most recent call first):
  Garbage-collecting
  File "json/decoder.py" raw_decode
  File "json/__init__.py" load
  File "flatten.py", line 29, in flatten
  File "meeting_job.py", line 367, in step_flatten
```

After ``step_speaker_id`` finishes (the path #131 fixed), ``step_flatten``
calls ``flatten()`` which does its OWN ``json.load`` on the same
post-processing background thread. CPython's GC interleaves with the
C-level decoder and the process dies. ``step_minutes`` does the same
thing further down the pipeline.

## Fix

Apply the same in-memory pattern the speaker_id fix established:

- ``flatten(json_path, transcript_data=None)`` - when the dict is
  supplied, skip ``json.load``.
- ``_generate_minutes(..., transcript_data=None)`` - same.
- ``MeetingJob`` keeps ``self.transcript_data`` alive across
  ``step_speaker_id``, ``step_flatten``, and ``step_minutes``. The dict
  is released in ``step_complete``.
- ``step_flatten`` and ``step_minutes`` pass ``self.transcript_data``
  through.

CLI flatten (``python -m whisper_sync.flatten``) keeps disk-load behavior
because that runs on a fresh main thread where ``json.load`` is safe.

## Tests

- New ``tests/test_flatten.py`` covers both in-memory and disk-fallback
  paths.
- Updated ``tests/test_meeting_job.py``: ``step_speaker_id`` no longer
  clears ``transcript_data``; ``step_complete`` does. New
  ``step_flatten`` test asserts pass-through.
- All 51 non-numpy tests pass; numpy-dependent tests are skipped (no
  numpy in system python; pre-existing).

## Test plan

- [ ] Restart WhisperSync and record a meeting; pipeline runs to
      ``step_complete`` without the 0x80000003 crash.
- [ ] ``transcript-readable.txt`` and ``minutes.md`` are produced.
- [ ] Existing recovery flow (Meetings tray menu) still works because it
      now calls ``flatten``/``_generate_minutes`` without supplying
      ``transcript_data`` and falls back to disk read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)