### PR TITLE
fix: remove gc.collect() calls (regression from PR #134)

### DIFF
--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1965,8 +1965,6 @@ class WhisperSync:
 
         Recording start/stop is NEVER touched here.
         """
-        import gc
-
         while True:
             job = self._post_queue.get()
             if job is None:
@@ -1978,17 +1976,12 @@ class WhisperSync:
                 logger.error(f"Post-processing failed for {job.name}: {e}", exc_info=True)
             finally:
                 self._post_queue.task_done()
-                # Cycle GC is disabled process-wide (see main()) to prevent
-                # GC interleaving with native C calls (multiprocessing,
-                # pystray, json.load) on this background thread. Run an
-                # explicit collection here at a safe checkpoint: the job is
-                # done, no native call is in flight, and the next get() will
-                # block until another meeting arrives.
-                collected = gc.collect()
-                if collected:
-                    logger.debug(
-                        "post-process gc.collect freed %d cycles", collected
-                    )
+                # NOTE: do NOT call gc.collect() here. The cycle collector
+                # is process-wide and runs on the calling thread's stack;
+                # it can race with native C calls in any OTHER thread
+                # (subprocess.communicate for Claude CLI, multiprocessing
+                # queue feeders, pystray menu build) and crash with
+                # 0x80000003. See PR #134 which introduced this regression.
 
     def _run_meeting_job(self, job: MeetingJob):
         """Execute all steps of a MeetingJob with error recovery.
@@ -3620,25 +3613,19 @@ class WhisperSync:
         # Periodic flush for persistent weekly stats
         self._stats_flush_stop = threading.Event()
         def _stats_flush_loop():
-            import gc
             while not self._stats_flush_stop.wait(weekly_stats._flush_interval):
                 try:
                     weekly_stats.flush()
                 except Exception:
                     pass
-                # Cycle GC is disabled process-wide (see main()). The
-                # post-process worker covers meeting paths; this catches
-                # dictation-only sessions where _post_process_worker never
-                # ticks. Pure-Python flush above ran without any C call in
-                # flight, so this is a safe checkpoint.
-                try:
-                    collected = gc.collect()
-                    if collected:
-                        logger.debug(
-                            "stats-flush gc.collect freed %d cycles", collected
-                        )
-                except Exception:
-                    pass
+                # NOTE: do NOT call gc.collect() here. It is process-wide
+                # and crashes (0x80000003) when any other thread is mid
+                # native C call (e.g., subprocess.communicate waiting for
+                # Claude CLI for ~2 min per meeting). PR #134 added a
+                # gc.collect() here and shipped this regression; today's
+                # crashes (both at line 3635 in this loop) prove it. Cycle
+                # objects now leak slowly; refcount cleanup still works
+                # for ~99% of allocations. Accept the leak.
         threading.Thread(target=_stats_flush_loop, daemon=True).start()
 
         try:

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3622,10 +3622,10 @@ class WhisperSync:
                 # and crashes (0x80000003) when any other thread is mid
                 # native C call (e.g., subprocess.communicate waiting for
                 # Claude CLI for ~2 min per meeting). PR #134 added a
-                # gc.collect() here and shipped this regression; today's
-                # crashes (both at line 3635 in this loop) prove it. Cycle
-                # objects now leak slowly; refcount cleanup still works
-                # for ~99% of allocations. Accept the leak.
+                # gc.collect() here and shipped this regression; the
+                # crashes both pointed at the gc.collect() inside this
+                # loop. Cycle objects now leak slowly; refcount cleanup
+                # still works for ~99% of allocations. Accept the leak.
         threading.Thread(target=_stats_flush_loop, daemon=True).start()
 
         try:


### PR DESCRIPTION
## Summary

PR #134 added ``gc.collect()`` to ``_stats_flush_loop`` and
``_post_process_worker`` as "safe checkpoints." That reasoning was wrong:
``gc.collect()`` is process-wide and traverses live objects regardless
of what OTHER threads are doing.

Today's log (whisper-sync-2026-05-11.log) has two 0x80000003 crashes
with the same trace, both happening DURING ``gc.collect()`` while a
Claude CLI ``subprocess.communicate()`` was active in the post-process
thread:

```
Current thread (most recent call first):
  Garbage-collecting
  File "__main__.py", line 3635 in _stats_flush_loop
...
Thread (post-process):
  subprocess.communicate
  _generate_minutes (or _generate_name_suggestions)
  step_minutes / step_rename
```

In both cases the stats-flush thread's ``gc.collect()`` raced with an
active C call in the post-process thread and corrupted the heap. The
minutes/rename Claude calls run ~2 min each, so the stats-flush loop's
30s tick lands inside that window most of the time.

## Fix

Remove both ``gc.collect()`` calls. Keep ``gc.disable()`` at startup -
that part is correct and does prevent automatic GC, which was the
original crash cause.

Cycle objects now leak slowly. Refcount cleanup still works for the
vast majority of allocations. Memory growth from cycles is bounded
and tolerable; crashes are not.

## Mic warnings

The ``mic open attempt failed (rate=16000 dtype=float32)`` debug lines
and the ``mic: requested 16000 Hz float32 rejected; using 48000 Hz``
warnings are NOT crashes. They are the normal 16k to 48k probe-and-
fallback in ``capture._open_input_stream``. The 48k path succeeds.
Could be silenced via a "cache the effective rate after first open"
change in a separate small PR; not blocking.

## Test plan

- [ ] Restart WhisperSync; record meetings back-to-back with summarize
      enabled (so minutes/rename runs Claude CLI for ~2 min each).
- [ ] No ``0x80000003`` crash during that window.
- [ ] No ``stats-flush gc.collect freed N cycles`` debug lines.
- [ ] Memory usage growth over a full day is acceptable (Task Manager
      check). If pathological, revisit with a coordinated collect
      strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)