### PR TITLE
feat: multi-channel mic support with mono downmix

### DIFF
--- a/docs/plans/2026-05-11-stability-rebuild.md
+++ b/docs/plans/2026-05-11-stability-rebuild.md
@@ -283,3 +283,27 @@ Repo convention: unittest + fake modules in `sys.modules` (see
     real timeouts), Phase 1b (migrate the ~20 ephemeral thread spawn
     sites in __main__.py onto the executors/scheduler). Phase 1b is the
     largest remaining diff; suggest one PR per group of spawn sites.
+
+- **2026-06-10/11 (session 2, overnight)**: Log validation across May 12 -
+  June 10 found the dominant RECENT crash family is tkinter Tcl churn
+  (access violations in tkinter __del__; shutdown-GC faults), confirming
+  Phase 3 as top priority. Shipped:
+  - **#141**: real-data test harness (6 integration tests against real
+    meetings, flatten byte-exact vs known-good outputs; opt-in WS_E2E=1
+    end-to-end worker transcription of a real recording). The E2E
+    immediately found and fixed a real bug: stage_finalize never
+    populated word_count/num_speakers/duration/speaker_segments - every
+    meeting logged "0 words, 0 speakers" and weekly stats recorded
+    zeros. Also: heartbeat now logs rss=NMB (memory forensics) and
+    dictation auto-stops at dictation_max_minutes (default 30).
+  - **#142 (Phase 3)**: persistent hidden Tk root in DialogDispatcher;
+    all 8 dialog sites in __main__.py are Toplevel children; zero
+    tk.Tk() churn in the tray app. Copilot caught a shutdown
+    state-clear race (fixed + regression test).
+  - **Multi-channel mic support** (user request): _open_input_stream
+    ladder now tries native max_input_channels when mono open is
+    rejected (laptop 4-mic arrays were unusable); _mic_callback
+    downmixes mean-across-channels before resample/write; effective
+    channel count cached. 8 new tests (channel ladder + downmix math).
+  - REMAINING: Phase 5 (state consolidation), Phase 6 (worker protocol),
+    Phase 1b (ephemeral thread migration onto executors).

--- a/tests/test_capture_mic_downmix.py
+++ b/tests/test_capture_mic_downmix.py
@@ -103,6 +103,23 @@ class MicDownmixTests(unittest.TestCase):
             atol=1e-3,
         )
 
+    def test_downmix_output_stays_float32(self):
+        # Regression for Copilot review on PR #143: the downmix result
+        # must remain float32 (the callback's normalization invariant) on
+        # every input dtype, including a hypothetical float64 input.
+        for in_dtype in (np.float32, np.int16, np.float64):
+            rec = self._make_recorder(channels=4)
+            frames = 64
+            if in_dtype == np.int16:
+                indata = np.full((frames, 4), 1000, dtype=in_dtype)
+            else:
+                indata = np.full((frames, 4), 0.25, dtype=in_dtype)
+            rec._mic_callback(indata, frames, None, None)
+            self.assertEqual(
+                rec._mic_data[0].dtype, np.float32,
+                f"downmix of {in_dtype.__name__} input must yield float32",
+            )
+
     def test_mono_input_unaffected(self):
         # channels=1 sessions must behave exactly as before.
         rec = self._make_recorder(channels=1)

