### PR TITLE
feat: stability rebuild phase 3 - persistent Tk root for all dialogs

### DIFF
--- a/tests/test_dialog_dispatcher_root.py
+++ b/tests/test_dialog_dispatcher_root.py
@@ -1,0 +1,128 @@
+"""Tests for the DialogDispatcher persistent Tk root (stability Phase 3).
+
+Uses a fake tk factory so no real tkinter is needed. The contract under
+test: ONE root, created lazily on the dispatcher thread, passed to every
+wants_root dialog, destroyed exactly once on the dispatcher thread at
+shutdown — never left for interpreter-exit GC (the access-violation crash
+family in the May-June 2026 production logs).
+"""
+
+import threading
+import unittest
+
+from whisper_sync.dialog_dispatcher import DialogDispatcher
+
+
+class _FakeRoot:
+    def __init__(self):
+        self.created_on = threading.current_thread().name
+        self.destroyed = 0
+        self.destroyed_on = None
+
+    def destroy(self):
+        self.destroyed += 1
+        self.destroyed_on = threading.current_thread().name
+
+
+class DialogDispatcherRootTests(unittest.TestCase):
+    def setUp(self):
+        self.roots: list[_FakeRoot] = []
+
+        def _factory():
+            r = _FakeRoot()
+            self.roots.append(r)
+            return r
+
+        self.d = DialogDispatcher(name="test-dispatcher", tk_factory=_factory)
+        self.d.start()
+
+    def tearDown(self):
+        self.d.shutdown(timeout=2.0)
+
+    def test_root_created_lazily_and_reused_across_dialogs(self):
+        self.assertEqual(self.roots, [], "root must not exist before first dialog")
+
+        seen = []
+        for i in range(3):
+            self.d.run(lambda root: seen.append(root), label=f"dlg{i}", wants_root=True)
+
+        self.assertEqual(len(self.roots), 1, "exactly ONE root for many dialogs")
+        self.assertTrue(all(r is self.roots[0] for r in seen),
+                        "every dialog must receive the same persistent root")
+
+    def test_root_created_and_destroyed_on_dispatcher_thread(self):
+        self.d.run(lambda root: None, label="dlg", wants_root=True)
+        root = self.roots[0]
+        self.assertEqual(root.created_on, "test-dispatcher")
+
+        self.d.shutdown(timeout=2.0)
+        self.assertEqual(root.destroyed, 1, "root destroyed exactly once at shutdown")
+        self.assertEqual(
+            root.destroyed_on, "test-dispatcher",
+            "root must die on ITS OWN thread, never via GC elsewhere",
+        )
+
+    def test_shutdown_without_any_dialog_destroys_nothing(self):
+        self.d.shutdown(timeout=2.0)
+        self.assertEqual(self.roots, [], "no root was created, none to destroy")
+
+    def test_legacy_no_root_callable_still_works(self):
+        out = self.d.run(lambda: "legacy-result", label="legacy")
+        self.assertEqual(out, "legacy-result")
+        self.assertEqual(self.roots, [], "legacy dialogs must not force a root")
+
+    def test_dialog_exception_propagates_and_root_survives(self):
+        self.d.run(lambda root: None, label="ok", wants_root=True)
+
+        def _boom(root):
+            raise RuntimeError("dialog blew up")
+
+        with self.assertRaises(RuntimeError):
+            self.d.run(_boom, label="boom", wants_root=True)
+
+        root = self.roots[0]
+        self.assertEqual(root.destroyed, 0, "a crashing dialog must not kill the root")
+        # And the dispatcher keeps serving dialogs with the same root.
+        seen = []
+        self.d.run(lambda r: seen.append(r), label="after-boom", wants_root=True)
+        self.assertIs(seen[0], root)
+
+    def test_reentrant_wants_root_call_runs_inline_with_same_root(self):
+        outer_inner = []
+
+        def _outer(root):
+            # Nested dialog request from within a dialog (same thread) must
+            # run inline with the SAME root, not deadlock.
+            inner = self.d.run(lambda r: r, label="inner", wants_root=True)
+            outer_inner.append((root, inner))
+
+        self.d.run(_outer, label="outer", wants_root=True)
+        outer_root, inner_root = outer_inner[0]
+        self.assertIs(outer_root, inner_root)
+
+    def test_root_factory_failure_propagates_but_dispatcher_survives(self):
+        calls = []
+
+        def _flaky_factory():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("tk init failed")
+            r = _FakeRoot()
+            self.roots.append(r)
+            return r
+
+        d = DialogDispatcher(name="flaky-dispatcher", tk_factory=_flaky_factory)
+        d.start()
+        try:
+            with self.assertRaises(RuntimeError):
+                d.run(lambda root: None, label="first", wants_root=True)
+            # Second attempt: factory works, dispatcher recovered.
+            seen = []
+            d.run(lambda root: seen.append(root), label="second", wants_root=True)
+            self.assertEqual(len(seen), 1)
+        finally:
+            d.shutdown(timeout=2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dialog_dispatcher_root.py
+++ b/tests/test_dialog_dispatcher_root.py
@@ -100,6 +100,45 @@ class DialogDispatcherRootTests(unittest.TestCase):
         outer_root, inner_root = outer_inner[0]
         self.assertIs(outer_root, inner_root)
 
+    def test_timed_out_shutdown_keeps_dispatcher_state(self):
+        # Regression for Copilot review on PR #142: if shutdown's join
+        # times out (dialog still open), state must stay intact so a later
+        # start() cannot spawn a SECOND thread that would reuse the Tk
+        # root across threads.
+        gate = threading.Event()
+        entered = threading.Event()
+
+        def _blocking_dialog(root):
+            entered.set()
+            gate.wait(timeout=10.0)
+
+        # run() blocks until the dialog completes, so submit from a helper.
+        t = threading.Thread(
+            target=lambda: self.d.run(
+                _blocking_dialog, label="stuck", wants_root=True
+            ),
+            daemon=True,
+        )
+        t.start()
+        self.assertTrue(entered.wait(timeout=2.0))
+
+        # Shutdown with a tiny timeout: join times out, state must hold.
+        self.d.shutdown(timeout=0.05)
+        self.assertTrue(self.d._started, "timed-out shutdown must keep state")
+        first_thread = self.d._thread
+        self.assertIsNotNone(first_thread)
+
+        # start() while the original thread lives must NOT spawn another.
+        self.d.start()
+        self.assertIs(self.d._thread, first_thread)
+
+        # Release the dialog; the sentinel already queued by the first
+        # shutdown lets the loop exit; a second shutdown clears state.
+        gate.set()
+        t.join(timeout=2.0)
+        self.d.shutdown(timeout=2.0)
+        self.assertFalse(self.d._started)
+
     def test_root_factory_failure_propagates_but_dispatcher_survives(self):
         calls = []
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -1001,9 +1001,11 @@ class WhisperSync:
         """Show a dialog to name a recovered meeting. Returns name string or _ABORT."""
         result = [self._ABORT]
 
-        def _show():
+        def _show(_proot):
             import tkinter as tk
-            root = tk.Tk()
+            # Toplevel child of the persistent hidden root: no Tk/Tcl
+            # interpreter churn per dialog (stability rebuild Phase 3).
+            root = tk.Toplevel(_proot)
             root.title("WhisperSync: Recovered Meeting")
             root.attributes("-topmost", True)
             root.geometry("420x180")
@@ -1041,10 +1043,10 @@ class WhisperSync:
             root.geometry(f"+{x}+{y}")
 
             root.protocol("WM_DELETE_WINDOW", _skip)
-            root.mainloop()
+            self._run_modal(_proot, root)
 
         try:
-            self._dialog_dispatcher.run(_show, label="ask_recovery_name")
+            self._dialog_dispatcher.run(_show, label="ask_recovery_name", wants_root=True)
         except Exception:
             logger.exception("dialog crashed: _ask_recovery_name")
             return self._ABORT
@@ -1133,6 +1135,22 @@ class WhisperSync:
         root.geometry(f"+{x}+{y}")
 
     @staticmethod
+    def _run_modal(_proot, dlg):
+        """Run a Toplevel dialog modally on the persistent root.
+
+        Replaces the old per-dialog ``root.mainloop()``: the persistent
+        root's event loop services the Toplevel while ``wait_window``
+        blocks until the dialog is destroyed. grab_set makes it modal so
+        stray clicks on other dialogs can't interleave.
+        """
+        dlg.update_idletasks()
+        try:
+            dlg.grab_set()
+        except Exception:
+            pass  # not viewable yet / grab unavailable - non-fatal
+        _proot.wait_window(dlg)
+
+    @staticmethod
     def _style_window(root):
         """Apply consistent modern styling to a tkinter window."""
         root.configure(bg="#1e1e2e")
@@ -1182,12 +1200,12 @@ class WhisperSync:
         logger.info("dialog open: _ask_meeting_name")
         result = [self._ABORT]
 
-        def _show_dialog():
+        def _show_dialog(_proot):
             import tkinter as tk
 
             from .transcribe import DIARIZE_METHODS
 
-            root = tk.Tk()
+            root = tk.Toplevel(_proot)
             root.title("WhisperSync")
             self._style_window(root)
             root.geometry("440x210")
@@ -1287,7 +1305,7 @@ class WhisperSync:
 
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _abort)
-            root.mainloop()
+            self._run_modal(_proot, root)
 
         # Run on the shared dialog dispatcher thread. The dispatcher catches
         # exceptions and re-raises them in our thread, so we mirror the prior
