### PR TITLE
fix: disable cycle GC, run gc.collect at safe checkpoints

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1965,6 +1965,8 @@ class WhisperSync:
 
         Recording start/stop is NEVER touched here.
         """
+        import gc
+
         while True:
             job = self._post_queue.get()
             if job is None:
@@ -1976,6 +1978,17 @@ class WhisperSync:
                 logger.error(f"Post-processing failed for {job.name}: {e}", exc_info=True)
             finally:
                 self._post_queue.task_done()
+                # Cycle GC is disabled process-wide (see main()) to prevent
+                # GC interleaving with native C calls (multiprocessing,
+                # pystray, json.load) on this background thread. Run an
+                # explicit collection here at a safe checkpoint: the job is
+                # done, no native call is in flight, and the next get() will
+                # block until another meeting arrives.
+                collected = gc.collect()
+                if collected:
+                    logger.debug(
+                        "post-process gc.collect freed %d cycles", collected
+                    )
 
     def _run_meeting_job(self, job: MeetingJob):
         """Execute all steps of a MeetingJob with error recovery.
@@ -3639,6 +3652,22 @@ def main():
     # Install faulthandler FIRST so native segfaults are persisted. The
     # helper retains the file handle module-scope so it cannot be GC'd.
     install_faulthandler(get_log_path())
+
+    # Disable the CPython cycle collector process-wide. Refcounting still
+    # cleans up ~99% of objects; only true reference cycles need this. The
+    # cycle collector is what causes the recurring 0x80000003 / STATUS_BREAKPOINT
+    # crashes: it can fire on ANY background thread mid-allocation inside a
+    # native C extension, corrupting the heap. We've already had to patch
+    # json.load (PR #131, #132) one site at a time as crashes landed in:
+    #   - speakers.write_speaker_map (json.load)
+    #   - flatten/_generate_minutes (json.load)
+    #   - worker_manager._wait_response (multiprocessing.Queue.get)
+    #   - pystray._build_menu (pystray MenuItem __init__)
+    # The pattern is general, not call-specific. Disable auto-GC and run
+    # gc.collect() at safe checkpoints (between meetings, on idle) instead.
+    import gc
+    gc.disable()
+    logger.info("Cycle GC disabled; explicit gc.collect() at safe checkpoints")
 
     heartbeat = Heartbeat(logger, interval=60.0)
     try:

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3620,9 +3620,23 @@ class WhisperSync:
         # Periodic flush for persistent weekly stats
         self._stats_flush_stop = threading.Event()
         def _stats_flush_loop():
+            import gc
             while not self._stats_flush_stop.wait(weekly_stats._flush_interval):
                 try:
                     weekly_stats.flush()
+                except Exception:
+                    pass
+                # Cycle GC is disabled process-wide (see main()). The
+                # post-process worker covers meeting paths; this catches
+                # dictation-only sessions where _post_process_worker never
+                # ticks. Pure-Python flush above ran without any C call in
+                # flight, so this is a safe checkpoint.
+                try:
+                    collected = gc.collect()
+                    if collected:
+                        logger.debug(
+                            "stats-flush gc.collect freed %d cycles", collected
+                        )
                 except Exception:
                     pass
         threading.Thread(target=_stats_flush_loop, daemon=True).start()


### PR DESCRIPTION
## Summary

Today's log shows two NEW ``0x80000003`` crashes after the dev pull
(both fixes from yesterday confirmed merged at ``9f38969``):

```
09:36:18 step_transcribe / Company-Research---Chetan
  Current thread: Garbage-collecting
    multiprocessing/queues.py get
    worker_manager.py _wait_response
    meeting_job.py step_transcribe

15:10:11 step_minutes / Company-Research----Chetan
  Current thread: Garbage-collecting
    pystray/_base.py __init__   (MenuItem)
    __main__.py _build_menu
    __main__.py _refresh_menu
    __main__.py _process_overlay   (background thread)
```

Both crashes are the **same root mechanism** as the prior json.load
fixes: CPython cycle GC firing on a background thread mid-allocation
inside a native C extension, corrupting the heap. Different extensions,
identical pattern.

We've now had to patch the same crash mode in:

- ``speakers.write_speaker_map`` (json.load) — PR #131
- ``flatten`` and ``_generate_minutes`` (json.load) — PR #132
- ``worker_manager._wait_response`` (multiprocessing.Queue.get) — today
- ``pystray._build_menu`` (pystray MenuItem __init__) — today

Patching call-by-call can't keep up. Today the next crashes landed in
multiprocessing.Queue and pystray. Tomorrow it would be somewhere else.

## Fix

Structural intervention: disable the cycle collector process-wide, run
``gc.collect()`` at safe checkpoints (no native call in flight).

Refcounting still cleans up ~99% of objects automatically; only true
reference cycles need the cycle collector, and those get freed by the
explicit collect() calls at safe boundaries.

- ``main()``: ``gc.disable()`` at startup, before threads spawn
- ``_post_process_worker``: ``gc.collect()`` after each meeting,
  before the next ``queue.get()`` block (no C extension active)

This addresses ALL four crash sites uniformly and prevents the next
unknown one in the same family.

## Risk

- **Memory**: Cycle leaks accumulate between collect() calls. The
  post-process collect() runs after every meeting (≤1/min in heavy use,
  way more typical). If this ever becomes a measurable issue, add
  collect() checkpoints to the stats-flush loop and main idle loop.
- **Tests**: 51 pass. The change is structural; no logic to assert in
  unit tests beyond the call existing.

## Test plan

- [ ] Restart WhisperSync; log shows ``Cycle GC disabled; explicit
      gc.collect() at safe checkpoints``.
- [ ] Record several meetings back-to-back; pipeline runs end-to-end on
      every one without ``0x80000003``.
- [ ] Background overlay dictation during a meeting (the path that
      crashed at 15:10) does not crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)