--- a/tests/test_capture_mic_downmix.py
+++ b/tests/test_capture_mic_downmix.py
@@ -1,0 +1,144 @@
+"""Tests for multi-channel mic downmix (laptop mic-array support).
+
+Mic arrays (e.g. 4-mic laptop arrays) may reject a mono open entirely;
+_open_input_stream falls back to the device's native channel count and
+_mic_callback downmixes to mono (mean across channels) before resampling
+and writing. These tests drive _mic_callback directly with synthetic
+multi-channel audio and verify the downmix math.
+
+Requires numpy/scipy (capture.py imports them at module level). Run under
+the app venv:
+
+    whisper-env/Scripts/python.exe -m unittest tests.test_capture_mic_downmix
+"""
+
+import unittest
+
+try:
+    import numpy as np
+    import scipy.signal  # noqa: F401 -- capture.py imports it at module level
+    _HAS_DEPS = True
+except ImportError:
+    _HAS_DEPS = False
+
+
+@unittest.skipUnless(_HAS_DEPS, "requires numpy AND scipy (run under app venv)")
+class MicDownmixTests(unittest.TestCase):
+    def _make_recorder(self, channels=4, effective_rate=16000):
+        from whisper_sync.capture import AudioRecorder
+        rec = AudioRecorder(sample_rate=16000)
+        rec._recording = True
+        rec._mic_channels = channels
+        rec._mic_effective_rate = effective_rate
+        if effective_rate != 16000:
+            from math import gcd
+            g = gcd(16000, effective_rate)
+            rec._mic_resample_up = 16000 // g
+            rec._mic_resample_down = effective_rate // g
+        return rec
+
+    def test_four_channel_input_downmixes_to_channel_mean(self):
+        rec = self._make_recorder(channels=4)
+        # Channels carry constants 0.1, 0.2, 0.3, 0.4 -> mean 0.25.
+        frames = 1024
+        indata = np.tile(
+            np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32), (frames, 1)
+        )
+
+        rec._mic_callback(indata, frames, None, None)
+
+        self.assertEqual(len(rec._mic_data), 1)
+        mono = rec._mic_data[0]
+        self.assertEqual(mono.shape, (frames, 1), "output must be mono")
+        np.testing.assert_allclose(
+            mono, np.full((frames, 1), 0.25, dtype=np.float32), atol=1e-6,
+        )
+
+    def test_downmix_preserves_signal_content(self):
+        # Same 440 Hz sine on all 4 channels: the mono mean must equal the
+        # original sine (no attenuation, no phase change).
+        rec = self._make_recorder(channels=4)
+        frames = 1600
+        t = np.arange(frames, dtype=np.float32) / 16000.0
+        sine = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        indata = np.tile(sine.reshape(-1, 1), (1, 4))
+
+        rec._mic_callback(indata, frames, None, None)
+
+        mono = rec._mic_data[0].reshape(-1)
+        np.testing.assert_allclose(mono, sine, atol=1e-6)
+
+    def test_downmix_int16_input_normalizes_then_averages(self):
+        rec = self._make_recorder(channels=2)
+        frames = 64
+        # ch0 = +16384 (0.5 after /32768), ch1 = -16384 (-0.5) -> mean 0.0
+        indata = np.column_stack([
+            np.full(frames, 16384, dtype=np.int16),
+            np.full(frames, -16384, dtype=np.int16),
+        ])
+
+        rec._mic_callback(indata, frames, None, None)
+
+        mono = rec._mic_data[0]
+        np.testing.assert_allclose(
+            mono, np.zeros((frames, 1), dtype=np.float32), atol=1e-6,
+        )
+
+    def test_downmix_composes_with_resampling(self):
+        # 48 kHz 4-channel device: downmix to mono FIRST, then 3:1
+        # decimation to 16 kHz. One second in -> 16000 mono frames out.
+        rec = self._make_recorder(channels=4, effective_rate=48000)
+        frames = 48000
+        indata = np.full((frames, 4), 0.25, dtype=np.float32)
+
+        rec._mic_callback(indata, frames, None, None)
+
+        mono = rec._mic_data[0]
+        self.assertEqual(mono.shape[1], 1, "output must be mono")
+        self.assertEqual(len(mono), 16000, "48k input must resample to 16k")
+        # DC level survives downmix + resample (ignore FIR edge transients).
+        np.testing.assert_allclose(
+            mono[100:-100].reshape(-1),
+            np.full(len(mono) - 200, 0.25, dtype=np.float32),
+            atol=1e-3,
+        )
+
+    def test_mono_input_unaffected(self):
+        # channels=1 sessions must behave exactly as before.
+        rec = self._make_recorder(channels=1)
+        frames = 256
+        indata = np.full((frames, 1), 0.7, dtype=np.float32)
+
+        rec._mic_callback(indata, frames, None, None)
+
+        mono = rec._mic_data[0]
+        np.testing.assert_allclose(
+            mono, np.full((frames, 1), 0.7, dtype=np.float32), atol=1e-6,
+        )
+
+    def test_downmixed_audio_reaches_disk_writer(self):
+        # Meeting path: multi-channel mic with disk streaming must write
+        # MONO frames to the WAV writer (header says channels=1).
+        class _FakeWriter:
+            def __init__(self):
+                self.writes = []
+
+            def write(self, chunk):
+                self.writes.append(chunk.copy())
+
+        rec = self._make_recorder(channels=4)
+        rec._disk_only = True
+        writer = _FakeWriter()
+        rec._mic_writer = writer
+
+        frames = 512
+        indata = np.full((frames, 4), 0.2, dtype=np.float32)
+        rec._mic_callback(indata, frames, None, None)
+
+        self.assertEqual(len(writer.writes), 1)
+        self.assertEqual(writer.writes[0].shape, (frames, 1),
+                         "disk writer must receive mono frames")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capture_open_input.py
+++ b/tests/test_capture_open_input.py
@@ -43,6 +43,7 @@ class OpenInputStreamLadderTests(unittest.TestCase):
         fake.query_devices = lambda device: {
             "default_samplerate": 48000.0,
             "name": f"FakeMic-{device}",
+            "max_input_channels": 4,
         }
 
         from whisper_sync import capture