@@ -1295,7 +1313,7 @@ class WhisperSync:
         # the prior contract: _save_and_enqueue's caller never sees a hang
         # if Tk init or geometry blows up mid-dialog.
         try:
-            self._dialog_dispatcher.run(_show_dialog, label="ask_meeting_name")
+            self._dialog_dispatcher.run(_show_dialog, label="ask_meeting_name", wants_root=True)
         except Exception:
             logger.exception("dialog crashed: _ask_meeting_name")
             result[0] = self._ABORT
@@ -1417,10 +1435,10 @@ class WhisperSync:
         """Show a dialog when Claude CLI is not available. Returns True if user checked 'don't show again'."""
         result = [False]
 
-        def _show():
+        def _show(_proot):
             import tkinter as tk
 
-            root = tk.Tk()
+            root = tk.Toplevel(_proot)
             root.title("WhisperSync")
             self._style_window(root)
             root.geometry("420x160")
@@ -1448,10 +1466,10 @@ class WhisperSync:
 
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _ok)
-            root.mainloop()
+            self._run_modal(_proot, root)
 
         try:
-            self._dialog_dispatcher.run(_show, label="show_llm_unavailable")
+            self._dialog_dispatcher.run(_show, label="show_llm_unavailable", wants_root=True)
         except Exception:
             logger.exception("dialog crashed: _show_llm_unavailable")
 
