### PR TITLE
fix: bump speaker-id timeout to 240s, drop retry, log elapsed

### DIFF
--- a/whisper_sync/speakers.py
+++ b/whisper_sync/speakers.py
@@ -9,6 +9,7 @@ Handles:
 import json
 import re
 import subprocess
+import time
 from pathlib import Path
 
 from .logger import logger
@@ -275,53 +276,70 @@ def identify_speakers(
     if readable_text:
         full_prompt += f"\n\n---\n\nFull readable transcript (for boundary detection):\n{readable_text}"
 
-    max_attempts = 2
-    timeout_s = 90
-
-    for attempt in range(max_attempts):
-        try:
-            result = subprocess.run(
-                ["claude", "-p", "--model", "sonnet"],
-                input=full_prompt,
-                capture_output=True,
-                text=True,
-                timeout=timeout_s,
-                cwd=str(Path(__file__).parent.parent.parent),
+    # Empirically, claude -p --model sonnet on Windows takes 100-160s for a
+    # ~14K-char prompt (model latency, not MCP loading; --strict-mcp-config
+    # made no difference). The previous 90s/2-attempt setup never succeeded
+    # under those conditions and wasted 180s on every meeting before falling
+    # back to manual entry. One 240s attempt is a strict improvement: typical
+    # case auto-fills in ~2 min, worst case bails after 4 min.
+    timeout_s = 240
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--model", "sonnet"],
+            input=full_prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            cwd=str(Path(__file__).parent.parent.parent),
+        )
+        elapsed = time.monotonic() - started
+        if result.returncode != 0:
+            logger.warning(
+                "Speaker identification CLI failed (rc=%s, elapsed=%.1fs)",
+                result.returncode, elapsed,
             )
-            if result.returncode != 0:
-                logger.warning(f"Speaker identification CLI failed: {result.returncode}")
-                if result.stderr:
-                    logger.debug(f"Claude CLI stderr (truncated): {result.stderr[:500]}")
-                return None
+            if result.stderr:
+                logger.debug(f"Claude CLI stderr (truncated): {result.stderr[:500]}")
+            return None
 
-            # Robust JSON extraction: find first { to last }
-            response = result.stdout.strip()
-            first_brace = response.find("{")
-            last_brace = response.rfind("}")
-            if first_brace == -1 or last_brace == -1 or last_brace <= first_brace:
-                logger.warning("Speaker identification response contains no valid JSON object")
-                logger.debug(f"Raw response: {response[:500]}")
-                return None
+        # Robust JSON extraction: find first { to last }
+        response = result.stdout.strip()
+        first_brace = response.find("{")
+        last_brace = response.rfind("}")
+        if first_brace == -1 or last_brace == -1 or last_brace <= first_brace:
+            logger.warning(
+                "Speaker identification response contains no valid JSON object (elapsed=%.1fs)",
+                elapsed,
+            )
+            logger.debug(f"Raw response: {response[:500]}")
+            return None
 
-            json_str = response[first_brace:last_brace + 1]
-            return json.loads(json_str)
+        json_str = response[first_brace:last_brace + 1]
+        parsed = json.loads(json_str)
+        logger.info(
+            "Speaker identification succeeded (elapsed=%.1fs, mapped=%d)",
+            elapsed, len(parsed.get("speaker_map", {})),
+        )
+        return parsed
 
-        except json.JSONDecodeError as e:
-            logger.warning(f"Speaker identification returned invalid JSON: {e}")
-            logger.debug(f"Raw response: {result.stdout[:500]}")
-            return None
-        except FileNotFoundError:
-            logger.warning("Claude CLI not found - speaker identification skipped")
-            return None
-        except subprocess.TimeoutExpired:
-            if attempt < max_attempts - 1:
-                logger.warning(f"Speaker identification timed out ({timeout_s}s), retrying...")
-                continue
-            logger.warning(f"Speaker identification timed out after {max_attempts} attempts ({timeout_s}s each)")
-            return None
-        except Exception as e:
-            logger.warning(f"Speaker identification failed: {e}")
-            return None
+    except json.JSONDecodeError as e:
+        logger.warning(f"Speaker identification returned invalid JSON: {e}")
+        logger.debug(f"Raw response: {result.stdout[:500]}")
+        return None
+    except FileNotFoundError:
+        logger.warning("Claude CLI not found - speaker identification skipped")
+        return None
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - started
+        logger.warning(
+            "Speaker identification timed out after %.1fs (limit=%ss)",
+            elapsed, timeout_s,
+        )
+        return None
+    except Exception as e:
+        logger.warning(f"Speaker identification failed: {e}")
+        return None
 
 
 def opus_deep_identify(


### PR DESCRIPTION
## Summary

Speaker identification has timed out on every meeting in today's logs:

```
10:31:36 [WARNING] Speaker identification timed out (90s), retrying...
10:33:06 [WARNING] Speaker identification timed out after 2 attempts (90s each)
10:33:06 [WARNING] Speaker ID not applied, showing manual entry dialog
```

After confirming PR #132 fixed the post-processing crash, I dug into why
the 90s timeout never holds.

## Investigation

Direct timing of ``claude -p --model sonnet`` against the actual probe
prompt (~14K chars) for a real meeting:

| Run | Config | Time |
| --- | --- | --- |
| 1 | sonnet | 101.6s success |
| 2 | haiku | TIMEOUT @ 180s |
| 3 | sonnet | 136.5s success |
| 4 | sonnet --strict-mcp-config | 156.4s success |

The bottleneck is model latency, not MCP loading -
``--strict-mcp-config`` (skip MCP discovery) made no difference. The 90s
threshold simply never holds for this prompt size on this machine. With
2 attempts, every meeting wastes a full 180s before bailing to manual
entry, and the auto-fill path (the whole point of identify_speakers)
never triggers.

## Fix

- ``timeout_s`` 90 → 240 (covers observed P95 with margin)
- ``max_attempts`` 2 → 1 (retry takes same time; only doubles wait)
- Log elapsed seconds on success, timeout, and CLI-error paths so
  production data drives future tuning instead of guessing.

Worst-case wait shrinks from 180s (always-fail) to 240s (sometimes-fail);
typical case becomes ~120s with a populated dialog instead of empty
placeholders.

## Tests

- 16 affected tests pass (test_speakers, test_meeting_job, test_flatten).
- No new tests: this is a constant + control-flow change covered by the
  existing failsafe tests, and the actual subprocess behavior cannot be
  unit-tested.

## Test plan

- [ ] Restart WhisperSync, record a meeting; speaker dialog should
      auto-populate within ~2 min instead of opening empty after 3 min.
- [ ] Log shows ``Speaker identification succeeded (elapsed=Xs, mapped=N)``.
- [ ] If Claude CLI is genuinely down/slow, log shows
      ``Speaker identification timed out after Xs (limit=240s)`` instead
      of the old double-warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)