### PR TITLE
fix: cache mic format per-device to silence 16k probe noise

### DIFF
--- a/tests/test_capture_open_input.py
+++ b/tests/test_capture_open_input.py
@@ -38,7 +38,12 @@ class OpenInputStreamLadderTests(unittest.TestCase):
             return self._responder(kwargs)
 
         fake.InputStream = _fake_input_stream
-        fake.query_devices = lambda device: {"default_samplerate": 48000.0}
+        # Return a stable device name keyed off the requested device id, so
+        # the per-device cache key is deterministic across test calls.
+        fake.query_devices = lambda device: {
+            "default_samplerate": 48000.0,
+            "name": f"FakeMic-{device}",
+        }
 
         from whisper_sync import capture
         self._orig_sd = capture.sd
@@ -121,6 +126,46 @@ class OpenInputStreamLadderTests(unittest.TestCase):
                 dtype="float32", callback=lambda *_: None,
             )
 
+    def test_cache_keyed_by_device_name_not_raw_arg(self):
+        # device=None and device=7 must produce DIFFERENT cache entries
+        # even though both could resolve to "the default mic" at different
+        # times. The fake query_devices returns "FakeMic-None" for None
+        # and "FakeMic-7" for 7, so the keys differ.
+        from whisper_sync import capture
+        from whisper_sync.capture import _open_input_stream, _MIC_FORMAT_CACHE
+
+        responses = [
+            _FakePortAudioError("16k rejected"),
+            mock.Mock(name="stream-A"),  # device=None succeeds at 48k
+            _FakePortAudioError("16k rejected again"),
+            mock.Mock(name="stream-B"),  # device=7 succeeds at 48k
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+
+        _open_input_stream(
+            device=None, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+
+        with capture._MIC_FORMAT_CACHE_LOCK:
+            keys = list(_MIC_FORMAT_CACHE.keys())
+        device_names = sorted(k[0] for k in keys)
+        self.assertEqual(
+            device_names, ["FakeMic-7", "FakeMic-None"],
+            "cache must be keyed by resolved device name, not raw device arg",
+        )
+
     def test_cache_skips_probe_on_second_open(self):
         # First call: 16000 fails, 48000 succeeds -> cache (48000, float32)
         # for this device. Second call MUST hit the cache and open at 48000
@@ -162,10 +207,13 @@ class OpenInputStreamLadderTests(unittest.TestCase):
         self.assertEqual(cache_calls[0]["dtype"], "float32")
 
     def test_cache_evicts_and_reprobes_when_cached_format_fails(self):
-        # Prime cache with a known-good (48000, float32) for device 7.
+        # Prime cache with a known-good (48000, float32) for device 7. The
+        # cache key uses the resolved device NAME (from sd.query_devices),
+        # not the raw device id, so changing the OS default mic invalidates
+        # the entry automatically.
         from whisper_sync import capture
         from whisper_sync.capture import _open_input_stream, _MIC_FORMAT_CACHE
-        cache_key = (7, 16000, "float32", 1)
+        cache_key = ("FakeMic-7", 16000, "float32", 1)
         with capture._MIC_FORMAT_CACHE_LOCK:
             _MIC_FORMAT_CACHE[cache_key] = (48000, "float32")
 

--- a/tests/test_capture_open_input.py
+++ b/tests/test_capture_open_input.py
@@ -47,6 +47,10 @@ class OpenInputStreamLadderTests(unittest.TestCase):
 
     def setUp(self):
         self._install_fake_sd()
+        # Clear the per-device cache so prior test state doesn't bleed in.
+        from whisper_sync import capture
+        with capture._MIC_FORMAT_CACHE_LOCK:
+            capture._MIC_FORMAT_CACHE.clear()
 
     def test_first_attempt_succeeds_returns_requested_rate(self):
         self._responder = lambda kwargs: mock.Mock(name="stream")
@@ -115,6 +119,82 @@ class OpenInputStreamLadderTests(unittest.TestCase):
             _open_input_stream(
                 device=7, target_samplerate=16000, channels=1,
                 dtype="float32", callback=lambda *_: None,
+            )
+
+    def test_cache_skips_probe_on_second_open(self):
+        # First call: 16000 fails, 48000 succeeds -> cache (48000, float32)
+        # for this device. Second call MUST hit the cache and open at 48000
+        # directly with NO probe of 16000.
+        responses = [
+            _FakePortAudioError("16k rejected"),
+            mock.Mock(name="stream-1"),
+            mock.Mock(name="stream-2"),
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+
+        # First open: probes both rates.
+        _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        first_calls = list(self.calls)
+        self.assertEqual(len(first_calls), 2)
+
+        # Second open: cache hit, single attempt at 48000.
+        _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        cache_calls = self.calls[len(first_calls):]
+        self.assertEqual(
+            len(cache_calls), 1,
+            "second open should skip the probe and only call InputStream once",
+        )
+        self.assertEqual(cache_calls[0]["samplerate"], 48000)
+        self.assertEqual(cache_calls[0]["dtype"], "float32")
+
+    def test_cache_evicts_and_reprobes_when_cached_format_fails(self):
+        # Prime cache with a known-good (48000, float32) for device 7.
+        from whisper_sync import capture
+        from whisper_sync.capture import _open_input_stream, _MIC_FORMAT_CACHE
+        cache_key = (7, 16000, "float32", 1)
+        with capture._MIC_FORMAT_CACHE_LOCK:
+            _MIC_FORMAT_CACHE[cache_key] = (48000, "float32")
+
+        # Now simulate the device suddenly rejecting the cached format.
+        # The helper must evict the stale cache entry and re-probe.
+        responses = [
+            _FakePortAudioError("cached rate now rejected"),  # cached attempt
+            _FakePortAudioError("16k still rejected"),         # probe 16k
+            mock.Mock(name="recovered-stream"),                # probe 48k succeeds
+        ]
+
+        def _responder(kwargs):
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        self._responder = _responder
+        stream, rate = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(rate, 48000)
+        # Cache should have been re-populated with the now-working entry.
+        with capture._MIC_FORMAT_CACHE_LOCK:
+            self.assertEqual(
+                _MIC_FORMAT_CACHE.get(cache_key), (48000, "float32"),
+                "cache should refresh after eviction",
             )
 
 

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -53,6 +53,15 @@ def get_default_devices(api_filter: str | None = "WASAPI") -> dict:
     return {"input": defaults[0], "output": defaults[1]}
 
 
+# Cache of (device_key, target_samplerate, target_dtype, channels) -> (effective_rate, effective_dtype)
+# Lets us skip the probe-and-fail sequence on subsequent opens for the same
+# device that already rejected the target rate once. On Windows this avoids
+# logging "mic open attempt failed (rate=16000 ...)" + "16000 Hz float32 rejected"
+# on every dictation/meeting start.
+_MIC_FORMAT_CACHE: dict[tuple, tuple[int, str]] = {}
+_MIC_FORMAT_CACHE_LOCK = threading.Lock()
+
+
 def _open_input_stream(*, device, target_samplerate: int, channels: int,
                        dtype: str, callback):
     """Open ``sd.InputStream`` with a fallback ladder for format rejections.
@@ -73,7 +82,30 @@ def _open_input_stream(*, device, target_samplerate: int, channels: int,
     the target.
 
     Reraises the last ``PortAudioError`` if every attempt fails.
+
+    A successful (rate, dtype) combination is cached per device so future
+    opens skip the probe and avoid logging the same fallback every session.
     """
+    cache_key = (device, target_samplerate, dtype, channels)
+    with _MIC_FORMAT_CACHE_LOCK:
+        cached = _MIC_FORMAT_CACHE.get(cache_key)
+
+    if cached is not None:
+        cached_rate, cached_dtype = cached
+        try:
+            stream = sd.InputStream(
+                samplerate=cached_rate,
+                channels=channels,
+                dtype=cached_dtype,
+                device=device,
+                callback=callback,
+            )
+            return stream, cached_rate
+        except sd.PortAudioError:
+            # Device state changed; fall through to full probe.
+            with _MIC_FORMAT_CACHE_LOCK:
+                _MIC_FORMAT_CACHE.pop(cache_key, None)
+
     attempts = [(target_samplerate, dtype)]
     try:
         native = int(sd.query_devices(device)["default_samplerate"])
@@ -95,11 +127,18 @@ def _open_input_stream(*, device, target_samplerate: int, channels: int,
                 device=device,
                 callback=callback,
             )
-            if rate != target_samplerate or this_dtype != dtype:
-                logger.warning(
-                    "mic: requested %d Hz %s rejected; using %d Hz %s",
+            fell_back = (rate != target_samplerate or this_dtype != dtype)
+            if fell_back:
+                # Only log the fallback the FIRST time we discover it; cache
+                # hits below skip this branch. Use INFO not WARNING because
+                # the fallback succeeds and downstream code resamples.
+                logger.info(
+                    "mic: %d Hz %s rejected; using %d Hz %s "
+                    "(caching for this device)",
                     target_samplerate, dtype, rate, this_dtype,
                 )
+            with _MIC_FORMAT_CACHE_LOCK:
+                _MIC_FORMAT_CACHE[cache_key] = (rate, this_dtype)
             return stream, rate
         except sd.PortAudioError as e:
             last_err = e

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -85,8 +85,21 @@ def _open_input_stream(*, device, target_samplerate: int, channels: int,
 
     A successful (rate, dtype) combination is cached per device so future
     opens skip the probe and avoid logging the same fallback every session.
+    The cache key includes the resolved device name (not the raw ``device``
+    arg) so that ``device=None`` callers don't get a stale entry if the OS
+    default input device changes between calls.
     """
-    cache_key = (device, target_samplerate, dtype, channels)
+    # Resolve a stable device identity for the cache key. When the caller
+    # passes device=None, sd.query_devices(None) returns info about the
+    # current default device; including its name in the key means the
+    # cache automatically invalidates when the user swaps default mic.
+    try:
+        device_info = sd.query_devices(device)
+        device_name = device_info.get("name", "")
+    except Exception:
+        device_info = None
+        device_name = ""
+    cache_key = (device_name, target_samplerate, dtype, channels)
     with _MIC_FORMAT_CACHE_LOCK:
         cached = _MIC_FORMAT_CACHE.get(cache_key)
 
@@ -108,7 +121,9 @@ def _open_input_stream(*, device, target_samplerate: int, channels: int,
 
     attempts = [(target_samplerate, dtype)]
     try:
-        native = int(sd.query_devices(device)["default_samplerate"])
+        # Reuse the device_info we already queried above, if available.
+        info = device_info if device_info is not None else sd.query_devices(device)
+        native = int(info["default_samplerate"])
     except Exception:
         native = None
     if native and native != target_samplerate:


### PR DESCRIPTION
## Summary

The mic-open helper tries the caller-requested rate (16000 Hz float32)
first, then falls back to the device's native rate (48000) on Windows
where MME rejects 16k float32. The fallback works correctly and
downstream code resamples - but every single dictation/meeting start
emits:

```
DEBUG: mic open attempt failed (rate=16000 dtype=float32): ...
WARNING: mic: requested 16000 Hz float32 rejected; using 48000 Hz
```

Today's log has 50+ of these. They are NOT errors (the fallback path
succeeds and produces correct audio), but the user noticed them and
read them as errors during the crash investigation.

## Fix

- Cache ``(rate, dtype)`` per device after first successful open. Second
  and subsequent opens hit the cache and open at the working rate
  directly - no probe, no log line.
- If the cached format ever fails (device state changed, user swapped
  mic), evict and re-probe.
- Downgrade the first-time fallback log from WARNING to INFO since the
  fallback is a successful outcome.

## Tests

2 new tests in ``test_capture_open_input.py``:

- ``test_cache_skips_probe_on_second_open`` - prove second open uses
  exactly 1 ``InputStream`` call at the cached rate, not 2.
- ``test_cache_evicts_and_reprobes_when_cached_format_fails`` - prove
  cache is evicted and refreshed if device rejects the cached format.

51 existing tests still pass.

## Test plan

- [ ] Restart WhisperSync.
- [ ] First dictation/meeting start: log shows one INFO line about the
      16k -> 48k fallback (instead of WARNING).
- [ ] All subsequent starts: no mic warning/debug noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)