@@ -1500,10 +1518,10 @@ class WhisperSync:
                     if len(parts) >= 2:
                         known_names.append(parts[1])
 
-        def _show():
+        def _show(_proot):
             import tkinter as tk
 
-            root = tk.Tk()
+            root = tk.Toplevel(_proot)
             root.title("WhisperSync")
             self._style_window(root)
 
@@ -1862,7 +1880,7 @@ class WhisperSync:
 
             self._center_window(root)
             root.protocol("WM_DELETE_WINDOW", _skip)
-            root.mainloop()
+            self._run_modal(_proot, root)
 
         # Run on the shared dialog dispatcher thread. Previously this method
         # spawned a fresh daemon thread per call and ran tk.Tk() there. That
@@ -1870,7 +1888,7 @@ class WhisperSync:
         # later as STATUS_BREAKPOINT (0x80000003) at speakers.py:541 inside
         # json.load, on the post-processing worker thread.
         try:
-            self._dialog_dispatcher.run(_show, label="ask_speaker_confirmation")
+            self._dialog_dispatcher.run(_show, label="ask_speaker_confirmation", wants_root=True)
         except Exception:
             logger.exception("speaker dialog crashed")
             result[0] = None
@@ -2893,17 +2911,14 @@ class WhisperSync:
         consistent thread; we just don't block our caller. A small worker
         thread bridges the call so this method returns immediately as before.
         """
-        def _show():
-            import tkinter as tk
+        def _show(_proot):
             from tkinter import messagebox
-            root = tk.Tk()
-            root.withdraw()
-            messagebox.showerror(f"WhisperSync: {title}", message)
-            root.destroy()
+            # parent=persistent root: no Tk/Tcl interpreter churn.
+            messagebox.showerror(f"WhisperSync: {title}", message, parent=_proot)
 
         def _dispatch():
             try:
-                self._dialog_dispatcher.run(_show, label="error_popup")
+                self._dialog_dispatcher.run(_show, label="error_popup", wants_root=True)
             except Exception:
                 logger.exception("error popup failed: %s", title)
 
@@ -2922,19 +2937,15 @@ class WhisperSync:
         current = self._output_dir()
         result = [None]  # None=cancelled, (Path, bool)=(new_path, move_files)
 
-        def _show():
+        def _show(_proot):
             import tkinter as tk
             from tkinter import filedialog
-
-            root = tk.Tk()
-            root.withdraw()
-            root.attributes("-topmost", True)
 
             new_dir = filedialog.askdirectory(
                 title="Choose output folder for recordings",
                 initialdir=str(current) if current.exists() else str(Path.home()),
+                parent=_proot,
             )
-            root.destroy()
 
             if not new_dir or Path(new_dir) == current:
                 return
@@ -2952,8 +2963,8 @@ class WhisperSync:
             # this a same-thread call rather than a deadlock).
             move_result = [None]
 
-            def _show_move_dialog():
-                dlg = tk.Tk()
+            def _show_move_dialog(_mroot):
+                dlg = tk.Toplevel(_mroot)
                 dlg.title("WhisperSync")
                 self._style_window(dlg)
                 dlg.geometry("440x150")
@@ -2998,11 +3009,11 @@ class WhisperSync:
 
                 self._center_window(dlg)
                 dlg.protocol("WM_DELETE_WINDOW", _cancel)
-                dlg.mainloop()
+                self._run_modal(_mroot, dlg)
 
             # Same-thread call via dispatcher (reentrancy guard runs inline).
             try:
-                self._dialog_dispatcher.run(_show_move_dialog, label="change_output_move_dialog")
+                self._dialog_dispatcher.run(_show_move_dialog, label="change_output_move_dialog", wants_root=True)
             except Exception:
                 logger.exception("change-output move dialog crashed")
                 move_result[0] = None
@@ -3013,7 +3024,7 @@ class WhisperSync:
             result[0] = (new_path, move_result[0])
 
         try:
-            self._dialog_dispatcher.run(_show, label="change_output_folder")
+            self._dialog_dispatcher.run(_show, label="change_output_folder", wants_root=True)
         except Exception:
             logger.exception("change-output dialog crashed")
             return
@@ -3477,23 +3488,19 @@ class WhisperSync:
         """Show a tkinter dialog asking if user wants to download a large model."""
         result = [False]
 
-        def _show():
-            import tkinter as tk
+        def _show(_proot):
             from tkinter import messagebox
-            root = tk.Tk()
-            root.withdraw()
-            answer = messagebox.askyesno(
+            result[0] = messagebox.askyesno(
                 "WhisperSync: Large Download",
                 f"Model '{model_name}' ({size}) is not cached locally.\n\n"
                 f"Download now?\n\n"
                 f"Warning: This is a large download.\n"
                 f"Skip if you are on mobile data.",
+                parent=_proot,
             )
-            result[0] = answer
-            root.destroy()
 
         try:
-            self._dialog_dispatcher.run(_show, label="prompt_large_download")
+            self._dialog_dispatcher.run(_show, label="prompt_large_download", wants_root=True)
         except Exception:
             logger.exception("dialog crashed: _prompt_large_download")
 

--- a/whisper_sync/dialog_dispatcher.py
+++ b/whisper_sync/dialog_dispatcher.py
@@ -14,11 +14,15 @@ per-request ``Event``, and read back the result. Because every dialog runs
 on the same thread, tkinter's thread-local state stays consistent across
 dialogs and never gets orphaned.
 
-This module deliberately knows nothing about the dialog implementations.
-Callers pass a no-arg callable that performs the full ``tk.Tk()`` /
-``mainloop()`` / ``root.destroy()`` cycle and returns whatever value the
-dialog produced (or raises). The dispatcher captures the return value or
-exception and hands it back to the caller's thread.
+Second-generation fix (stability rebuild Phase 3): the dispatcher also
+owns ONE persistent hidden ``tk.Tk()`` root. Dialogs submitted with
+``wants_root=True`` receive it and build ``tk.Toplevel`` children instead
+of creating/destroying a full Tk (Tcl interpreter) per dialog. The
+create/destroy churn was the dominant crash family in the May-June 2026
+production logs: access violations in ``tkinter __del__`` and
+interpreter-shutdown GC faults over orphaned Tcl objects. The root is
+created lazily on the dispatcher thread and destroyed exactly once, on
+that same thread, at shutdown.
 """
 
 from __future__ import annotations
