### PR TITLE
feat: stability rebuild phase 4 - speaker loopback disk streaming

### DIFF
--- a/tests/test_capture_speaker_streaming.py
+++ b/tests/test_capture_speaker_streaming.py
@@ -1,0 +1,165 @@
+"""Tests for speaker-loopback disk streaming (flat-RAM meetings).
+
+Requires numpy/scipy (capture.py imports them at module level), so the
+whole module skips on interpreters without them — same convention as the
+other capture tests. Run with the app venv:
+
+    whisper-env/Scripts/python.exe -m unittest tests.test_capture_speaker_streaming
+"""
+
+import unittest
+
+try:
+    import numpy as np
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
+
+class _FakeWriter:
+    """Records write() calls; mimics StreamingWavWriter surface."""
+
+    def __init__(self, path="fake/speaker-temp.wav"):
+        from pathlib import Path
+        self.path = Path(path)
+        self.writes = []
+        self.closed = False
+
+    def write(self, chunk):
+        self.writes.append(chunk.copy())
+
+    def close(self):
+        self.closed = True
+
+
+@unittest.skipUnless(_HAS_NUMPY, "requires numpy/scipy (run under app venv)")
+class SpeakerStreamingTests(unittest.TestCase):
+    def _make_recorder(self):
+        from whisper_sync.capture import AudioRecorder
+        return AudioRecorder(sample_rate=16000)
+
+    def test_chunks_stream_to_writer_not_ram(self):
+        rec = self._make_recorder()
+        rec._speaker_native_rate = 48000
+        writer = _FakeWriter()
+        rec._speaker_writer = writer
+
+        # Feed 2 seconds of 48 kHz audio in 1000-frame chunks.
+        chunk = np.zeros((1000, 1), dtype=np.float32)
+        for _ in range(96):
+            rec._ingest_speaker_chunk(chunk)
+
+        self.assertEqual(
+            rec._speaker_data, [],
+            "disk-streaming mode must not accumulate chunks in RAM",
+        )
+        self.assertGreaterEqual(len(writer.writes), 1, "blocks must reach the writer")
+        total_frames = sum(len(w) for w in writer.writes)
+        # 96k frames @48k resampled to 16k -> ~32k frames written so far
+        # (the tail below one block may still be buffered).
+        self.assertGreater(total_frames, 16000)
+
+    def test_resampled_to_target_rate(self):
+        rec = self._make_recorder()
+        rec._speaker_native_rate = 48000
+        writer = _FakeWriter()
+        rec._speaker_writer = writer
+
+        # Exactly 1 second @48k triggers exactly one block flush.
+        chunk = np.ones((48000, 1), dtype=np.float32) * 0.5
+        rec._ingest_speaker_chunk(chunk)
+
+        self.assertEqual(len(writer.writes), 1)
+        # 48000 native frames -> 16000 target frames (3:1 decimation)
+        self.assertEqual(len(writer.writes[0]), 16000)
+
+    def test_ram_fallback_without_writer(self):
+        rec = self._make_recorder()
+        rec._speaker_native_rate = 48000
+        rec._speaker_writer = None
+
+        chunk = np.zeros((1000, 1), dtype=np.float32)
+        rec._ingest_speaker_chunk(chunk)
+        self.assertEqual(len(rec._speaker_data), 1, "no writer -> RAM as before")
+
+    def test_stop_flushes_tail_and_returns_speaker_path(self):
+        rec = self._make_recorder()
+        rec._speaker_native_rate = 48000
+        writer = _FakeWriter()
+        rec._speaker_writer = writer
+
+        # Half a second buffered — below the 1s flush threshold.
+        chunk = np.zeros((24000, 1), dtype=np.float32)
+        rec._ingest_speaker_chunk(chunk)
+        self.assertEqual(writer.writes, [], "tail below 1s stays buffered")
+
+        result = rec.stop()
+
+        self.assertTrue(writer.closed, "stop() must finalize the speaker WAV")
+        self.assertEqual(len(writer.writes), 1, "stop() must flush the tail block")
+        self.assertEqual(len(writer.writes[0]), 8000)  # 24000 @48k -> 8000 @16k
+        self.assertEqual(result.get("speaker_path"), writer.path)
+        self.assertNotIn("speaker", result, "disk path replaces in-memory array")
+        self.assertIsNone(rec._speaker_writer)
+
+    def test_start_streaming_opens_speaker_writer_when_loopback_active(self):
+        from whisper_sync import capture
+        rec = self._make_recorder()
+        rec._speaker_pa_stream = object()  # loopback "active"
+        rec._speaker_native_rate = 48000
+
+        created = []
+
+        class _FakeWavWriter(_FakeWriter):
+            def __init__(self, path, channels=1, rate=16000):
+                super().__init__(path)
+                self.channels = channels
+                self.rate = rate
+                created.append(self)
+
+        orig = capture.StreamingWavWriter
+        capture.StreamingWavWriter = _FakeWavWriter
+        try:
+            rec.start_streaming("fake/mic-temp.wav", disk_only=True)
+        finally:
+            capture.StreamingWavWriter = orig
+
+        self.assertEqual(len(created), 2, "mic AND speaker writers must open")
+        speaker = created[1]
+        self.assertEqual(speaker.path.name, "speaker-temp.wav")
+        self.assertEqual(
+            speaker.rate, 16000,
+            "speaker WAV must be written at target rate (post-resample)",
+        )
+        self.assertIs(rec._speaker_writer, speaker)
+
+    def test_start_streaming_ram_fallback_when_speaker_writer_fails(self):
+        from whisper_sync import capture
+        rec = self._make_recorder()
+        rec._speaker_pa_stream = object()
+
+        calls = []
+
+        class _FlakyWriter(_FakeWriter):
+            def __init__(self, path, channels=1, rate=16000):
+                calls.append(path)
+                if len(calls) == 2:  # mic ok, speaker fails
+                    raise OSError("disk full")
+                super().__init__(path)
+
+        orig = capture.StreamingWavWriter
+        capture.StreamingWavWriter = _FlakyWriter
+        try:
+            rec.start_streaming("fake/mic-temp.wav", disk_only=True)
+        finally:
+            capture.StreamingWavWriter = orig
+
+        self.assertIsNone(rec._speaker_writer, "failed open must fall back to RAM")
+        # And the RAM path still works
+        chunk = np.zeros((100, 1), dtype=np.float32)
+        rec._ingest_speaker_chunk(chunk)
+        self.assertEqual(len(rec._speaker_data), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capture_speaker_streaming.py
+++ b/tests/test_capture_speaker_streaming.py
@@ -11,9 +11,10 @@ import unittest
 
 try:
     import numpy as np
-    _HAS_NUMPY = True
+    import scipy.signal  # noqa: F401 -- capture.py imports it at module level
+    _HAS_DEPS = True
 except ImportError:
-    _HAS_NUMPY = False
+    _HAS_DEPS = False
 
 
 class _FakeWriter:
@@ -32,7 +33,7 @@ class _FakeWriter:
         self.closed = True
 
 
-@unittest.skipUnless(_HAS_NUMPY, "requires numpy/scipy (run under app venv)")
+@unittest.skipUnless(_HAS_DEPS, "requires numpy AND scipy (run under app venv)")
 class SpeakerStreamingTests(unittest.TestCase):
     def _make_recorder(self):
         from whisper_sync.capture import AudioRecorder
@@ -159,6 +160,53 @@ class SpeakerStreamingTests(unittest.TestCase):
         chunk = np.zeros((100, 1), dtype=np.float32)
         rec._ingest_speaker_chunk(chunk)
         self.assertEqual(len(rec._speaker_data), 1)
+
+    def test_pre_writer_backlog_migrates_on_next_ingest(self):
+        # Regression for Copilot review on PR #139: loopback starts in
+        # start() BEFORE start_streaming() opens the writer, so the first
+        # chunks land in _speaker_data. They must migrate to the disk
+        # stream, in order, not be silently dropped.
+        rec = self._make_recorder()
+        rec._speaker_native_rate = 48000
+
+        # Phase A: no writer yet — chunks accumulate in RAM (marker value 1.0).
+        early = np.ones((24000, 1), dtype=np.float32)
+        rec._ingest_speaker_chunk(early)
+        self.assertEqual(len(rec._speaker_data), 1)
+
+        # Phase B: writer opens; next chunk (marker 0.5) triggers migration
+        # and, with 24000+24000=48000 native frames buffered, one flush.
+        writer = _FakeWriter()
+        rec._speaker_writer = writer
+        late = np.ones((24000, 1), dtype=np.float32) * 0.5
+        rec._ingest_speaker_chunk(late)
+
+        self.assertEqual(rec._speaker_data, [], "backlog must migrate out of RAM")
+        self.assertEqual(len(writer.writes), 1)
+        block = writer.writes[0].reshape(-1)
+        self.assertEqual(len(block), 16000)  # 48000 @48k -> 16000 @16k
+        # Order check: first half of the resampled block comes from the
+        # early (1.0) audio, second half from the late (0.5) audio.
+        self.assertGreater(float(block[4000]), 0.75, "early audio must come first")
+        self.assertLess(float(block[12000]), 0.75, "late audio must come second")
+
+    def test_pre_writer_backlog_migrates_on_stop(self):
+        # Short-meeting case: writer opens but NO callback fires afterwards.
+        # stop() must still migrate + flush the backlog.
+        rec = self._make_recorder()
+        rec._speaker_native_rate = 48000
+
+        early = np.ones((24000, 1), dtype=np.float32)
+        rec._ingest_speaker_chunk(early)  # no writer yet -> RAM
+
+        writer = _FakeWriter()
+        rec._speaker_writer = writer
+        result = rec.stop()
+
+        self.assertEqual(len(writer.writes), 1, "stop() must flush migrated backlog")
+        self.assertEqual(len(writer.writes[0]), 8000)  # 24000 @48k -> 8000 @16k
+        self.assertTrue(writer.closed)
+        self.assertEqual(result.get("speaker_path"), writer.path)
 
 
 if __name__ == "__main__":

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1908,18 +1908,32 @@ class WhisperSync:
                 meeting_dir.mkdir(parents=True, exist_ok=True)
 
                 wav_path = meeting_dir / "recording.wav"
+
+                # Speaker channel may arrive as a disk path (disk-streamed
+                # at target rate — the flat-RAM path) or as an in-memory
+                # array (legacy/RAM fallback). Normalize to an array here;
+                # this read is the only transient large allocation left.
+                speaker_arr = None
+                if "speaker_path" in audio:
+                    from .streaming_wav import StreamingWavWriter
+                    speaker_arr = StreamingWavWriter.read_audio_from(
+                        audio["speaker_path"]
+                    ).reshape(-1, 1)
+                elif "speaker" in audio:
+                    speaker_arr = audio["speaker"]
+
                 if "mic_path" in audio:
                     # Disk-only mode: mic audio already on disk as streaming WAV
                     mic_wav_path = audio["mic_path"]
-                    if "speaker" in audio:
+                    if speaker_arr is not None:
                         from .streaming_wav import StreamingWavWriter
                         mic_array = StreamingWavWriter.read_audio_from(mic_wav_path)
-                        save_stereo_wav(str(wav_path), mic_array.reshape(-1, 1), audio["speaker"], self.cfg["sample_rate"])
+                        save_stereo_wav(str(wav_path), mic_array.reshape(-1, 1), speaker_arr, self.cfg["sample_rate"])
                     else:
                         import shutil
                         shutil.move(str(mic_wav_path), str(wav_path))
-                elif "speaker" in audio:
-                    save_stereo_wav(str(wav_path), audio["mic"], audio["speaker"], self.cfg["sample_rate"])
+                elif speaker_arr is not None:
+                    save_stereo_wav(str(wav_path), audio["mic"], speaker_arr, self.cfg["sample_rate"])
                 else:
                     save_wav(str(wav_path), audio["mic"], self.cfg["sample_rate"])
 

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -187,6 +187,12 @@ class AudioRecorder:
         self._pyaudio = None
         self._speaker_pa_stream = None
         self._speaker_native_rate: int | None = None
+        # Block buffer for in-callback speaker resampling (disk streaming).
+        # Chunks accumulate to ~1s blocks before each resample+write so the
+        # per-callback cost stays trivial and FIR edge effects are bounded
+        # to block boundaries (inaudible for ASR).
+        self._speaker_block: list[np.ndarray] = []
+        self._speaker_block_frames = 0
 
     def _mic_callback(self, indata, frames, time_info, status):
         try:
@@ -320,7 +326,7 @@ class AudioRecorder:
                         if native_channels > 1:
                             audio = audio.reshape(-1, native_channels).mean(axis=1)
                         mono = audio.reshape(-1, 1)
-                        self._speaker_data.append(mono.copy())
+                        self._ingest_speaker_chunk(mono)
                 except Exception:
                     pass
                 return (None, pyaudio.paContinue)
@@ -339,6 +345,46 @@ class AudioRecorder:
         except Exception as e:
             logger.warning(f"Speaker loopback failed: {e}")
             self._close_pyaudio()
+
+    def _ingest_speaker_chunk(self, mono: np.ndarray) -> None:
+        """Route a mono float32 speaker chunk to disk or RAM.
+
+        When a speaker writer is open (meeting disk-streaming mode), chunks
+        accumulate into ~1 second blocks, are resampled to the target rate,
+        and stream to disk — RAM stays flat for the whole meeting. Without
+        a writer (legacy/RAM mode), chunks accumulate in RAM as before.
+
+        Historically the speaker channel was ALWAYS RAM-accumulated at the
+        device's native rate: 48 kHz x 4 bytes ~= 691 MB/hour held for the
+        entire meeting. The mic channel got disk streaming; this gives the
+        speaker channel the same treatment.
+        """
+        if self._speaker_writer is None:
+            self._speaker_data.append(mono.copy())
+            return
+
+        self._speaker_block.append(mono.copy())
+        self._speaker_block_frames += len(mono)
+        native = self._speaker_native_rate or self.sample_rate
+        if self._speaker_block_frames >= native:  # ~1 second buffered
+            self._flush_speaker_block()
+
+    def _flush_speaker_block(self) -> None:
+        """Resample the buffered speaker block and write it to disk."""
+        if not self._speaker_block or self._speaker_writer is None:
+            self._speaker_block = []
+            self._speaker_block_frames = 0
+            return
+        block = np.concatenate(self._speaker_block, axis=0).reshape(-1)
+        self._speaker_block = []
+        self._speaker_block_frames = 0
+        native = self._speaker_native_rate or self.sample_rate
+        if native != self.sample_rate:
+            g = gcd(self.sample_rate, native)
+            block = resample_poly(block, self.sample_rate // g, native // g)
+        self._speaker_writer.write(
+            block.astype(np.float32, copy=False).reshape(-1, 1)
+        )
 
     def _close_pyaudio(self):
         """Clean up PyAudio loopback resources."""
@@ -379,12 +425,19 @@ class AudioRecorder:
             result["mic_path"] = self._mic_writer.path
         elif self._mic_data:
             result["mic"] = np.concatenate(self._mic_data, axis=0)
-        if self._speaker_data:
+
+        if self._speaker_writer is not None:
+            # Disk-streamed speaker channel: flush the tail block, finalize
+            # the WAV (already at target rate), hand back the path. The
+            # caller reads it lazily; RAM stayed flat for the whole meeting.
+            self._flush_speaker_block()
+            self._speaker_writer.close()
+            result["speaker_path"] = self._speaker_writer.path
+            self._speaker_writer = None
+        elif self._speaker_data:
             raw = np.concatenate(self._speaker_data, axis=0)
             # Resample from native rate to target sample rate if needed
             if self._speaker_native_rate and self._speaker_native_rate != self.sample_rate:
-                from math import gcd
-                from scipy.signal import resample_poly
                 up = self.sample_rate // gcd(self.sample_rate, self._speaker_native_rate)
                 down = self._speaker_native_rate // gcd(self.sample_rate, self._speaker_native_rate)
                 resampled = resample_poly(raw.flatten(), up, down)
@@ -402,7 +455,9 @@ class AudioRecorder:
 
         Args:
             mic_path: Path for mic WAV file.
-            speaker_path: Optional path for speaker WAV file.
+            speaker_path: Optional explicit path for the speaker WAV file.
+                Defaults to ``speaker-temp.wav`` next to ``mic_path`` when
+                the loopback stream is active and ``disk_only`` is set.
             disk_only: If True, skip RAM accumulation -- audio lives only on disk.
                 Use for long meetings to prevent MemoryError.
 
@@ -417,6 +472,26 @@ class AudioRecorder:
         # meeting silently captured nothing.
         self._mic_writer = writer
         self._disk_only = disk_only
+
+        # Speaker channel: stream to disk too when in disk_only mode and
+        # loopback is capturing. Historically the speaker channel was
+        # ALWAYS RAM-accumulated at native rate (~691 MB/hour); see
+        # _ingest_speaker_chunk. Failure here is non-fatal: the callback
+        # falls back to RAM accumulation exactly as before.
+        if disk_only and self.speaker_loopback_active:
+            if speaker_path is None:
+                speaker_path = Path(mic_path).parent / "speaker-temp.wav"
+            try:
+                self._speaker_block = []
+                self._speaker_block_frames = 0
+                self._speaker_writer = StreamingWavWriter(
+                    speaker_path, channels=1, rate=self.sample_rate
+                )
+            except Exception as e:
+                logger.warning(
+                    "Speaker disk streaming unavailable (RAM fallback): %s", e
+                )
+                self._speaker_writer = None
 
     def stop_streaming(self):
         """Close and finalize streaming WAV writers."""

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -363,11 +363,32 @@ class AudioRecorder:
             self._speaker_data.append(mono.copy())
             return
 
+        # Loopback capture starts in start() BEFORE start_streaming() opens
+        # the writer, so the first chunks land in _speaker_data. Migrate
+        # that backlog into the block buffer here (we ARE the callback
+        # thread — single consumer, no race) so meeting-start audio is not
+        # silently dropped when stop() returns only speaker_path.
+        self._migrate_speaker_backlog()
+
         self._speaker_block.append(mono.copy())
         self._speaker_block_frames += len(mono)
         native = self._speaker_native_rate or self.sample_rate
         if self._speaker_block_frames >= native:  # ~1 second buffered
             self._flush_speaker_block()
+
+    def _migrate_speaker_backlog(self) -> None:
+        """Move pre-writer RAM chunks into the disk-streaming block buffer.
+
+        Chunks captured between loopback start and writer creation are at
+        the same native rate the block buffer expects, so they prepend
+        cleanly. No-op when there is no backlog.
+        """
+        if not self._speaker_data:
+            return
+        backlog, self._speaker_data = self._speaker_data, []
+        # Prepend in order: backlog audio came first.
+        self._speaker_block = backlog + self._speaker_block
+        self._speaker_block_frames += sum(len(c) for c in backlog)
 
     def _flush_speaker_block(self) -> None:
         """Resample the buffered speaker block and write it to disk."""
@@ -427,9 +448,14 @@ class AudioRecorder:
             result["mic"] = np.concatenate(self._mic_data, axis=0)
 
         if self._speaker_writer is not None:
-            # Disk-streamed speaker channel: flush the tail block, finalize
-            # the WAV (already at target rate), hand back the path. The
-            # caller reads it lazily; RAM stayed flat for the whole meeting.
+            # Disk-streamed speaker channel: migrate any pre-writer backlog
+            # (covers meetings so short that no callback ran after the
+            # writer opened), flush the tail block, finalize the WAV
+            # (already at target rate), hand back the path. The caller
+            # reads it lazily; RAM stayed flat for the whole meeting.
+            # Safe: _recording is already False and the PA stream closed,
+            # so no callback can race these buffers.
+            self._migrate_speaker_backlog()
             self._flush_speaker_block()
             self._speaker_writer.close()
             result["speaker_path"] = self._speaker_writer.path


### PR DESCRIPTION
## Context

Phase 4 (memory) of **docs/plans/2026-05-11-stability-rebuild.md**.
Independent of #138 (Phase 2); branched from dev.

## Problem

The speaker loopback channel was **always RAM-accumulated at native rate
for the entire meeting**. `start_streaming()` only ever created the mic
writer; `_speaker_writer` was never assigned by any caller. At 48 kHz
float32 mono that is **~691 MB/hour** held until `stop()`, then a
full-size resample allocates more on top. Dominant memory consumer for
long meetings - a 2-hour meeting held ~1.4 GB before this change.

## Fix

Give the speaker channel the same disk-streaming treatment the mic has:

- `_ingest_speaker_chunk()` routes loopback chunks: with a writer open
  (meeting `disk_only` mode), chunks buffer into ~1 s blocks, resample
  to the target rate, and stream to `speaker-temp.wav`. RAM stays flat
  for the whole meeting. Without a writer, RAM accumulation works
  exactly as before (automatic fallback).
- `start_streaming(disk_only=True)` opens the speaker writer when
  loopback is active. Open failure logs and falls back to RAM.
- `stop()` flushes the tail, finalizes the WAV, returns `speaker_path`
  instead of a giant array.
- `_save_and_enqueue` normalizes `speaker_path`/`speaker` into one array
  read at save time (the only transient allocation left).

Resample-per-block FIR edge effects are bounded to 1 s block boundaries
(sub-millisecond transients) - irrelevant for ASR.

Crash safety unchanged: `speaker-temp.wav` was already covered by
`fix_orphan` scanning, `cleanup_temp_files`, and `discard_streaming`.

## Tests

6 new in `test_capture_speaker_streaming.py`: stream-not-RAM, 3:1
resample frame-count correctness, RAM fallback, tail flush + path
return, writer creation on start_streaming, open-failure fallback.

These need numpy/scipy (capture.py imports them at module level), so
they run under the app venv like the other capture tests:
- venv: **19 pass** (13 existing capture + 6 new)
- system suite: **77 pass**

## Test plan

- [ ] Record a meeting with speaker audio playing; recording.wav stereo
      output identical in structure to before.
- [ ] Task Manager during a 1h+ meeting: RAM stays flat instead of
      climbing ~11 MB/min.
- [ ] Abort path (Discard in naming dialog) cleans up speaker-temp.wav.
- [ ] Mic-only meetings (loopback unavailable) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)