### PR TITLE
feat: stability rebuild phase 5a - atomic transitions + thread-safe stats

### DIFF
--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -1,0 +1,69 @@
+"""Tests for whisper_sync.session_stats — lock-guarded session counters.
+
+The previous bare-dict stats raced: `d[k] += v` is read-modify-write and
+was executed concurrently from the dictation worker, the overlay worker,
+and the meeting pipeline.
+"""
+
+import threading
+import unittest
+
+from whisper_sync.session_stats import SessionStats
+
+
+class SessionStatsTests(unittest.TestCase):
+    def test_record_dictation_accumulates(self):
+        s = SessionStats()
+        s.record_dictation(100, 1.5)
+        s.record_dictation(50, 0.5)
+        snap = s.snapshot()
+        self.assertEqual(snap["dictations"], 2)
+        self.assertEqual(snap["total_dictation_chars"], 150)
+        self.assertAlmostEqual(snap["total_dictation_time"], 2.0)
+
+    def test_record_meeting_accumulates(self):
+        s = SessionStats()
+        s.record_meeting(3600, 5000)
+        s.record_meeting(1800, 2500)
+        snap = s.snapshot()
+        self.assertEqual(snap["meetings"], 2)
+        self.assertEqual(snap["total_meeting_seconds"], 5400)
+        self.assertEqual(snap["total_meeting_words"], 7500)
+
+    def test_snapshot_includes_session_start_and_is_a_copy(self):
+        s = SessionStats()
+        snap = s.snapshot()
+        self.assertIn("session_start", snap)
+        snap["dictations"] = 999  # mutating the snapshot...
+        self.assertEqual(s.snapshot()["dictations"], 0, "...must not affect the source")
+
+    def test_concurrent_increments_do_not_lose_updates(self):
+        # The bug this class fixes: bare-dict `+=` from many threads loses
+        # increments. 8 threads x 250 dictations each must total exactly 2000.
+        s = SessionStats()
+        per_thread = 250
+        barrier = threading.Barrier(8)
+
+        def _hammer():
+            barrier.wait(timeout=2.0)
+            for _ in range(per_thread):
+                s.record_dictation(10, 0.01)
+                s.record_feature_suggestion()
+
+        threads = [threading.Thread(target=_hammer, daemon=True) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        snap = s.snapshot()
+        self.assertEqual(snap["dictations"], 8 * per_thread)
+        self.assertEqual(snap["feature_suggestions"], 8 * per_thread)
+        self.assertEqual(snap["total_dictation_chars"], 8 * per_thread * 10)
+        self.assertAlmostEqual(
+            snap["total_dictation_time"], 8 * per_thread * 0.01, places=2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_transitions.py
+++ b/tests/test_state_transitions.py
@@ -1,0 +1,104 @@
+"""Tests for StateManager.try_transition (stability rebuild Phase 5).
+
+The historical race: hotkey handlers read state.current.mode, branched,
+then emitted - but worker threads completing in between could change mode,
+so two starts could both pass the same check. try_transition makes
+check-and-set atomic under the state lock.
+"""
+
+import threading
+import unittest
+
+from whisper_sync.state_manager import (
+    StateManager, DICTATION_STARTED, MEETING_STARTED, IDLE,
+)
+
+
+def _make_state():
+    return StateManager(tray=None, config={})
+
+
+class TryTransitionTests(unittest.TestCase):
+    def test_transition_applies_when_mode_allowed(self):
+        sm = _make_state()
+        ok = sm.try_transition(
+            (None, "done", "error"), DICTATION_STARTED, mode="dictation"
+        )
+        self.assertTrue(ok)
+        self.assertEqual(sm.current.mode, "dictation")
+
+    def test_transition_rejected_when_mode_not_allowed(self):
+        sm = _make_state()
+        sm.emit(MEETING_STARTED, mode="meeting")
+        ok = sm.try_transition(
+            (None, "done", "error"), DICTATION_STARTED, mode="dictation"
+        )
+        self.assertFalse(ok)
+        self.assertEqual(sm.current.mode, "meeting", "rejected transition must not mutate state")
+
+    def test_rejected_transition_emits_no_event(self):
+        sm = _make_state()
+        sm.emit(MEETING_STARTED, mode="meeting")
+        events = []
+        sm.on_any(events.append)
+        sm.try_transition((None,), DICTATION_STARTED, mode="dictation")
+        self.assertEqual(events, [], "rejected transition must notify nobody")
+
+    def test_accepted_transition_notifies_listeners(self):
+        sm = _make_state()
+        events = []
+        sm.on_any(events.append)
+        sm.try_transition((None,), DICTATION_STARTED, mode="dictation")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].type, DICTATION_STARTED)
+        self.assertEqual(events[0].new_state.mode, "dictation")
+
+    def test_exactly_one_winner_under_contention(self):
+        # The race this API exists to close: N threads all try to claim
+        # idle -> dictation simultaneously; exactly ONE may win.
+        sm = _make_state()
+        barrier = threading.Barrier(8)
+        wins = []
+
+        def _claim():
+            barrier.wait(timeout=2.0)
+            if sm.try_transition(
+                (None,), DICTATION_STARTED, mode="dictation"
+            ):
+                wins.append(threading.current_thread().name)
+
+        threads = [threading.Thread(target=_claim, daemon=True) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=2.0)
+
+        self.assertEqual(
+            len(wins), 1,
+            f"exactly one thread must win the transition, got {wins}",
+        )
+        self.assertEqual(sm.current.mode, "dictation")
+
+    def test_other_state_fields_set_atomically_with_mode(self):
+        sm = _make_state()
+        ok = sm.try_transition(
+            (None,), IDLE, mode=None, meeting_transcribing=True
+        )
+        self.assertTrue(ok)
+        self.assertTrue(sm.current.meeting_transcribing)
+
+    def test_emit_unchanged_for_existing_callers(self):
+        # emit must behave exactly as before the refactor (shared internals).
+        sm = _make_state()
+        events = []
+        sm.on(MEETING_STARTED, events.append)
+        sm.emit(MEETING_STARTED, mode="meeting", data={"x": 1})
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].data, {"x": 1})
+        self.assertEqual(events[0].old_state.mode, None)
+        self.assertEqual(events[0].new_state.mode, "meeting")
+        self.assertEqual(len(sm.history), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -168,6 +168,9 @@ class WhisperSync:
         # _dictation_history is appended from dictation AND overlay worker
         # threads and read by menu builds; guard every access.
         self._dictation_history_lock = threading.Lock()
+        # Flash gate: lock-guarded check-and-set (Event.is_set()+set() alone
+        # is not atomic; two hotkey threads could both observe False).
+        self._flash_lock = threading.Lock()
         self._flash_active = threading.Event()
 
     @staticmethod
@@ -232,12 +235,13 @@ class WhisperSync:
 
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
-        # Event instead of a bare attribute: the old getattr-default
-        # pattern raced concurrent hotkey threads (both could see False
-        # and both start animations).
-        if self._flash_active.is_set():
-            return
-        self._flash_active.set()
+        # Lock-guarded check-and-set: the old getattr-default pattern (and
+        # a bare Event is_set/set pair) raced concurrent hotkey threads -
+        # both could observe "not flashing" and both start animations.
+        with self._flash_lock:
+            if self._flash_active.is_set():
+                return
+            self._flash_active.set()
         animator = IconAnimator(self.tray, lock=self._tray_lock)
         animator.flash(count=2, interval_ms=150)
         # Reset after the animation completes (~600ms) on the shared

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -161,17 +161,14 @@ class WhisperSync:
         self._dialog_dispatcher = DialogDispatcher()
         self._dialog_dispatcher.start()
         self._cpu_name = _get_cpu_name()
-        # Session stats
-        self._stats = {
-            "dictations": 0,
-            "meetings": 0,
-            "feature_suggestions": 0,
-            "total_dictation_chars": 0,
-            "total_dictation_time": 0.0,
-            "total_meeting_seconds": 0,
-            "total_meeting_words": 0,
-            "session_start": datetime.now(),
-        }
+        # Session stats: lock-guarded; mutated from dictation/overlay/meeting
+        # worker threads concurrently (see session_stats.py).
+        from .session_stats import SessionStats
+        self._stats = SessionStats()
+        # _dictation_history is appended from dictation AND overlay worker
+        # threads and read by menu builds; guard every access.
+        self._dictation_history_lock = threading.Lock()
+        self._flash_active = threading.Event()
 
     @staticmethod
     def _migrate_data():
@@ -235,17 +232,18 @@ class WhisperSync:
 
     def _yellow_flash(self):
         """Universal loading/queuing signal: two quick yellow flashes (150ms on/off/on)."""
-        if getattr(self, '_flashing', False):
+        # Event instead of a bare attribute: the old getattr-default
+        # pattern raced concurrent hotkey threads (both could see False
+        # and both start animations).
+        if self._flash_active.is_set():
             return
-        self._flashing = True
+        self._flash_active.set()
         animator = IconAnimator(self.tray, lock=self._tray_lock)
         animator.flash(count=2, interval_ms=150)
-        # Reset flag after animation completes (~600ms)
-        import time
-        def _reset():
-            time.sleep(0.7)
-            self._flashing = False
-        threading.Thread(target=_reset, daemon=True).start()
+        # Reset after the animation completes (~600ms) on the shared
+        # scheduler instead of spawning a sleep thread per flash.
+        from .scheduler import scheduler
+        scheduler.call_later(0.7, self._flash_active.clear, label="flash-reset")
 
     # --- Click dispatch ---
 
@@ -408,7 +406,17 @@ class WhisperSync:
             self._feature_suggest_active = False
             self._yellow_flash()
             return
-        self.state.emit(DICTATION_STARTED, mode="dictation")
+        # Atomic claim: only start if mode is still startable. A worker
+        # completion (or a double-fired hotkey on another thread) changing
+        # mode between the toggle's check and this start is rejected here
+        # instead of producing two concurrent recording sessions.
+        if not self.state.try_transition(
+            (None, "transcribing", "done", "error"),
+            DICTATION_STARTED, mode="dictation",
+        ):
+            logger.debug("dictation start rejected: mode changed concurrently")
+            self._feature_suggest_active = False
+            return
         mic = self.cfg.get("mic_device")
         if self.cfg.get("use_system_devices", True):
             # Explicitly use the WASAPI default instead of falling through
@@ -564,7 +572,7 @@ class WhisperSync:
                         entry_id = feature_log.append_raw(text, t2 - t0)
                         logger.info(f"Feature suggestion saved: {char_count} chars in {t2 - t0:.2f}s")
                         notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
-                        self._stats["feature_suggestions"] += 1
+                        self._stats.record_feature_suggestion()
                         weekly_stats.record_feature_suggestion()
                         # Format asynchronously via Claude CLI
                         threading.Thread(
@@ -584,20 +592,19 @@ class WhisperSync:
                     effective_model = self.cfg.get("backup_model", "base") if used_backup else dictation_model
                     logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={effective_model}{' (backup)' if used_backup else ''}")
                     # Update session stats
-                    self._stats["dictations"] += 1
-                    self._stats["total_dictation_chars"] += char_count
-                    self._stats["total_dictation_time"] += t2 - t0
+                    self._stats.record_dictation(char_count, t2 - t0)
                     weekly_stats.record_dictation(char_count, t2 - t0)
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
                         dictation_log.append(text, t2 - t0, model=effective_model)
-                        self._dictation_history.append({
-                            "text": text,
-                            "timestamp": datetime.now().strftime("%H:%M"),
-                            "chars": len(text),
-                        })
-                        if len(self._dictation_history) > 10:
-                            self._dictation_history = self._dictation_history[-10:]
+                        with self._dictation_history_lock:
+                            self._dictation_history.append({
+                                "text": text,
+                                "timestamp": datetime.now().strftime("%H:%M"),
+                                "chars": len(text),
+                            })
+                            if len(self._dictation_history) > 10:
+                                self._dictation_history = self._dictation_history[-10:]
                         self._refresh_menu()
                 # Success -- remove crash-safety WAV (text is in the log)
                 self.recorder.stop_streaming()  # defensive: ensure writer closed
@@ -704,7 +711,7 @@ class WhisperSync:
                         entry_id = feature_log.append_raw(text, duration)
                         logger.info(f"Feature suggestion (overlay) saved: {char_count} chars in {duration:.2f}s", extra={"secondary": True})
                         notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
-                        self._stats["feature_suggestions"] += 1
+                        self._stats.record_feature_suggestion()
                         weekly_stats.record_feature_suggestion()
                         threading.Thread(
                             target=self._format_feature_async,
@@ -716,21 +723,20 @@ class WhisperSync:
                         paste(text, self.cfg["paste_method"], restore=not self.cfg.get("incognito", False))
 
                     # Update session stats
-                    self._stats["dictations"] += 1
-                    self._stats["total_dictation_chars"] += char_count
-                    self._stats["total_dictation_time"] += duration
+                    self._stats.record_dictation(char_count, duration)
                     weekly_stats.record_dictation(char_count, duration)
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
                         dictation_log.append(text, duration, model=backup_model)
-                        self._dictation_history.append({
-                            "text": text,
-                            "timestamp": datetime.now().strftime("%H:%M"),
-                            "chars": len(text),
-                        })
-                        if len(self._dictation_history) > 10:
-                            self._dictation_history = self._dictation_history[-10:]
+                        with self._dictation_history_lock:
+                            self._dictation_history.append({
+                                "text": text,
+                                "timestamp": datetime.now().strftime("%H:%M"),
+                                "chars": len(text),
+                            })
+                            if len(self._dictation_history) > 10:
+                                self._dictation_history = self._dictation_history[-10:]
                         self._refresh_menu()
 
                     delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
@@ -757,21 +763,20 @@ class WhisperSync:
                     logger.info(f"Overlay dictation fallback: {duration:.2f}s, {char_count} chars", extra={"secondary": True})
 
                     # Post-dictation bookkeeping (same as the normal overlay path)
-                    self._stats["dictations"] += 1
-                    self._stats["total_dictation_chars"] += char_count
-                    self._stats["total_dictation_time"] += duration
+                    self._stats.record_dictation(char_count, duration)
                     weekly_stats.record_dictation(char_count, duration)
 
                     incognito = self.cfg.get("incognito", False)
                     if text and not incognito:
                         dictation_log.append(text, duration, model=dictation_model)
-                        self._dictation_history.append({
-                            "text": text,
-                            "timestamp": datetime.now().strftime("%H:%M"),
-                            "chars": len(text),
-                        })
-                        if len(self._dictation_history) > 10:
-                            self._dictation_history = self._dictation_history[-10:]
+                        with self._dictation_history_lock:
+                            self._dictation_history.append({
+                                "text": text,
+                                "timestamp": datetime.now().strftime("%H:%M"),
+                                "chars": len(text),
+                            })
+                            if len(self._dictation_history) > 10:
+                                self._dictation_history = self._dictation_history[-10:]
                         self._refresh_menu()
 
                     delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
@@ -1143,7 +1148,13 @@ class WhisperSync:
                 self._start_meeting()
 
     def _start_meeting(self):
-        self.state.emit(MEETING_STARTED, mode="meeting")
+        # Atomic claim, same rationale as _start_dictation.
+        if not self.state.try_transition(
+            (None, "transcribing", "done", "error"),
+            MEETING_STARTED, mode="meeting",
+        ):
+            logger.debug("meeting start rejected: mode changed concurrently")
+            return
         self._meeting_start_time = datetime.now()
         mic = self.cfg.get("mic_device")
         speaker = self.cfg.get("speaker_device")
@@ -2349,17 +2360,20 @@ class WhisperSync:
 
     def _clear_dictation_history(self):
         """Clear the in-memory dictation history (menu only, logs on disk are preserved)."""
-        self._dictation_history.clear()
+        with self._dictation_history_lock:
+            self._dictation_history.clear()
         self._refresh_menu()
 
     def _build_recent_dictations_menu(self):
         """Build the Recent Dictations submenu items."""
-        if not self._dictation_history:
+        with self._dictation_history_lock:
+            history = list(self._dictation_history)
+        if not history:
             return pystray.Menu(
                 pystray.MenuItem("No dictations yet", None, enabled=False),
             )
         items = []
-        for entry in reversed(self._dictation_history):
+        for entry in reversed(history):
             full_text = entry["text"]
             preview = full_text[:40]
             if len(full_text) > 40:
@@ -3111,7 +3125,7 @@ class WhisperSync:
 
     def _build_session_stats_menu(self):
         """Build weekly stats submenu with today and wk columns."""
-        s = self._stats
+        s = self._stats.snapshot()
         uptime = datetime.now() - s["session_start"]
         hours, remainder = divmod(int(uptime.total_seconds()), 3600)
         minutes = remainder // 60

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -163,9 +163,7 @@ class MeetingJob:
         )
 
         # Session stats
-        self.app._stats["meetings"] += 1
-        self.app._stats["total_meeting_seconds"] += int(duration)
-        self.app._stats["total_meeting_words"] += words
+        self.app._stats.record_meeting(int(duration), words)
         weekly_stats.record_meeting(int(duration), words)
 
         # Speaker segment previews

--- a/whisper_sync/session_stats.py
+++ b/whisper_sync/session_stats.py
@@ -1,0 +1,64 @@
+"""Thread-safe session statistics.
+
+The app previously kept session stats in a bare dict mutated concurrently
+from the dictation worker, the overlay dictation worker, and the meeting
+post-processing pipeline with no lock (stability rebuild plan section
+3.2). Increments raced (`d[k] += v` is read-modify-write) and the menu
+read mid-update values.
+
+This class owns the counters behind a lock and exposes increment methods
+plus an atomic ``snapshot()`` for the stats menu.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+
+
+class SessionStats:
+    """Lock-guarded per-session counters."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._session_start = datetime.now()
+        self._counts = {
+            "dictations": 0,
+            "meetings": 0,
+            "feature_suggestions": 0,
+            "total_dictation_chars": 0,
+            "total_dictation_time": 0.0,
+            "total_meeting_seconds": 0,
+            "total_meeting_words": 0,
+        }
+
+    # -- increments ---------------------------------------------------------
+
+    def record_dictation(self, chars: int, duration_s: float) -> None:
+        with self._lock:
+            self._counts["dictations"] += 1
+            self._counts["total_dictation_chars"] += chars
+            self._counts["total_dictation_time"] += duration_s
+
+    def record_meeting(self, seconds: int, words: int) -> None:
+        with self._lock:
+            self._counts["meetings"] += 1
+            self._counts["total_meeting_seconds"] += int(seconds)
+            self._counts["total_meeting_words"] += words
+
+    def record_feature_suggestion(self) -> None:
+        with self._lock:
+            self._counts["feature_suggestions"] += 1
+
+    # -- reads --------------------------------------------------------------
+
+    @property
+    def session_start(self) -> datetime:
+        return self._session_start
+
+    def snapshot(self) -> dict:
+        """Atomic copy of all counters plus session_start."""
+        with self._lock:
+            snap = dict(self._counts)
+        snap["session_start"] = self._session_start
+        return snap

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -175,8 +175,8 @@ class StateManager:
         unknown_keys = [k for k in state_changes if not hasattr(self._state, k)]
         if unknown_keys:
             _logger.warning(
-                "StateManager.emit received unknown state field(s): %s",
-                ", ".join(sorted(unknown_keys)),
+                "StateManager received unknown state field(s) for %s: %s",
+                event_type, ", ".join(sorted(unknown_keys)),
             )
         for k, v in state_changes.items():
             if hasattr(self._state, k):

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -125,40 +125,88 @@ class StateManager:
         follow-up state change, prefer scheduling it on a background thread.
         """
         with self._lock:
-            old = replace(self._state)
-            # Warn on unknown state fields (catches typos at call sites)
-            unknown_keys = [k for k in state_changes if not hasattr(self._state, k)]
-            if unknown_keys:
-                _logger.warning(
-                    "StateManager.emit received unknown state field(s): %s",
-                    ", ".join(sorted(unknown_keys)),
-                )
-            for k, v in state_changes.items():
-                if hasattr(self._state, k):
-                    setattr(self._state, k, v)
-            event = StateEvent(
-                type=event_type,
-                timestamp=time.time(),
-                old_state=old,
-                new_state=replace(self._state),
-                data=dict(data) if data is not None else {},
+            event, typed_cbs, global_cbs = self._apply_locked(
+                event_type, data, state_changes
             )
-            self._event_log.append(event)
-            # Snapshot listener lists under lock to avoid racey iteration
-            typed_cbs = list(self._typed_listeners.get(event_type, []))
-            global_cbs = list(self._global_listeners)
+        self._notify(event, typed_cbs, global_cbs)
 
-        # Notify outside lock
+    def try_transition(self, allowed_from, event_type: str, *,
+                       data: dict | None = None, **state_changes) -> bool:
+        """Atomically transition mode IF the current mode allows it.
+
+        The historical race: hotkey handlers read ``state.current.mode``,
+        branched, and then emitted a transition - but worker threads
+        completing in between could change mode, so two starts could both
+        pass the same check (e.g. a dictation hotkey double-fire racing a
+        transcription completion). This method makes check-and-set one
+        atomic step under the state lock.
+
+        Args:
+            allowed_from: iterable of modes (including ``None``) from which
+                this transition may proceed.
+            event_type: event to emit when the transition is taken.
+            state_changes: state fields to set, exactly as in ``emit``
+                (must include the new ``mode`` if the mode is changing).
+
+        Returns:
+            True if the transition was applied (listeners notified),
+            False if the current mode was not in ``allowed_from``
+            (state untouched, nothing emitted).
+        """
+        allowed = tuple(allowed_from)
+        with self._lock:
+            if self._state.mode not in allowed:
+                _logger.debug(
+                    "try_transition rejected: mode=%r not in %r (event=%s)",
+                    self._state.mode, allowed, event_type,
+                )
+                return False
+            event, typed_cbs, global_cbs = self._apply_locked(
+                event_type, data, state_changes
+            )
+        self._notify(event, typed_cbs, global_cbs)
+        return True
+
+    def _apply_locked(self, event_type: str, data: dict | None,
+                      state_changes: dict):
+        """Apply state changes and build the event. Caller holds the lock."""
+        old = replace(self._state)
+        # Warn on unknown state fields (catches typos at call sites)
+        unknown_keys = [k for k in state_changes if not hasattr(self._state, k)]
+        if unknown_keys:
+            _logger.warning(
+                "StateManager.emit received unknown state field(s): %s",
+                ", ".join(sorted(unknown_keys)),
+            )
+        for k, v in state_changes.items():
+            if hasattr(self._state, k):
+                setattr(self._state, k, v)
+        event = StateEvent(
+            type=event_type,
+            timestamp=time.time(),
+            old_state=old,
+            new_state=replace(self._state),
+            data=dict(data) if data is not None else {},
+        )
+        self._event_log.append(event)
+        # Snapshot listener lists under lock to avoid racey iteration
+        typed_cbs = list(self._typed_listeners.get(event_type, []))
+        global_cbs = list(self._global_listeners)
+        return event, typed_cbs, global_cbs
+
+    @staticmethod
+    def _notify(event, typed_cbs, global_cbs):
+        """Call listeners outside the lock."""
         for cb in typed_cbs:
             try:
                 cb(event)
             except Exception:
-                _logger.exception("Typed listener error for %s", event_type)
+                _logger.exception("Typed listener error for %s", event.type)
         for cb in global_cbs:
             try:
                 cb(event)
             except Exception:
-                _logger.exception("Global listener error for %s", event_type)
+                _logger.exception("Global listener error for %s", event.type)
 
     def on(self, event_type: str, callback: Callable[[StateEvent], None]):
         """Subscribe to a specific event type. Thread-safe."""


### PR DESCRIPTION
## Context

Phase 5 (state consolidation) part A, per the plan doc section 3.2
(scattered, racy state on the WhisperSync god-object). ConfigStore is
deferred to 5b - it touches 100+ `cfg` sites and deserves its own
reviewable PR.

## Changes

- **`StateManager.try_transition(allowed_from, event, **changes)`**:
  atomic check-and-set under the state lock. The historical race: hotkey
  handlers read `state.current.mode`, branched, then emitted - but
  worker threads completing in between could change mode, so two starts
  could both pass the same check. `_start_dictation` and
  `_start_meeting` now claim their mode atomically; a concurrent mode
  change rejects the start instead of producing two recording sessions.
  `emit()` refactored onto shared `_apply_locked`/`_notify` internals -
  behavior unchanged (locked test asserts identical event semantics).

- **`session_stats.SessionStats`**: lock-guarded counters replace the
  bare `_stats` dict mutated concurrently from the dictation worker,
  overlay worker, and meeting pipeline (`d[k] += v` is read-modify-write;
  increments were being lost). Stats menu reads an atomic `snapshot()`.

- **`_dictation_history`**: all 3 append sites, the menu reader, and
  clear now hold a lock (was mutated from two worker threads bare).

- **`_yellow_flash`**: the `getattr(self, '_flashing', False)` flag
  (two threads could both see False and double-animate) replaced with a
  `threading.Event`; the 0.7 s reset moved off a per-flash sleep thread
  onto the shared scheduler (one less ephemeral-thread spawn site).

## Tests

11 new:
- 7 `try_transition`: apply/reject semantics, no-event-on-reject,
  listener notification, **8-thread contention with exactly one
  winner**, atomic multi-field set, and emit-behavior-unchanged.
- 4 `SessionStats`: accumulation, snapshot isolation, **8-thread x 250
  increments with zero lost updates**.

System suite: **107 pass**.

## Test plan

- [ ] Dictation + meeting hotkeys behave normally (start/stop/toggle).
- [ ] Mash the dictation hotkey rapidly: at most one session starts;
      log may show `dictation start rejected: mode changed concurrently`.
- [ ] Stats menu shows correct counts after several dictations/meetings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)