@@ -34,11 +38,12 @@ logger = logging.getLogger(__name__)
 class _DialogRequest:
     """Internal: a single dialog call queued for the dispatcher thread."""
 
-    __slots__ = ("fn", "label", "result", "exc", "done")
+    __slots__ = ("fn", "label", "wants_root", "result", "exc", "done")
 
-    def __init__(self, fn: Callable[[], Any], label: str):
+    def __init__(self, fn: Callable[..., Any], label: str, wants_root: bool):
         self.fn = fn
         self.label = label
+        self.wants_root = wants_root
         self.result: Any = None
         self.exc: BaseException | None = None
         self.done = threading.Event()
@@ -62,12 +67,28 @@ class DialogDispatcher:
 
     _SENTINEL = object()
 
-    def __init__(self, name: str = "dialog-dispatcher"):
+    def __init__(self, name: str = "dialog-dispatcher", tk_factory=None):
         self._name = name
         self._queue: "queue.Queue[Any]" = queue.Queue()
         self._thread: threading.Thread | None = None
         self._started = False
         self._lock = threading.Lock()
+        # Persistent hidden Tk root. Created lazily ON the dispatcher
+        # thread at the first wants_root dialog and destroyed exactly once
+        # at shutdown. Eliminates the tk.Tk() create/destroy churn that
+        # leaves Tcl interpreter objects whose __del__ crashes with access
+        # violations (the dominant crash family in May-June 2026 logs:
+        # "tkinter/__init__.py line 414 in __del__" + shutdown-GC faults).
+        self._root = None
+        # Test seam: returns a hidden root window. Defaults to real tkinter.
+        self._tk_factory = tk_factory if tk_factory is not None else self._default_tk_factory
+
+    @staticmethod
+    def _default_tk_factory():
+        import tkinter as tk
+        root = tk.Tk()
+        root.withdraw()  # never shown; dialogs are Toplevel children
+        return root
 
     def start(self) -> None:
         """Start the dispatcher thread. Idempotent."""
