### PR TITLE
feat: stability rebuild phase 2 - tray mutation serialization + debounce

### DIFF
--- a/docs/plans/2026-05-11-stability-rebuild.md
+++ b/docs/plans/2026-05-11-stability-rebuild.md
@@ -254,4 +254,11 @@ Repo convention: unittest + fake modules in `sys.modules` (see
 ## 6. Progress log
 
 - **2026-05-11 (session 1)**: Full codebase read. This plan written.
-  Phase 1 implementation started (scheduler, executors, idle_gc + tests).
+  Phase 1 implemented: scheduler.py, executors.py (+ native_call gauge
+  wrapped around ALL main-process subprocess sites), idle_gc.py wired
+  into run(). 26 new tests. PR #137. Copilot caught a submit/shutdown
+  race in Executor (fixed: enqueue under lock) and a flaky test (fixed).
+  Phase 2 implemented on stacked branch feat/stability-phase2-tray:
+  tray_refresh.MenuRefresher (debounced single-owner menu rebuild),
+  _update_tray extended to own menu swaps under _tray_lock,
+  _refresh_menu converted to coalescing request. 7 new tests (84 total).

--- a/tests/test_tray_refresh.py
+++ b/tests/test_tray_refresh.py
@@ -1,0 +1,131 @@
+"""Tests for whisper_sync.tray_refresh — debounced single-owner menu refresh."""
+
+import threading
+import time
+import unittest
+
+from whisper_sync.scheduler import Scheduler
+from whisper_sync.tray_refresh import MenuRefresher
+
+
+class MenuRefresherTests(unittest.TestCase):
+    def setUp(self):
+        self.sched = Scheduler(name="test-tray-sched")
+        self.builds = []
+        self.applied = []
+        self.build_threads = set()
+        self.apply_threads = set()
+
+    def tearDown(self):
+        self.sched.shutdown(timeout=2.0)
+
+    def _make(self, debounce_s=0.05, build_fn=None):
+        def _build():
+            self.build_threads.add(threading.current_thread().name)
+            menu = object()
+            self.builds.append(menu)
+            return menu
+
+        def _apply(menu):
+            self.apply_threads.add(threading.current_thread().name)
+            self.applied.append(menu)
+
+        return MenuRefresher(
+            build_menu=build_fn or _build,
+            apply_menu=_apply,
+            debounce_s=debounce_s,
+            sched=self.sched,
+        )
+
+    def _wait_for(self, predicate, timeout=2.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.01)
+        return False
+
+    def test_burst_of_requests_coalesces_to_one_rebuild(self):
+        r = self._make(debounce_s=0.08)
+        for _ in range(10):
+            r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 1))
+        time.sleep(0.2)  # ensure no extra rebuilds trail in
+        self.assertEqual(len(self.builds), 1, "10 burst requests must build once")
+        self.assertEqual(len(self.applied), 1)
+
+    def test_request_after_completion_triggers_new_rebuild(self):
+        r = self._make(debounce_s=0.03)
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 1))
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 2))
+        self.assertEqual(len(self.builds), 2)
+
+    def test_applied_menu_is_the_built_menu(self):
+        r = self._make(debounce_s=0.02)
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 1))
+        self.assertIs(self.applied[0], self.builds[0])
+
+    def test_build_and_apply_run_on_scheduler_thread_not_caller(self):
+        r = self._make(debounce_s=0.02)
+        caller = threading.current_thread().name
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 1))
+        self.assertEqual(len(self.build_threads), 1)
+        self.assertEqual(self.build_threads, self.apply_threads)
+        self.assertNotIn(caller, self.build_threads,
+                         "rebuild must not run on the requesting thread")
+
+    def test_build_exception_does_not_break_future_requests(self):
+        calls = []
+
+        def _flaky_build():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("kaboom")
+            menu = object()
+            self.builds.append(menu)
+            return menu
+
+        r = self._make(debounce_s=0.02, build_fn=_flaky_build)
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(calls) == 1))
+        time.sleep(0.05)
+        self.assertEqual(len(self.applied), 0, "failed build must not apply")
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 1),
+                        "refresher must recover after a failed build")
+
+    def test_concurrent_requests_from_many_threads_coalesce(self):
+        r = self._make(debounce_s=0.08)
+        start = threading.Barrier(8)
+
+        def _spam():
+            start.wait(timeout=2.0)
+            for _ in range(5):
+                r.request()
+
+        threads = [threading.Thread(target=_spam, daemon=True) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=2.0)
+        self.assertTrue(self._wait_for(lambda: len(self.applied) >= 1))
+        time.sleep(0.2)
+        # 40 requests across 8 threads within the debounce window: at most
+        # 2 rebuilds can land (one if all fall in a single window; two if a
+        # request arrives while the first rebuild is mid-flight).
+        self.assertLessEqual(len(self.builds), 2,
+                             f"expected coalescing, got {len(self.builds)} rebuilds")
+
+    def test_rebuild_count_telemetry(self):
+        r = self._make(debounce_s=0.02)
+        self.assertEqual(r.rebuild_count, 0)
+        r.request()
+        self.assertTrue(self._wait_for(lambda: r.rebuild_count == 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tray_refresh.py
+++ b/tests/test_tray_refresh.py
@@ -126,6 +126,25 @@ class MenuRefresherTests(unittest.TestCase):
         r.request()
         self.assertTrue(self._wait_for(lambda: r.rebuild_count == 1))
 
+    def test_pending_released_when_scheduler_shut_down(self):
+        # Regression for Copilot review on PR #138: a shut-down scheduler
+        # returns a pre-cancelled handle; the pending flag must be released
+        # or every later request becomes a permanent no-op.
+        r = self._make(debounce_s=0.02)
+        self.sched.shutdown(timeout=2.0)
+        r.request()  # handle is pre-cancelled; must not wedge the flag
+        self.assertFalse(
+            r._pending,
+            "pending flag must be released when scheduling cannot run",
+        )
+        # A working scheduler must be able to serve future requests.
+        from whisper_sync.scheduler import Scheduler
+        self.sched = Scheduler(name="test-tray-sched-2")
+        r._sched = self.sched
+        r.request()
+        self.assertTrue(self._wait_for(lambda: len(self.applied) == 1),
+                        "refresher must recover once scheduling works again")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -138,6 +138,7 @@ class WhisperSync:
         self.recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
         self.tray = None
         self.state = None  # Initialized after tray creation in run()
+        self._menu_refresher = None  # MenuRefresher, created in run()
         self._lock = threading.RLock()
         self._tray_lock = threading.Lock()  # Serialize all tray icon/title updates (pystray not thread-safe)
         self._api_filter = "Windows WASAPI"  # None = show all
@@ -210,8 +211,14 @@ class WhisperSync:
                             shutil.copy2(f, dest)
                 logger.info(f"Migrated dictation logs -> {new_dict_dir}")
 
-    def _update_tray(self, icon=None, title=None):
-        """Thread-safe tray icon/title update. Serializes all pystray mutations."""
+    def _update_tray(self, icon=None, title=None, menu=None):
+        """Thread-safe tray update. Serializes ALL pystray mutations.
+
+        Every pystray write (icon, title, AND menu) must go through this
+        method under _tray_lock. Assigning tray.menu from arbitrary
+        threads raced the Win32 pump and corrupted the heap (2026-05-07
+        crash: _build_menu <- _refresh_menu <- _process_overlay).
+        """
         with self._tray_lock:
             if self.tray is None:
                 return
@@ -219,6 +226,9 @@ class WhisperSync:
                 self.tray.icon = icon
             if title is not None:
                 self.tray.title = title
+            if menu is not None:
+                self.tray.menu = menu
+                self.tray.update_menu()
 
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
@@ -2689,9 +2699,16 @@ class WhisperSync:
             pass  # toast is best-effort
 
     def _refresh_menu(self):
-        if self.tray:
-            self.tray.menu = self._build_menu()
-            self.tray.update_menu()
+        """Request a debounced menu rebuild. Safe from any thread.
+
+        The actual rebuild runs on the scheduler thread via MenuRefresher
+        and the swap goes through _update_tray under _tray_lock. Burst
+        requests (dictation completion fires history + stats + state
+        refreshes back-to-back) coalesce into one rebuild.
+        """
+        refresher = getattr(self, "_menu_refresher", None)
+        if refresher is not None and self.tray is not None:
+            refresher.request()
 
     def _save_and_refresh(self):
         config.save(self.cfg)
@@ -3546,6 +3563,15 @@ class WhisperSync:
             idle_icon(),
             "WhisperSync: Idle",
             menu=self._build_menu(),
+        )
+
+        # Debounced single-owner menu refresh (see tray_refresh.py). All
+        # _refresh_menu() calls from any thread coalesce here; the rebuild
+        # runs on the scheduler thread and swaps under _tray_lock.
+        from .tray_refresh import MenuRefresher
+        self._menu_refresher = MenuRefresher(
+            build_menu=self._build_menu,
+            apply_menu=lambda m: self._update_tray(menu=m),
         )
 
         self.state = StateManager(self.tray, self.cfg)

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -212,12 +212,15 @@ class WhisperSync:
                 logger.info(f"Migrated dictation logs -> {new_dict_dir}")
 
     def _update_tray(self, icon=None, title=None, menu=None):
-        """Thread-safe tray update. Serializes ALL pystray mutations.
+        """Thread-safe tray update under _tray_lock.
 
-        Every pystray write (icon, title, AND menu) must go through this
-        method under _tray_lock. Assigning tray.menu from arbitrary
-        threads raced the Win32 pump and corrupted the heap (2026-05-07
-        crash: _build_menu <- _refresh_menu <- _process_overlay).
+        Every pystray mutation must hold _tray_lock: either via this
+        method or, on the animation hot path, IconAnimator's direct
+        icon/title writes (icons.py) which take the same lock. Menu
+        swaps specifically must come through here (via MenuRefresher) —
+        assigning tray.menu from arbitrary threads raced the Win32 pump
+        and corrupted the heap (2026-05-07 crash: _build_menu <-
+        _refresh_menu <- _process_overlay).
         """
         with self._tray_lock:
             if self.tray is None:

--- a/whisper_sync/tray_refresh.py
+++ b/whisper_sync/tray_refresh.py
@@ -1,0 +1,84 @@
+"""Debounced, single-owner tray menu refresh.
+
+pystray is not thread-safe, and menu rebuilds are expensive: _build_menu
+allocates hundreds of MenuItem objects with closures. Historically,
+_refresh_menu() assigned ``tray.menu`` inline from whatever thread wanted
+a refresh (dictation workers, overlay threads, the GitHub poller, recovery
+threads). That raced the Win32 message pump reading the menu — the
+2026-05-07 15:10 crash trace is exactly ``_build_menu ← _refresh_menu ←
+_process_overlay`` corrupting the heap mid-MenuItem-construction.
+
+MenuRefresher fixes both problems:
+
+- **Single owner**: the rebuild runs on the shared scheduler thread, and
+  the swap is applied through a caller-supplied ``apply_menu`` callback
+  that takes the tray lock. Arbitrary threads only ever call
+  ``request()``, which is lock-cheap and never touches pystray.
+- **Debounce**: N requests within the window coalesce into ONE rebuild.
+  Menu refreshes happen after every dictation, every github poll, every
+  config change; bursts (e.g. dictation completion triggering history +
+  stats + state updates) previously rebuilt the menu several times
+  back-to-back.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+from .logger import logger
+from .scheduler import scheduler as _default_scheduler
+
+
+class MenuRefresher:
+    """Coalesces menu refresh requests into debounced single rebuilds."""
+
+    def __init__(
+        self,
+        build_menu: Callable[[], object],
+        apply_menu: Callable[[object], None],
+        debounce_s: float = 0.3,
+        sched=None,
+    ):
+        """
+        Args:
+            build_menu: builds and returns a new menu object. Runs on the
+                scheduler thread.
+            apply_menu: applies the built menu to the tray (must take the
+                tray lock internally). Runs on the scheduler thread.
+            debounce_s: coalescing window.
+            sched: scheduler override for tests; defaults to the shared
+                process scheduler.
+        """
+        self._build_menu = build_menu
+        self._apply_menu = apply_menu
+        self._debounce_s = debounce_s
+        self._sched = sched if sched is not None else _default_scheduler
+        self._lock = threading.Lock()
+        self._pending = False
+        # Telemetry for tests/forensics
+        self.rebuild_count = 0
+
+    def request(self) -> None:
+        """Request a menu refresh. Safe from any thread; coalesces bursts."""
+        with self._lock:
+            if self._pending:
+                return
+            self._pending = True
+        self._sched.call_later(self._debounce_s, self._run, label="menu-refresh")
+
+    def _run(self) -> None:
+        # Clear the pending flag FIRST so a request arriving during the
+        # rebuild schedules a fresh pass (it may carry newer state).
+        with self._lock:
+            self._pending = False
+        try:
+            menu = self._build_menu()
+        except Exception:
+            logger.exception("menu rebuild failed")
+            return
+        try:
+            self._apply_menu(menu)
+            self.rebuild_count += 1
+        except Exception:
+            logger.exception("menu apply failed")

--- a/whisper_sync/tray_refresh.py
+++ b/whisper_sync/tray_refresh.py
@@ -65,7 +65,20 @@ class MenuRefresher:
             if self._pending:
                 return
             self._pending = True
-        self._sched.call_later(self._debounce_s, self._run, label="menu-refresh")
+        try:
+            handle = self._sched.call_later(
+                self._debounce_s, self._run, label="menu-refresh"
+            )
+        except Exception:
+            handle = None
+            logger.exception("menu refresh scheduling failed")
+        # A shut-down scheduler returns a pre-cancelled handle (and a
+        # scheduling error yields none); the job will never run, so the
+        # pending flag must be released or every future request becomes
+        # a permanent no-op.
+        if handle is None or handle.cancelled:
+            with self._lock:
+                self._pending = False
 
     def _run(self) -> None:
         # Clear the pending flag FIRST so a request arriving during the


### PR DESCRIPTION
## Context

Phase 2 of **docs/plans/2026-05-11-stability-rebuild.md** (merged with
Phase 1 in #137).

## Problem

`_update_tray` serialized icon/title writes under `_tray_lock`, but
`_refresh_menu()` assigned `tray.menu` + `update_menu()` with **no lock**,
inline from whatever thread wanted a refresh: dictation workers, overlay
threads, the GitHub poller, recovery threads. `_build_menu()` allocates
hundreds of pystray MenuItems with closures, so this raced the Win32
message pump reading the menu. The 2026-05-07 15:10 crash trace is exactly
this path: `_build_menu <- _refresh_menu <- _process_overlay`.

## Changes

- **tray_refresh.py** — `MenuRefresher`: debounced (300 ms) single-owner
  menu rebuild. `request()` is lock-cheap and safe from any thread; the
  rebuild runs on the shared scheduler thread (from #137); bursts coalesce
  into ONE rebuild.
- `_update_tray` now accepts `menu=` and owns ALL pystray mutations under
  `_tray_lock` (icon, title, and menu + `update_menu()`).
- `_refresh_menu()` delegates to the refresher. All ~15 call sites keep
  working unchanged; pre-tray calls remain no-ops as before.

Side benefit: dictation completion previously triggered several
back-to-back full menu rebuilds (history + stats + state listeners);
now one. With gc disabled, fewer closure-heavy menu graphs also means
less garbage for the idle collector.

## Tests

7 new in `test_tray_refresh.py`: burst coalescing, recovery after build
failure, scheduler-thread ownership (never the requesting thread),
cross-thread burst coalescing, telemetry. **84 total pass.**

## Test plan

- [ ] Restart WhisperSync; menu still updates after dictations, config
      changes, github polls (within ~300 ms instead of instantly).
- [ ] No crash during overlay dictation while meeting transcribes (the
      05-07 reproduction path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)