@@ -60,7 +61,7 @@ class OpenInputStreamLadderTests(unittest.TestCase):
     def test_first_attempt_succeeds_returns_requested_rate(self):
         self._responder = lambda kwargs: mock.Mock(name="stream")
         from whisper_sync.capture import _open_input_stream
-        stream, rate = _open_input_stream(
+        stream, rate, channels = _open_input_stream(
             device=7, target_samplerate=16000, channels=1,
             dtype="float32", callback=lambda *_: None,
         )
@@ -69,51 +70,92 @@ class OpenInputStreamLadderTests(unittest.TestCase):
         self.assertEqual(len(self.calls), 1)
 
     def test_falls_back_to_native_samplerate_on_portaudio_error(self):
-        responses = [
-            _FakePortAudioError("MME error 32"),  # first try
-            mock.Mock(name="stream"),             # second try ok
-        ]
-
+        # Device rejects ANYTHING at 16 kHz (rate problem, like MME error
+        # 32) regardless of channel count; accepts native 48 kHz.
         def _responder(kwargs):
-            r = responses.pop(0)
-            if isinstance(r, Exception):
-                raise r
-            return r
+            if kwargs["samplerate"] == 16000:
+                raise _FakePortAudioError("MME error 32")
+            return mock.Mock(name="stream")
 
         self._responder = _responder
         from whisper_sync.capture import _open_input_stream
-        stream, rate = _open_input_stream(
+        stream, rate, channels = _open_input_stream(
             device=7, target_samplerate=16000, channels=1,
             dtype="float32", callback=lambda *_: None,
         )
         self.assertIsNotNone(stream)
         self.assertEqual(rate, 48000)  # device default from fake query_devices
-        # First attempt at 16000, second at 48000
+        self.assertEqual(channels, 1, "rate fallback should keep mono")
         self.assertEqual(self.calls[0]["samplerate"], 16000)
-        self.assertEqual(self.calls[1]["samplerate"], 48000)
+        self.assertEqual(self.calls[-1]["samplerate"], 48000)
 
     def test_falls_back_to_int16_when_float32_and_native_both_fail(self):
-        responses = [
-            _FakePortAudioError("float32/16k rejected"),
-            _FakePortAudioError("float32/48k rejected"),
-            mock.Mock(name="stream"),
-        ]
-
+        # Device only accepts int16 (any rate/channels).
         def _responder(kwargs):
-            r = responses.pop(0)
-            if isinstance(r, Exception):
-                raise r
-            return r
+            if kwargs["dtype"] != "int16":
+                raise _FakePortAudioError("float32 rejected")
+            return mock.Mock(name="stream")
 
         self._responder = _responder
         from whisper_sync.capture import _open_input_stream
-        stream, rate = _open_input_stream(
+        stream, rate, channels = _open_input_stream(
             device=7, target_samplerate=16000, channels=1,
             dtype="float32", callback=lambda *_: None,
         )
         self.assertIsNotNone(stream)
         self.assertEqual(rate, 48000)
         self.assertEqual(self.calls[-1]["dtype"], "int16")
+
+    def test_mic_array_rejecting_mono_falls_back_to_native_channels(self):
+        # The user-reported case: a laptop 4-mic array refuses ANY mono
+        # open but accepts its native 4-channel format. Previously every
+        # rung used channels=1, all failed, and the app was unusable with
+        # the built-in mic.
+        def _responder(kwargs):
+            if kwargs["channels"] == 1:
+                raise _FakePortAudioError("mono not supported by mic array")
+            return mock.Mock(name="stream")
+
+        self._responder = _responder
+        from whisper_sync.capture import _open_input_stream
+        stream, rate, channels = _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        self.assertIsNotNone(stream)
+        self.assertEqual(channels, 4, "must fall back to native channel count")
+        self.assertEqual(rate, 16000, "rate should stay at target when only channels failed")
+        # Mono was attempted FIRST (preferred), 4ch second.
+        self.assertEqual(self.calls[0]["channels"], 1)
+        self.assertEqual(self.calls[1]["channels"], 4)
+
+    def test_channel_fallback_caches_effective_channels(self):
+        from whisper_sync import capture
+        from whisper_sync.capture import _open_input_stream, _MIC_FORMAT_CACHE
+
+        def _responder(kwargs):
+            if kwargs["channels"] == 1:
+                raise _FakePortAudioError("mono not supported")
+            return mock.Mock(name="stream")
+
+        self._responder = _responder
+        _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        with capture._MIC_FORMAT_CACHE_LOCK:
+            cached = _MIC_FORMAT_CACHE[("FakeMic-7", 16000, "float32", 1)]
+        self.assertEqual(cached, (16000, "float32", 4))
+
+        # Second open: single cache-hit call straight at 4 channels.
+        first_calls = len(self.calls)
+        _open_input_stream(
+            device=7, target_samplerate=16000, channels=1,
+            dtype="float32", callback=lambda *_: None,
+        )
+        cache_calls = self.calls[first_calls:]
+        self.assertEqual(len(cache_calls), 1)
+        self.assertEqual(cache_calls[0]["channels"], 4)
 
     def test_reraises_if_all_attempts_fail(self):
         def _responder(kwargs):
@@ -167,81 +209,69 @@ class OpenInputStreamLadderTests(unittest.TestCase):
         )
 
     def test_cache_skips_probe_on_second_open(self):
-        # First call: 16000 fails, 48000 succeeds -> cache (48000, float32)
-        # for this device. Second call MUST hit the cache and open at 48000
-        # directly with NO probe of 16000.
-        responses = [
-            _FakePortAudioError("16k rejected"),
-            mock.Mock(name="stream-1"),
-            mock.Mock(name="stream-2"),
-        ]
-
+        # First open: device rejects 16 kHz (any channels), accepts 48 kHz
+        # mono -> cache (48000, float32, 1). Second open MUST hit the
+        # cache: a single InputStream call at 48 kHz, no 16 kHz probe.
         def _responder(kwargs):
-            r = responses.pop(0)
-            if isinstance(r, Exception):
-                raise r
-            return r
+            if kwargs["samplerate"] == 16000:
+                raise _FakePortAudioError("16k rejected")
+            return mock.Mock(name="stream")
 
         self._responder = _responder
         from whisper_sync.capture import _open_input_stream
 
-        # First open: probes both rates.
         _open_input_stream(
             device=7, target_samplerate=16000, channels=1,
             dtype="float32", callback=lambda *_: None,
         )
-        first_calls = list(self.calls)
-        self.assertEqual(len(first_calls), 2)
+        first_calls = len(self.calls)
+        self.assertGreater(first_calls, 1, "first open must probe")
 
-        # Second open: cache hit, single attempt at 48000.
         _open_input_stream(
             device=7, target_samplerate=16000, channels=1,
             dtype="float32", callback=lambda *_: None,
         )
-        cache_calls = self.calls[len(first_calls):]
+        cache_calls = self.calls[first_calls:]
         self.assertEqual(
             len(cache_calls), 1,
             "second open should skip the probe and only call InputStream once",
         )
         self.assertEqual(cache_calls[0]["samplerate"], 48000)
         self.assertEqual(cache_calls[0]["dtype"], "float32")
+        self.assertEqual(cache_calls[0]["channels"], 1)
 
     def test_cache_evicts_and_reprobes_when_cached_format_fails(self):
-        # Prime cache with a known-good (48000, float32) for device 7. The
-        # cache key uses the resolved device NAME (from sd.query_devices),
-        # not the raw device id, so changing the OS default mic invalidates
-        # the entry automatically.
+        # Prime cache with a known-good (48000, float32, 1ch) for device 7.
+        # The cache key uses the resolved device NAME (from
+        # sd.query_devices), not the raw device id, so changing the OS
+        # default mic invalidates the entry automatically.
         from whisper_sync import capture
         from whisper_sync.capture import _open_input_stream, _MIC_FORMAT_CACHE
         cache_key = ("FakeMic-7", 16000, "float32", 1)
         with capture._MIC_FORMAT_CACHE_LOCK:
-            _MIC_FORMAT_CACHE[cache_key] = (48000, "float32")
+            _MIC_FORMAT_CACHE[cache_key] = (48000, "float32", 1)
 
-        # Now simulate the device suddenly rejecting the cached format.
-        # The helper must evict the stale cache entry and re-probe.
-        responses = [
-            _FakePortAudioError("cached rate now rejected"),  # cached attempt
-            _FakePortAudioError("16k still rejected"),         # probe 16k
-            mock.Mock(name="recovered-stream"),                # probe 48k succeeds
-        ]
-
+        # Device state changed: 48 kHz now rejected, only 16 kHz works.
+        # The helper must evict the stale entry, re-probe, and re-cache.
         def _responder(kwargs):
-            r = responses.pop(0)
-            if isinstance(r, Exception):
-                raise r
-            return r
+            if kwargs["samplerate"] == 48000:
+                raise _FakePortAudioError("48k now rejected")
+            return mock.Mock(name="recovered-stream")
 
         self._responder = _responder
-        stream, rate = _open_input_stream(
+        stream, rate, channels = _open_input_stream(
             device=7, target_samplerate=16000, channels=1,
             dtype="float32", callback=lambda *_: None,
         )
         self.assertIsNotNone(stream)
-        self.assertEqual(rate, 48000)
-        # Cache should have been re-populated with the now-working entry.
+        self.assertEqual(rate, 16000)
+        self.assertEqual(channels, 1)
+        # First call was the (failed) cached 48 kHz attempt.
+        self.assertEqual(self.calls[0]["samplerate"], 48000)
+        # Cache re-populated with the now-working entry.
         with capture._MIC_FORMAT_CACHE_LOCK:
             self.assertEqual(
-                _MIC_FORMAT_CACHE.get(cache_key), (48000, "float32"),
+                _MIC_FORMAT_CACHE.get(cache_key), (16000, "float32", 1),
                 "cache should refresh after eviction",
             )
 

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -244,8 +244,12 @@ class AudioRecorder:
             # arrays (e.g. laptop 4-mic arrays) may only open at their
             # native channel count; mean-across-channels matches the
             # loopback downmix and is what the ASR model expects.
+            # dtype is explicit: input is already float32 here (normalized
+            # above), and numpy preserves float32 in mean for float input,
+            # but pinning it guards the float32 invariant against any
+            # future dtype drift upstream.
             if self._mic_channels > 1 and normalized.ndim == 2 and normalized.shape[1] > 1:
-                normalized = normalized.mean(axis=1, keepdims=True)
+                normalized = normalized.mean(axis=1, keepdims=True, dtype=np.float32)
 
             # Resample to the canonical sample_rate only when the device
             # fell back to its native rate. up/down are precomputed in

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -53,12 +53,13 @@ def get_default_devices(api_filter: str | None = "WASAPI") -> dict:
     return {"input": defaults[0], "output": defaults[1]}
 
 
-# Cache of (device_key, target_samplerate, target_dtype, channels) -> (effective_rate, effective_dtype)
+# Cache of (device_name, target_samplerate, target_dtype, requested_channels)
+#   -> (effective_rate, effective_dtype, effective_channels)
 # Lets us skip the probe-and-fail sequence on subsequent opens for the same
-# device that already rejected the target rate once. On Windows this avoids
+# device that already rejected the target format once. On Windows this avoids
 # logging "mic open attempt failed (rate=16000 ...)" + "16000 Hz float32 rejected"
 # on every dictation/meeting start.
-_MIC_FORMAT_CACHE: dict[tuple, tuple[int, str]] = {}
+_MIC_FORMAT_CACHE: dict[tuple, tuple[int, str, int]] = {}
 _MIC_FORMAT_CACHE_LOCK = threading.Lock()
 
 
@@ -72,22 +73,27 @@ def _open_input_stream(*, device, target_samplerate: int, channels: int,
     retry, a single failed open propagates out of the hotkey handler and
     kills the keyboard dispatcher thread, bricking all further hotkeys.
 
-    Retry ladder:
+    Retry ladder, per (rate, dtype) rung:
       1. Caller-requested ``target_samplerate`` at ``dtype``.
       2. Device's native ``default_samplerate`` at the same ``dtype``.
       3. Device's native ``default_samplerate`` at ``int16``.
+    Each rung is tried at the requested ``channels`` first, then at the
+    device's native ``max_input_channels``. Microphone ARRAYS (e.g. laptop
+    4-mic arrays) often reject a mono open entirely; without the channel
+    fallback such devices were unusable with this app. Callers downmix
+    multi-channel input to mono in the audio callback.
 
-    Returns ``(stream, effective_samplerate)``. Callers are responsible
-    for resampling downstream audio when the effective rate differs from
-    the target.
+    Returns ``(stream, effective_samplerate, effective_channels)``.
+    Callers are responsible for resampling/downmixing downstream audio
+    when the effective format differs from the target.
 
     Reraises the last ``PortAudioError`` if every attempt fails.
 
-    A successful (rate, dtype) combination is cached per device so future
-    opens skip the probe and avoid logging the same fallback every session.
-    The cache key includes the resolved device name (not the raw ``device``
-    arg) so that ``device=None`` callers don't get a stale entry if the OS
-    default input device changes between calls.
+    A successful (rate, dtype, channels) combination is cached per device
+    so future opens skip the probe and avoid logging the same fallback
+    every session. The cache key includes the resolved device name (not
+    the raw ``device`` arg) so that ``device=None`` callers don't get a
+    stale entry if the OS default input device changes between calls.
     """
     # Resolve a stable device identity for the cache key. When the caller
     # passes device=None, sd.query_devices(None) returns info about the
@@ -104,60 +110,78 @@ def _open_input_stream(*, device, target_samplerate: int, channels: int,
         cached = _MIC_FORMAT_CACHE.get(cache_key)
 
     if cached is not None:
-        cached_rate, cached_dtype = cached
+        cached_rate, cached_dtype, cached_channels = cached
         try:
             stream = sd.InputStream(
                 samplerate=cached_rate,
-                channels=channels,
+                channels=cached_channels,
                 dtype=cached_dtype,
                 device=device,
                 callback=callback,
             )
-            return stream, cached_rate
+            return stream, cached_rate, cached_channels
         except sd.PortAudioError:
             # Device state changed; fall through to full probe.
             with _MIC_FORMAT_CACHE_LOCK:
                 _MIC_FORMAT_CACHE.pop(cache_key, None)
 
-    attempts = [(target_samplerate, dtype)]
+    rate_dtype_rungs = [(target_samplerate, dtype)]
+    native = None
+    native_channels = None
     try:
         # Reuse the device_info we already queried above, if available.
         info = device_info if device_info is not None else sd.query_devices(device)
         native = int(info["default_samplerate"])
+        native_channels = int(info.get("max_input_channels", 0)) or None
     except Exception:
-        native = None
+        pass
     if native and native != target_samplerate:
-        attempts.append((native, dtype))
-        attempts.append((native, "int16"))
+        rate_dtype_rungs.append((native, dtype))
+        rate_dtype_rungs.append((native, "int16"))
     else:
-        attempts.append((target_samplerate, "int16"))
+        rate_dtype_rungs.append((target_samplerate, "int16"))
+
+    # Channel candidates: requested first (mono), then the device's native
+    # channel count for mic arrays that refuse a mono open.
+    channel_candidates = [channels]
+    if native_channels and native_channels != channels:
+        channel_candidates.append(native_channels)
 
     last_err = None
-    for rate, this_dtype in attempts:
-        try:
-            stream = sd.InputStream(
-                samplerate=rate,
-                channels=channels,
-                dtype=this_dtype,
-                device=device,
-                callback=callback,
-            )
-            fell_back = (rate != target_samplerate or this_dtype != dtype)
-            if fell_back:
-                # Only log the fallback the FIRST time we discover it; cache
-                # hits below skip this branch. Use INFO not WARNING because
-                # the fallback succeeds and downstream code resamples.
-                logger.info(
-                    "mic: %d Hz %s rejected; using %d Hz %s "
-                    "(caching for this device)",
-                    target_samplerate, dtype, rate, this_dtype,
+    for rate, this_dtype in rate_dtype_rungs:
+        for this_channels in channel_candidates:
+            try:
+                stream = sd.InputStream(
+                    samplerate=rate,
+                    channels=this_channels,
+                    dtype=this_dtype,
+                    device=device,
+                    callback=callback,
                 )
-            with _MIC_FORMAT_CACHE_LOCK:
-                _MIC_FORMAT_CACHE[cache_key] = (rate, this_dtype)
-            return stream, rate
-        except sd.PortAudioError as e:
-            last_err = e
-            logger.debug("mic open attempt failed (rate=%s dtype=%s): %s", rate, this_dtype, e)
+                fell_back = (
+                    rate != target_samplerate
+                    or this_dtype != dtype
+                    or this_channels != channels
+                )
+                if fell_back:
+                    # Only log the fallback the FIRST time we discover it;
+                    # cache hits skip this branch. INFO not WARNING because
+                    # the fallback succeeds and downstream code adapts.
+                    logger.info(
+                        "mic: %d Hz %s %dch rejected; using %d Hz %s %dch "
+                        "(caching for this device)",
+                        target_samplerate, dtype, channels,
+                        rate, this_dtype, this_channels,
+                    )
+                with _MIC_FORMAT_CACHE_LOCK:
+                    _MIC_FORMAT_CACHE[cache_key] = (rate, this_dtype, this_channels)
+                return stream, rate, this_channels
+            except sd.PortAudioError as e:
+                last_err = e
+                logger.debug(
+                    "mic open attempt failed (rate=%s dtype=%s channels=%s): %s",
+                    rate, this_dtype, this_channels, e,
+                )
     assert last_err is not None
     raise last_err
 
@@ -174,6 +198,11 @@ class AudioRecorder:
         # recomputes it per buffer.
         self._mic_resample_up: int = 1
         self._mic_resample_down: int = 1
+        # Effective mic channel count for the current session. Usually 1,
+        # but mic ARRAYS (e.g. laptop 4-mic arrays) may reject a mono open;
+        # _open_input_stream then falls back to the device's native channel
+        # count and the callback downmixes to mono.
+        self._mic_channels: int = 1
         self._mic_data: list[np.ndarray] = []
         self._speaker_data: list[np.ndarray] = []
         self._mic_stream = None
@@ -210,6 +239,13 @@ class AudioRecorder:
                 normalized = indata.astype(np.float32)
             else:
                 normalized = indata
+
+            # Downmix multi-channel input to mono BEFORE resampling. Mic
+            # arrays (e.g. laptop 4-mic arrays) may only open at their
+            # native channel count; mean-across-channels matches the
+            # loopback downmix and is what the ASR model expects.
+            if self._mic_channels > 1 and normalized.ndim == 2 and normalized.shape[1] > 1:
+                normalized = normalized.mean(axis=1, keepdims=True)
 
             # Resample to the canonical sample_rate only when the device
             # fell back to its native rate. up/down are precomputed in
@@ -259,7 +295,7 @@ class AudioRecorder:
             # False so stop()/subsequent starts see a clean state.
             stream = None
             try:
-                stream, effective_rate = _open_input_stream(
+                stream, effective_rate, effective_channels = _open_input_stream(
                     device=mic_device,
                     target_samplerate=self.sample_rate,
                     channels=1,
@@ -277,6 +313,7 @@ class AudioRecorder:
 
             self._mic_stream = stream
             self._mic_effective_rate = effective_rate
+            self._mic_channels = effective_channels
             # Precompute the resample ratio once per session.
             if effective_rate != self.sample_rate:
                 g = gcd(self.sample_rate, effective_rate)


### PR DESCRIPTION
## Why (user-reported)

Laptop built-in mics are often 4-mic ARRAYS that reject a mono open
entirely. Every rung of the mic open-fallback ladder hardcoded
`channels=1`, so all rungs failed and the app was unusable with such
devices - only plug-in mono mics worked.

## Changes

- `_open_input_stream`: each (rate, dtype) rung now tries the requested
  mono open first, then the device's native `max_input_channels`.
  Returns `(stream, rate, channels)`; the per-device cache stores the
  working 3-tuple so later opens go straight to the working format.
- `_mic_callback`: downmixes multi-channel input to mono (mean across
  channels - same approach as the loopback path) AFTER int16
  normalization and BEFORE resampling. RAM accumulation, disk
  streaming, and the transcriber all see mono 16 kHz regardless of
  device topology. No virtual adapter or ffmpeg needed - it is one
  `mean(axis=1)` in the existing callback.
- `AudioRecorder.start()` records the effective channel count per
  session; mono devices behave exactly as before.

## Tests (thorough, per request)

- `test_capture_mic_downmix.py` (6 new): channel-mean correctness
  (4ch constants -> exact mean), 440 Hz sine preserved through downmix,
  int16 normalize-then-average, downmix composed with 48k->16k
  resampling (frame counts + DC level), mono passthrough unchanged,
  mono frames reaching the disk writer.
- 2 new ladder tests: mic array rejecting mono falls back to native 4ch
  at the target rate (the exact user scenario); effective channel count
  cached and reused on the second open (single InputStream call).
- Existing ladder/cache tests updated for the channel rung and 3-tuple
  cache with behavior-targeted responders.
- venv capture suite: **29 pass**. System suite: **88 pass**.

## Test plan

- [ ] On the laptop: select the built-in mic array, start a dictation -
      it should record (previously: mic open failure toast).
- [ ] Log shows one INFO line: `mic: 16000 Hz float32 1ch rejected;
      using 16000 Hz float32 4ch (caching for this device)`.
- [ ] Transcription quality on the downmixed mono is normal.
- [ ] External mono mic still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)