@@ -96,14 +117,22 @@ class DialogDispatcher:
             self._started = False
             self._thread = None
 
-    def run(self, fn: Callable[[], Any], label: str = "dialog") -> Any:
+    def run(self, fn: Callable[..., Any], label: str = "dialog",
+            wants_root: bool = False) -> Any:
         """Submit a dialog callable to the dispatcher and wait for its result.
 
-        The callable runs on the dispatcher thread. It must perform its own
-        tkinter setup, mainloop, and teardown. Whatever it returns becomes
-        the return value of ``run``. If it raises, the exception is
-        re-raised in the caller's thread.
+        The callable runs on the dispatcher thread. Two calling styles:
 
+        - ``wants_root=True`` (preferred): ``fn(root)`` receives the
+          persistent hidden Tk root. The dialog builds a ``tk.Toplevel``
+          child, runs ``root.wait_window(dlg)``, and never creates or
+          destroys a Tk/Tcl interpreter.
+        - ``wants_root=False`` (legacy): ``fn()`` manages its own tkinter
+          lifecycle. Still serialized, but churns a Tcl interpreter per
+          call - migrate these.
+
+        Whatever fn returns becomes the return value of ``run``. If it
+        raises, the exception is re-raised in the caller's thread.
         ``label`` is used for diagnostic logging only.
         """
         if not self._started:
@@ -115,9 +144,11 @@ class DialogDispatcher:
         # nested dialog request from within a dialog callback), just run
         # inline. Submitting to our own queue would deadlock.
         if threading.current_thread() is self._thread:
+            if wants_root:
+                return fn(self._ensure_root())
             return fn()
 
-        req = _DialogRequest(fn, label)
+        req = _DialogRequest(fn, label, wants_root)
         self._queue.put(req)
         # No timeout: dialogs intentionally have no hard cap. The user may
         # take as long as they need to fill in a meeting name or confirm
@@ -128,17 +159,43 @@ class DialogDispatcher:
             raise req.exc
         return req.result
 
-    def _run_loop(self) -> None:
-        while True:
-            item = self._queue.get()
-            if item is self._SENTINEL:
-                logger.debug("DialogDispatcher received shutdown sentinel")
-                return
-            req: _DialogRequest = item
+    def _ensure_root(self):
+        """Create the persistent hidden root if needed. Dispatcher thread only."""
+        if self._root is None:
+            self._root = self._tk_factory()
+            logger.debug("DialogDispatcher created persistent Tk root")
+        return self._root
+
+    def _destroy_root(self) -> None:
+        """Destroy the persistent root exactly once. Dispatcher thread only."""
+        if self._root is not None:
             try:
-                req.result = req.fn()
-            except BaseException as e:  # noqa: BLE001 - hand exception to caller
-                req.exc = e
-                logger.exception("DialogDispatcher: %r raised", req.label)
-            finally:
-                req.done.set()
+                self._root.destroy()
+                logger.debug("DialogDispatcher destroyed persistent Tk root")
+            except Exception:
+                logger.debug("Persistent Tk root destroy failed", exc_info=True)
+            self._root = None
+
+    def _run_loop(self) -> None:
+        try:
+            while True:
+                item = self._queue.get()
+                if item is self._SENTINEL:
+                    logger.debug("DialogDispatcher received shutdown sentinel")
+                    return
+                req: _DialogRequest = item
+                try:
+                    if req.wants_root:
+                        req.result = req.fn(self._ensure_root())
+                    else:
+                        req.result = req.fn()
+                except BaseException as e:  # noqa: BLE001 - hand exception to caller
+                    req.exc = e
+                    logger.exception("DialogDispatcher: %r raised", req.label)
+                finally:
+                    req.done.set()
+        finally:
+            # The root must die on ITS OWN thread, deterministically -
+            # never via interpreter-shutdown GC on some other thread
+            # (that is exactly the crash mode this class exists to fix).
+            self._destroy_root()

--- a/whisper_sync/dialog_dispatcher.py
+++ b/whisper_sync/dialog_dispatcher.py
@@ -23,6 +23,10 @@ production logs: access violations in ``tkinter __del__`` and
 interpreter-shutdown GC faults over orphaned Tcl objects. The root is
 created lazily on the dispatcher thread and destroyed exactly once, on
 that same thread, at shutdown.
+
+Scope: this covers the TRAY APP runtime (every dialog in __main__.py).
+installer_gui.py is a separate standalone installer process with its own
+single mainloop and is unaffected by per-dialog interpreter churn.
 """
 
 from __future__ import annotations
@@ -105,7 +109,15 @@ class DialogDispatcher:
             logger.debug("DialogDispatcher started")
 
     def shutdown(self, timeout: float | None = 5.0) -> None:
-        """Signal the dispatcher to stop and wait for it to exit."""
+        """Signal the dispatcher to stop and wait for it to exit.
+
+        State is cleared ONLY when the thread has actually exited. If the
+        join times out (e.g. a dialog is still open), the dispatcher stays
+        marked started: clearing state would let a later start() spawn a
+        SECOND dispatcher thread that reuses the persistent Tk root created
+        on the first thread - violating Tk thread-affinity and
+        reintroducing the exact crash class this class exists to prevent.
+        """
         with self._lock:
             if not self._started:
                 return
@@ -113,6 +125,12 @@ class DialogDispatcher:
         t = self._thread
         if t is not None:
             t.join(timeout=timeout)
+            if t.is_alive():
+                logger.warning(
+                    "DialogDispatcher shutdown timed out (dialog still open?); "
+                    "keeping dispatcher state intact"
+                )
+                return
         with self._lock:
             self._started = False
             self._thread = None


### PR DESCRIPTION
## Why now: this is the dominant RECENT crash family

Log validation across May 12 - June 10 (after the earlier fixes shipped)
shows near-daily crashes in two signatures the previous phases do NOT
cover:

- `tkinter/__init__.py line 414 in __del__` access violations
  (05-26, 06-01, 06-05)
- shutdown/restart 0x80000003 GC faults over orphaned Tcl objects
  (05-18, 05-21, 05-27, 06-10)

PR #129 serialized all dialogs onto one thread, but each dialog still
created and destroyed a full `tk.Tk()` (a complete Tcl interpreter).
The orphaned Tcl objects blow up later - in `__del__` during normal
operation or in the final interpreter-shutdown GC.

## Fix

- **DialogDispatcher owns ONE persistent hidden `tk.Tk()` root**:
  created lazily on the dispatcher thread, passed to `wants_root=True`
  dialog callables, destroyed exactly once on that same thread at
  shutdown - never left to interpreter-exit GC on a random thread.
- **All 8 dialog sites migrated** to `tk.Toplevel` children: meeting
  name, speaker confirmation (the big one), recovery name,
  LLM-unavailable, error popup / large-download prompt / folder picker
  (`parent=root`, no Tk creation at all), nested move dialog.
  Per-dialog `mainloop()` replaced by `_run_modal` (grab_set +
  `root.wait_window`) - same modal semantics.
- Zero `tk.Tk()` calls remain outside the dispatcher factory.

## Tests

- 7 contract tests with a fake-root factory (single root reused;
  created+destroyed on dispatcher thread exactly once; crashing dialog
  leaves root usable; reentrant nested dialog same-root inline; factory
  failure recovery; legacy callables unaffected).
- **Real-tkinter smoke verified on the dev machine**: 3 modal Toplevels
  served by one persistent root with clean shutdown.
- System suite: **92 pass**.

## Test plan

- [ ] Stop a meeting: naming dialog appears, modal, Save/Discard work.
- [ ] Speaker confirmation dialog: autocomplete, scroll, Deep Identify,
      Confirm/Skip all work.
- [ ] Quit/restart WhisperSync several times: no `access violation` /
      `tkinter __del__` lines in the log at exit.
- [ ] Days-long session with many dialogs: no 0x80000003 at shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)