### PR TITLE
feat: stability rebuild phase 6 - single-reader worker protocol

### DIFF
--- a/docs/plans/2026-05-11-stability-rebuild.md
+++ b/docs/plans/2026-05-11-stability-rebuild.md
@@ -307,3 +307,16 @@ Repo convention: unittest + fake modules in `sys.modules` (see
     channel count cached. 8 new tests (channel ladder + downmix math).
   - REMAINING: Phase 5 (state consolidation), Phase 6 (worker protocol),
     Phase 1b (ephemeral thread migration onto executors).
+
+- **2026-06-11 (session 2, Phase 6)**: worker_manager rewritten with a
+  single reader thread owning the response queue (the old shared-get
+  design let one consumer swallow another's response). Requests get
+  pending-slots keyed by request_id; worker death fails ALL pending
+  callers immediately; transcribe_fast regains a real timeout (expiry
+  kills the wedged worker and raises WorkerCrashedError); transcribe
+  (meetings) intentionally stays unbounded (hard caps killed legit long
+  transcriptions, see 4f3b307) with death-detection via the reader.
+  worker import deferred so the protocol layer is unit-testable without
+  numpy. 7 protocol tests (routing, out-of-order, stale-drop, ready,
+  startup-error, death-fails-all, timeout-kills). Real-data E2E re-run
+  against the new protocol.

--- a/tests/test_worker_protocol.py
+++ b/tests/test_worker_protocol.py
@@ -30,6 +30,9 @@ class _FakeProcess:
         self.alive = False
         self.exitcode = -9
 
+    def join(self, timeout=None):
+        self.joined = True
+
 
 def _make_worker():
     """Worker wired to fake process + plain queues, reader running."""
@@ -59,11 +62,9 @@ class WorkerProtocolTests(unittest.TestCase):
 
         t1 = threading.Thread(target=_call, args=("a",), daemon=True)
         t1.start()
-        # Wait until the request is registered, then answer it.
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and not w._pending:
-            time.sleep(0.01)
-        rid = w._request_q.get(timeout=1.0)["request_id"]
+        # The enqueued request is the synchronization point: by the time
+        # it is observable on the queue, the pending slot is registered.
+        rid = w._request_q.get(timeout=2.0)["request_id"]
         w._response_q.put({"type": "result", "text": "hello", "request_id": rid})
         t1.join(timeout=2.0)
         self.assertEqual(results["a"]["text"], "hello")
@@ -143,10 +144,12 @@ class WorkerProtocolTests(unittest.TestCase):
         threads = [threading.Thread(target=_call, daemon=True) for _ in range(3)]
         for t in threads:
             t.start()
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and len(w._pending) < 3:
-            time.sleep(0.01)
-        self.assertEqual(len(w._pending), 3)
+        # Drain all three enqueued requests as the synchronization point;
+        # each is only observable after its pending slot is registered.
+        for _ in range(3):
+            w._request_q.get(timeout=2.0)
+        with w._pending_lock:
+            self.assertEqual(len(w._pending), 3)
 
         w._process.alive = False  # worker dies with requests in flight
         for t in threads:
@@ -155,7 +158,8 @@ class WorkerProtocolTests(unittest.TestCase):
             len(errors), 3,
             "every pending caller must get WorkerCrashedError on death",
         )
-        self.assertEqual(w._pending, {}, "pending map must be drained")
+        with w._pending_lock:
+            self.assertEqual(w._pending, {}, "pending map must be drained")
 
     def test_timeout_kills_wedged_worker_and_raises(self):
         # Worker is alive but never answers (wedged). The request must
@@ -164,7 +168,8 @@ class WorkerProtocolTests(unittest.TestCase):
         with self.assertRaises(WorkerCrashedError):
             w._request({"type": "transcribe_fast"}, timeout=0.2)
         self.assertTrue(w._process.killed, "wedged worker must be killed on timeout")
-        self.assertEqual(w._pending, {}, "timed-out request must be unregistered")
+        with w._pending_lock:
+            self.assertEqual(w._pending, {}, "timed-out request must be unregistered")
 
 
 if __name__ == "__main__":

--- a/tests/test_worker_protocol.py
+++ b/tests/test_worker_protocol.py
@@ -41,7 +41,8 @@ def _make_worker():
     w._request_q = queue.Queue()
     w._response_q = queue.Queue()
     w._reader = threading.Thread(
-        target=w._reader_loop, args=(w._process, w._response_q), daemon=True
+        target=w._reader_loop, args=(w._process, w._response_q, w._gen),
+        daemon=True,
     )
     w._reader.start()
     return w
@@ -148,8 +149,8 @@ class WorkerProtocolTests(unittest.TestCase):
         # each is only observable after its pending slot is registered.
         for _ in range(3):
             w._request_q.get(timeout=2.0)
-        with w._pending_lock:
-            self.assertEqual(len(w._pending), 3)
+        with w._gen.pending_lock:
+            self.assertEqual(len(w._gen.pending), 3)
 
         w._process.alive = False  # worker dies with requests in flight
         for t in threads:
@@ -158,8 +159,8 @@ class WorkerProtocolTests(unittest.TestCase):
             len(errors), 3,
             "every pending caller must get WorkerCrashedError on death",
         )
-        with w._pending_lock:
-            self.assertEqual(w._pending, {}, "pending map must be drained")
+        with w._gen.pending_lock:
+            self.assertEqual(w._gen.pending, {}, "pending map must be drained")
 
     def test_timeout_kills_wedged_worker_and_raises(self):
         # Worker is alive but never answers (wedged). The request must
@@ -168,8 +169,83 @@ class WorkerProtocolTests(unittest.TestCase):
         with self.assertRaises(WorkerCrashedError):
             w._request({"type": "transcribe_fast"}, timeout=0.2)
         self.assertTrue(w._process.killed, "wedged worker must be killed on timeout")
-        with w._pending_lock:
-            self.assertEqual(w._pending, {}, "timed-out request must be unregistered")
+        with w._gen.pending_lock:
+            self.assertEqual(w._gen.pending, {}, "timed-out request must be unregistered")
+
+
+    def test_old_generation_reader_cannot_clobber_new_generation(self):
+        # Regression for Copilot review on PR #146: after restart(), a
+        # late-exiting OLD reader must not touch the NEW generation's
+        # ready state or pending map.
+        self.w = w = _make_worker()
+        old_gen = w._gen
+        old_process = w._process
+
+        # Simulate restart: fresh generation + process + reader (as
+        # start() does), while the old reader still runs.
+        from whisper_sync.worker_manager import _WorkerGeneration
+        w._gen = _WorkerGeneration()
+        w._process = _FakeProcess()
+        new_q = queue.Queue()
+        w._response_q = new_q
+        new_reader = threading.Thread(
+            target=w._reader_loop, args=(w._process, new_q, w._gen),
+            daemon=True,
+        )
+        new_reader.start()
+
+        # Old worker dies; old reader exits, failing ITS generation only.
+        old_process.alive = False
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not old_gen.ready_event.is_set():
+            time.sleep(0.01)
+        self.assertTrue(old_gen.ready_event.is_set(), "old gen unblocked")
+        self.assertFalse(
+            w._gen.ready_event.is_set(),
+            "old reader exit must NOT set the new generation's ready event",
+        )
+
+        # New generation still fully functional.
+        new_q.put({"type": "ready", "gpu_name": "G", "device": "cuda"})
+        self.assertTrue(w.wait_ready(timeout=2.0))
+
+    def test_closed_queue_valueerror_fails_pending(self):
+        # Regression for Copilot review on PR #146: a closed queue raises
+        # ValueError in get(); the reader must treat it as death and fail
+        # pending waiters rather than dying silently.
+        class _ClosingQueue:
+            def __init__(self):
+                self.calls = 0
+
+            def get(self, timeout=None):
+                self.calls += 1
+                raise ValueError("queue is closed")
+
+        w = TranscriptionWorker(cfg={})
+        w._process = _FakeProcess()
+        w._request_q = queue.Queue()
+        self.w = w
+
+        # Register a pending request directly, then run the reader against
+        # the closing queue.
+        from whisper_sync.worker_manager import _PendingRequest
+        pending = _PendingRequest()
+        with w._gen.pending_lock:
+            w._gen.pending[1] = pending
+
+        reader = threading.Thread(
+            target=w._reader_loop,
+            args=(w._process, _ClosingQueue(), w._gen),
+            daemon=True,
+        )
+        reader.start()
+        self.assertTrue(
+            pending.done.wait(timeout=2.0),
+            "pending waiter must be failed when the queue closes",
+        )
+        self.assertIsNone(pending.response, "failure marker must be set")
+        reader.join(timeout=2.0)
+        self.assertFalse(reader.is_alive(), "reader must exit on closed queue")
 
 
 if __name__ == "__main__":

--- a/tests/test_worker_protocol.py
+++ b/tests/test_worker_protocol.py
@@ -1,0 +1,171 @@
+"""Tests for the Phase 6 worker response protocol (single reader thread).
+
+Drives TranscriptionWorker's reader/request plumbing against a FAKE
+process and plain queues - no subprocess, no numpy. The contract:
+responses route to their waiter by request_id; stale responses are
+dropped; worker death fails every pending request; a timeout kills the
+wedged worker and raises WorkerCrashedError.
+"""
+
+import queue
+import threading
+import time
+import unittest
+
+from whisper_sync.worker_manager import TranscriptionWorker, WorkerCrashedError
+
+
+class _FakeProcess:
+    def __init__(self):
+        self.alive = True
+        self.killed = False
+        self.exitcode = None
+        self.pid = 12345
+
+    def is_alive(self):
+        return self.alive
+
+    def kill(self):
+        self.killed = True
+        self.alive = False
+        self.exitcode = -9
+
+
+def _make_worker():
+    """Worker wired to fake process + plain queues, reader running."""
+    w = TranscriptionWorker(cfg={})
+    w._process = _FakeProcess()
+    w._request_q = queue.Queue()
+    w._response_q = queue.Queue()
+    w._reader = threading.Thread(
+        target=w._reader_loop, args=(w._process, w._response_q), daemon=True
+    )
+    w._reader.start()
+    return w
+
+
+class WorkerProtocolTests(unittest.TestCase):
+    def tearDown(self):
+        # Let reader threads exit by killing their fake process.
+        if hasattr(self, "w") and self.w._process is not None:
+            self.w._process.alive = False
+
+    def test_response_routed_to_matching_request(self):
+        self.w = w = _make_worker()
+        results = {}
+
+        def _call(tag):
+            results[tag] = w._request({"type": "transcribe_fast"}, timeout=5.0)
+
+        t1 = threading.Thread(target=_call, args=("a",), daemon=True)
+        t1.start()
+        # Wait until the request is registered, then answer it.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not w._pending:
+            time.sleep(0.01)
+        rid = w._request_q.get(timeout=1.0)["request_id"]
+        w._response_q.put({"type": "result", "text": "hello", "request_id": rid})
+        t1.join(timeout=2.0)
+        self.assertEqual(results["a"]["text"], "hello")
+
+    def test_out_of_order_responses_route_correctly(self):
+        # Two concurrent requests; responses arrive in REVERSE order. Each
+        # waiter must receive its own response (the old shared-get design
+        # let one consumer swallow the other's message).
+        self.w = w = _make_worker()
+        results = {}
+
+        def _call(tag):
+            results[tag] = w._request({"type": "transcribe_fast"}, timeout=5.0)
+
+        threads = [
+            threading.Thread(target=_call, args=(tag,), daemon=True)
+            for tag in ("first", "second")
+        ]
+        for t in threads:
+            t.start()
+        # Collect both request ids in send order.
+        rid1 = w._request_q.get(timeout=2.0)["request_id"]
+        rid2 = w._request_q.get(timeout=2.0)["request_id"]
+        # Answer in reverse order with distinguishable payloads.
+        w._response_q.put({"type": "result", "text": f"resp-{rid2}", "request_id": rid2})
+        w._response_q.put({"type": "result", "text": f"resp-{rid1}", "request_id": rid1})
+        for t in threads:
+            t.join(timeout=2.0)
+        # Each result's text embeds the rid it was answered with; both
+        # callers got SOME response and the two responses are distinct.
+        texts = sorted(r["text"] for r in results.values())
+        self.assertEqual(texts, sorted([f"resp-{rid1}", f"resp-{rid2}"]))
+
+    def test_stale_response_dropped_without_breaking_reader(self):
+        self.w = w = _make_worker()
+        w._response_q.put({"type": "result", "text": "ghost", "request_id": 99999})
+        # Reader must survive; a fresh request still works.
+        results = {}
+        t = threading.Thread(
+            target=lambda: results.update(
+                ok=w._request({"type": "transcribe_fast"}, timeout=5.0)
+            ),
+            daemon=True,
+        )
+        t.start()
+        rid = w._request_q.get(timeout=2.0)["request_id"]
+        w._response_q.put({"type": "result", "text": "real", "request_id": rid})
+        t.join(timeout=2.0)
+        self.assertEqual(results["ok"]["text"], "real")
+
+    def test_ready_message_sets_state_and_wait_ready_passes(self):
+        self.w = w = _make_worker()
+        w._response_q.put({"type": "ready", "gpu_name": "FakeGPU", "device": "cuda"})
+        self.assertTrue(w.wait_ready(timeout=2.0))
+        self.assertEqual(w.gpu_name, "FakeGPU")
+        self.assertEqual(w.device, "cuda")
+        self.assertTrue(w.is_ready())
+
+    def test_startup_error_makes_wait_ready_false(self):
+        self.w = w = _make_worker()
+        w._response_q.put({
+            "type": "error", "message": "model preload failed",
+            "request_id": "__init__",
+        })
+        self.assertFalse(w.wait_ready(timeout=2.0))
+
+    def test_worker_death_fails_all_pending_requests(self):
+        self.w = w = _make_worker()
+        errors = []
+
+        def _call():
+            try:
+                w._request({"type": "transcribe_fast"}, timeout=10.0)
+            except WorkerCrashedError as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=_call, daemon=True) for _ in range(3)]
+        for t in threads:
+            t.start()
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and len(w._pending) < 3:
+            time.sleep(0.01)
+        self.assertEqual(len(w._pending), 3)
+
+        w._process.alive = False  # worker dies with requests in flight
+        for t in threads:
+            t.join(timeout=3.0)
+        self.assertEqual(
+            len(errors), 3,
+            "every pending caller must get WorkerCrashedError on death",
+        )
+        self.assertEqual(w._pending, {}, "pending map must be drained")
+
+    def test_timeout_kills_wedged_worker_and_raises(self):
+        # Worker is alive but never answers (wedged). The request must
+        # expire, kill the process, and raise - never hang forever.
+        self.w = w = _make_worker()
+        with self.assertRaises(WorkerCrashedError):
+            w._request({"type": "transcribe_fast"}, timeout=0.2)
+        self.assertTrue(w._process.killed, "wedged worker must be killed on timeout")
+        self.assertEqual(w._pending, {}, "timed-out request must be unregistered")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -60,6 +60,24 @@ class _PendingRequest:
         self.response: dict | None = None  # None after done => worker died
 
 
+class _WorkerGeneration:
+    """Per-spawn shared state, bound to exactly one reader thread.
+
+    A restart creates a NEW generation; the old reader only ever touches
+    its own generation's pending map and ready event, so a late-exiting
+    old reader can never clobber the successor worker's state (Copilot
+    finding on PR #146).
+    """
+
+    __slots__ = ("pending", "pending_lock", "ready_event", "ready_ok")
+
+    def __init__(self):
+        self.pending: dict[int, _PendingRequest] = {}
+        self.pending_lock = threading.Lock()
+        self.ready_event = threading.Event()
+        self.ready_ok = False
+
+
 class TranscriptionWorker:
     """Manages a long-lived transcription subprocess."""
 
@@ -73,13 +91,10 @@ class TranscriptionWorker:
         self._lock = threading.Lock()
         self.gpu_name: str | None = None
         self.device: str | None = None
-        # Reader-thread state (Phase 6). _pending maps request_id ->
-        # _PendingRequest; only the reader completes entries.
-        self._pending: dict[int, _PendingRequest] = {}
-        self._pending_lock = threading.Lock()
+        # Reader-thread state (Phase 6): one _WorkerGeneration per spawn;
+        # only that generation's bound reader completes its entries.
+        self._gen = _WorkerGeneration()
         self._reader: threading.Thread | None = None
-        self._ready_event = threading.Event()
-        self._ready_ok = False
 
     def _next_id(self) -> int:
         with self._lock:
@@ -96,8 +111,9 @@ class TranscriptionWorker:
         ctx = multiprocessing.get_context("spawn")
         self._request_q = ctx.Queue()
         self._response_q = ctx.Queue()
-        self._ready_event.clear()
-        self._ready_ok = False
+        # Fresh generation per spawn: the reader binds to THIS generation,
+        # so a lingering previous reader cannot touch the new state.
+        self._gen = _WorkerGeneration()
         self._process = ctx.Process(
             target=worker_main,
             args=(self._request_q, self._response_q, self._cfg, self._preload_model),
@@ -106,7 +122,7 @@ class TranscriptionWorker:
         self._process.start()
         self._reader = threading.Thread(
             target=self._reader_loop,
-            args=(self._process, self._response_q),
+            args=(self._process, self._response_q, self._gen),
             daemon=True,
             name="worker-response-reader",
         )
@@ -115,13 +131,15 @@ class TranscriptionWorker:
 
     # -- reader thread ------------------------------------------------------
 
-    def _reader_loop(self, process, response_q) -> None:
-        """Single owner of the response queue.
+    def _reader_loop(self, process, response_q, gen: _WorkerGeneration) -> None:
+        """Single owner of the response queue for ONE worker generation.
 
         Routes responses to pending waiters by request_id; handles 'ready'
         and startup-error messages; on process death fails every pending
-        request so no caller waits forever. Args are bound at spawn so a
-        restart() creating new process/queues never races this loop.
+        request so no caller waits forever. All args (process, queue, and
+        generation state) are bound at spawn, so a restart() creating a
+        new generation never races this loop, and a late exit here can
+        only touch THIS generation's state - never the successor's.
         """
         while True:
             alive = process.is_alive()
@@ -131,41 +149,46 @@ class TranscriptionWorker:
                 if not alive:
                     break  # drained after death
                 continue
-            except (EOFError, OSError):
+            except (EOFError, OSError, ValueError):
+                # ValueError: multiprocessing.Queue raises it once the
+                # queue is closed during shutdown/restart. Treat exactly
+                # like process death so pending waiters are failed below
+                # instead of stranded forever.
                 break
 
             mtype = msg.get("type")
             if mtype == "ready":
                 self.gpu_name = msg.get("gpu_name")
                 self.device = msg.get("device")
-                self._ready_ok = True
-                self._ready_event.set()
+                gen.ready_ok = True
+                gen.ready_event.set()
                 continue
             if msg.get("request_id") == "__init__":
                 # Startup failure (e.g. model preload error)
                 logger.error(f"Worker startup error: {msg.get('message')}")
-                self._ready_ok = False
-                self._ready_event.set()
+                gen.ready_ok = False
+                gen.ready_event.set()
                 continue
 
             rid = msg.get("request_id")
-            with self._pending_lock:
-                pending = self._pending.pop(rid, None)
+            with gen.pending_lock:
+                pending = gen.pending.pop(rid, None)
             if pending is not None:
                 pending.response = msg
                 pending.done.set()
             else:
                 logger.debug("worker reader: dropping stale response id=%r", rid)
 
-        # Process is dead and queue drained: fail everything outstanding.
-        with self._pending_lock:
-            orphans = list(self._pending.values())
-            self._pending.clear()
+        # Process is dead and queue drained: fail everything outstanding
+        # in THIS generation only.
+        with gen.pending_lock:
+            orphans = list(gen.pending.values())
+            gen.pending.clear()
         for p in orphans:
             p.response = None
             p.done.set()
-        # Unblock anyone still in wait_ready on a dead worker.
-        self._ready_event.set()
+        # Unblock anyone still in wait_ready on this (dead) generation.
+        gen.ready_event.set()
 
     # -- request plumbing ----------------------------------------------------
 
@@ -181,22 +204,23 @@ class TranscriptionWorker:
         alive — unusable either way) and raises WorkerCrashedError so the
         caller's existing crash handling respawns it.
         """
+        gen = self._gen
         request_id = self._next_id()
         pending = _PendingRequest()
-        with self._pending_lock:
-            self._pending[request_id] = pending
+        with gen.pending_lock:
+            gen.pending[request_id] = pending
         # Copy: never mutate the caller's dict (it may be reused/logged).
         outgoing = {**payload, "request_id": request_id}  # caller dict untouched
         try:
             self._request_q.put(outgoing)
         except Exception:
-            with self._pending_lock:
-                self._pending.pop(request_id, None)
+            with gen.pending_lock:
+                gen.pending.pop(request_id, None)
             raise
 
         if not pending.done.wait(timeout):
-            with self._pending_lock:
-                self._pending.pop(request_id, None)
+            with gen.pending_lock:
+                gen.pending.pop(request_id, None)
             logger.error(
                 "Worker request %s timed out after %ss; killing wedged worker",
                 payload.get("type"), timeout,
@@ -204,8 +228,6 @@ class TranscriptionWorker:
             try:
                 if self._process is not None and self._process.is_alive():
                     self._process.kill()
-                    # Reap promptly so repeated timeouts cannot accumulate
-                    # zombie children; stop()/restart() join again safely.
                     # join reaps the killed child immediately (review:
                     # repeated timeouts must not accumulate zombies).
                     self._process.join(timeout=3)
@@ -225,10 +247,11 @@ class TranscriptionWorker:
 
     def wait_ready(self, timeout: float = 120) -> bool:
         """Block until worker reports models are loaded."""
+        gen = self._gen
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if self._ready_event.wait(timeout=1.0):
-                return self._ready_ok and self.is_alive()
+            if gen.ready_event.wait(timeout=1.0):
+                return gen.ready_ok and self.is_alive()
             if not self.is_alive():
                 logger.error(
                     f"Worker died during startup (exit code {self._exitcode()})"
@@ -310,7 +333,7 @@ class TranscriptionWorker:
         return self._process is not None and self._process.is_alive()
 
     def is_ready(self) -> bool:
-        return self._ready_ok and self.is_alive()
+        return self._gen.ready_ok and self.is_alive()
 
     def update_config(self, cfg: dict):
         """Update the config snapshot for the next worker spawn."""
@@ -356,9 +379,10 @@ class TranscriptionWorker:
         except (ValueError, AttributeError):
             pass
         self._process = None
-        self._ready_ok = False
+        self._gen.ready_ok = False
         # Reader exits on its own after observing process death and
-        # draining; it fails any pending waiters first.
+        # draining; it fails its own generation's pending waiters first
+        # and cannot touch any successor generation's state.
 
     def _exitcode(self):
         return self._process.exitcode if self._process else None

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -2,6 +2,19 @@
 
 The worker runs whisperX/CTranslate2/CUDA in isolation. If it segfaults,
 the main process detects the death, logs it, and respawns automatically.
+
+Stability rebuild Phase 6: a single READER THREAD owns the response queue.
+Previously multiple threads raced ``response_q.get()`` (``wait_ready`` vs
+``_wait_response``; dictation vs meeting paths), and one consumer could
+swallow another's response, wedging the second caller forever. Now every
+request registers a pending-entry keyed by request_id; the reader routes
+responses to waiters and fails ALL pending requests when the process dies.
+``transcribe_fast`` (dictation, short audio) regains a real timeout:
+on expiry the worker is killed and respawn is left to the caller's
+WorkerCrashedError handling. ``transcribe`` (meetings) intentionally keeps
+NO timeout — long meetings legitimately exceed any fixed cap (the old hard
+timeout was removed in 4f3b307 for killing real transcriptions); worker
+death is still detected immediately via the reader.
 """
 
 import multiprocessing
@@ -11,10 +24,7 @@ import threading
 import time
 from pathlib import Path
 
-import numpy as np
-
 from .logger import logger
-from .worker import worker_main
 
 
 class WorkerCrashedError(RuntimeError):
@@ -36,6 +46,16 @@ def _reconstruct_error(response: dict) -> Exception:
     return RuntimeError(f"[{error_type}] {message}")
 
 
+class _PendingRequest:
+    """A response slot one caller waits on; completed by the reader thread."""
+
+    __slots__ = ("done", "response")
+
+    def __init__(self):
+        self.done = threading.Event()
+        self.response: dict | None = None  # None after done => worker died
+
+
 class TranscriptionWorker:
     """Manages a long-lived transcription subprocess."""
 
@@ -43,60 +63,177 @@ class TranscriptionWorker:
         self._cfg = cfg
         self._preload_model = preload_model
         self._process: multiprocessing.Process | None = None
-        self._request_q: multiprocessing.Queue | None = None
-        self._response_q: multiprocessing.Queue | None = None
-        self._ready = False
+        self._request_q = None
+        self._response_q = None
         self._request_counter = 0
         self._lock = threading.Lock()
         self.gpu_name: str | None = None
         self.device: str | None = None
+        # Reader-thread state (Phase 6). _pending maps request_id ->
+        # _PendingRequest; only the reader completes entries.
+        self._pending: dict[int, _PendingRequest] = {}
+        self._pending_lock = threading.Lock()
+        self._reader: threading.Thread | None = None
+        self._ready_event = threading.Event()
+        self._ready_ok = False
 
     def _next_id(self) -> int:
-        self._request_counter += 1
-        return self._request_counter
+        with self._lock:
+            self._request_counter += 1
+            return self._request_counter
 
     def start(self) -> None:
-        """Spawn the worker process. Non-blocking."""
+        """Spawn the worker process and its response reader. Non-blocking."""
+        # Deferred import: worker.py pulls numpy at module level, which is
+        # only needed in the subprocess. Keeping it out of module scope
+        # lets the protocol layer be unit-tested without heavy deps.
+        from .worker import worker_main
+
         ctx = multiprocessing.get_context("spawn")
         self._request_q = ctx.Queue()
         self._response_q = ctx.Queue()
-        self._ready = False
+        self._ready_event.clear()
+        self._ready_ok = False
         self._process = ctx.Process(
             target=worker_main,
             args=(self._request_q, self._response_q, self._cfg, self._preload_model),
             daemon=True,
         )
         self._process.start()
+        self._reader = threading.Thread(
+            target=self._reader_loop,
+            args=(self._process, self._response_q),
+            daemon=True,
+            name="worker-response-reader",
+        )
+        self._reader.start()
         logger.info(f"Worker process spawned (pid={self._process.pid})")
+
+    # -- reader thread ------------------------------------------------------
+
+    def _reader_loop(self, process, response_q) -> None:
+        """Single owner of the response queue.
+
+        Routes responses to pending waiters by request_id; handles 'ready'
+        and startup-error messages; on process death fails every pending
+        request so no caller waits forever. Args are bound at spawn so a
+        restart() creating new process/queues never races this loop.
+        """
+        while True:
+            alive = process.is_alive()
+            try:
+                msg = response_q.get(timeout=0.5)
+            except queue.Empty:
+                if not alive:
+                    break  # drained after death
+                continue
+            except (EOFError, OSError):
+                break
+
+            mtype = msg.get("type")
+            if mtype == "ready":
+                self.gpu_name = msg.get("gpu_name")
+                self.device = msg.get("device")
+                self._ready_ok = True
+                self._ready_event.set()
+                continue
+            if msg.get("request_id") == "__init__":
+                # Startup failure (e.g. model preload error)
+                logger.error(f"Worker startup error: {msg.get('message')}")
+                self._ready_ok = False
+                self._ready_event.set()
+                continue
+
+            rid = msg.get("request_id")
+            with self._pending_lock:
+                pending = self._pending.pop(rid, None)
+            if pending is not None:
+                pending.response = msg
+                pending.done.set()
+            else:
+                logger.debug("worker reader: dropping stale response id=%r", rid)
+
+        # Process is dead and queue drained: fail everything outstanding.
+        with self._pending_lock:
+            orphans = list(self._pending.values())
+            self._pending.clear()
+        for p in orphans:
+            p.response = None
+            p.done.set()
+        # Unblock anyone still in wait_ready on a dead worker.
+        self._ready_event.set()
+
+    # -- request plumbing ----------------------------------------------------
+
+    def _request(self, payload: dict, timeout: float | None) -> dict:
+        """Send a request and wait for its routed response.
+
+        timeout=None waits until the worker answers or dies (meeting
+        path). With a timeout, expiry KILLS the worker (it is wedged but
+        alive — unusable either way) and raises WorkerCrashedError so the
+        caller's existing crash handling respawns it.
+        """
+        request_id = self._next_id()
+        pending = _PendingRequest()
+        with self._pending_lock:
+            self._pending[request_id] = pending
+        payload["request_id"] = request_id
+        try:
+            self._request_q.put(payload)
+        except Exception:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise
+
+        if not pending.done.wait(timeout):
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            logger.error(
+                "Worker request %s timed out after %ss; killing wedged worker",
+                payload.get("type"), timeout,
+            )
+            try:
+                if self._process is not None and self._process.is_alive():
+                    self._process.kill()
+            except Exception:
+                pass
+            raise WorkerCrashedError(
+                f"Worker request timed out after {timeout}s (worker killed)"
+            )
+
+        if pending.response is None:
+            raise WorkerCrashedError(
+                f"Worker process died (exit code {self._exitcode()})"
+            )
+        return pending.response
+
+    # -- public API -----------------------------------------------------------
 
     def wait_ready(self, timeout: float = 120) -> bool:
         """Block until worker reports models are loaded."""
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._ready_event.wait(timeout=1.0):
+                return self._ready_ok and self.is_alive()
             if not self.is_alive():
-                logger.error(f"Worker died during startup (exit code {self._exitcode()})")
+                logger.error(
+                    f"Worker died during startup (exit code {self._exitcode()})"
+                )
                 return False
-            try:
-                msg = self._response_q.get(timeout=1.0)
-                if msg.get("type") == "ready":
-                    self._ready = True
-                    self.gpu_name = msg.get("gpu_name")
-                    self.device = msg.get("device")
-                    return True
-                if msg.get("type") == "error":
-                    logger.error(f"Worker startup error: {msg.get('message')}")
-                    return False
-            except queue.Empty:
-                continue
         logger.error("Worker startup timed out")
         return False
 
-    def transcribe_fast(self, audio_np: np.ndarray, model_override: str | None = None,
+    def transcribe_fast(self, audio_np, model_override: str | None = None,
                         timeout: float = 60) -> str:
         """Send dictation audio to worker, return transcribed text.
 
-        Audio is transferred via a temp .npy file to avoid pickling large arrays.
+        Audio is transferred via a temp .npy file to avoid pickling large
+        arrays. Dictations are short, so the timeout is real (Phase 6): a
+        wedged worker is killed and WorkerCrashedError raised instead of
+        hanging the dictation thread forever.
         """
+        import numpy as np
+
         # Save audio to temp file (NamedTemporaryFile avoids mktemp TOCTOU race)
         tmp_fd = tempfile.NamedTemporaryFile(suffix=".npy", prefix="ws_audio_", delete=False)
         tmp_path = Path(tmp_fd.name)
@@ -104,14 +241,11 @@ class TranscriptionWorker:
         np.save(str(tmp_path), audio_np)
 
         try:
-            request_id = self._next_id()
-            self._request_q.put({
+            response = self._request({
                 "type": "transcribe_fast",
                 "audio_path": str(tmp_path),
                 "model": model_override,
-                "request_id": request_id,
-            })
-            response = self._wait_response(request_id, timeout)
+            }, timeout=timeout)
         finally:
             tmp_path.unlink(missing_ok=True)
 
@@ -122,46 +256,44 @@ class TranscriptionWorker:
     def transcribe(self, audio_path: str, diarize: bool = False,
                    model_override: str | None = None,
                    diarize_method: str | None = None,
-                   timeout: float = 600) -> dict:
+                   timeout: float | None = None) -> dict:
         """Send meeting audio to worker, return result dict.
 
         Args:
             diarize_method: Force a specific diarization method
                 ("balanced_mix", "per_channel", "raw_audio"). None uses config.
+            timeout: None (default) waits until the worker answers or
+                dies — long meetings legitimately run for many minutes and
+                a hard cap killed real transcriptions (see 4f3b307).
+                Callers that know their audio is short (tests) may pass one.
         """
-        request_id = self._next_id()
-        self._request_q.put({
+        response = self._request({
             "type": "transcribe",
             "audio_path": audio_path,
             "diarize": diarize,
             "model": model_override,
             "diarize_method": diarize_method,
-            "request_id": request_id,
-        })
-        response = self._wait_response(request_id, timeout)
+        }, timeout=timeout)
         if response["type"] == "error":
             raise _reconstruct_error(response)
         return response.get("result", {})
 
     def reload_model(self, model_name: str, timeout: float = 120) -> bool:
         """Ask the worker to load a different model."""
-        request_id = self._next_id()
-        self._request_q.put({
-            "type": "reload_model",
-            "model": model_name,
-            "request_id": request_id,
-        })
         try:
-            response = self._wait_response(request_id, timeout)
+            response = self._request({
+                "type": "reload_model",
+                "model": model_name,
+            }, timeout=timeout)
             return response.get("type") == "model_loaded"
-        except (WorkerCrashedError, TimeoutError):
+        except WorkerCrashedError:
             return False
 
     def is_alive(self) -> bool:
         return self._process is not None and self._process.is_alive()
 
     def is_ready(self) -> bool:
-        return self._ready and self.is_alive()
+        return self._ready_ok and self.is_alive()
 
     def update_config(self, cfg: dict):
         """Update the config snapshot for the next worker spawn."""
@@ -170,9 +302,10 @@ class TranscriptionWorker:
     def restart(self) -> None:
         """Kill and respawn the worker (e.g., after a crash).
 
-        Blocks until the new worker is ready so that no concurrent
-        ``_wait_response`` call can race with ``wait_ready`` on the
-        response queue.
+        Blocks until the new worker is ready. The old reader thread is
+        bound to the old process/queue objects and exits on its own when
+        the old process dies; pending requests against the old worker are
+        failed by that reader, so no waiter leaks across the restart.
         """
         logger.info("Restarting transcription worker...")
         self.stop()
@@ -206,32 +339,9 @@ class TranscriptionWorker:
         except (ValueError, AttributeError):
             pass
         self._process = None
-        self._ready = False
+        self._ready_ok = False
+        # Reader exits on its own after observing process death and
+        # draining; it fails any pending waiters first.
 
-    def _wait_response(self, request_id: int, timeout: float = None) -> dict:
-        """Wait for a response matching request_id.
-
-        Blocks until the worker sends a matching response or dies. There is no
-        hard timeout - the only termination condition is worker death. The
-        ``timeout`` parameter is accepted for backward compatibility but ignored.
-        """
-        while True:
-            if not self.is_alive():
-                raise WorkerCrashedError(
-                    f"Worker process died (exit code {self._exitcode()})"
-                )
-            try:
-                msg = self._response_q.get(timeout=0.5)
-                if msg.get("request_id") == request_id:
-                    return msg
-                # Handle "ready" messages that arrive while waiting for a response
-                if msg.get("type") == "ready":
-                    self._ready = True
-                    self.gpu_name = msg.get("gpu_name")
-                    self.device = msg.get("device")
-                # Stale message from a previous request - discard
-            except queue.Empty:
-                continue
-
-    def _exitcode(self) -> int | None:
+    def _exitcode(self):
         return self._process.exitcode if self._process else None

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -172,6 +172,10 @@ class TranscriptionWorker:
     def _request(self, payload: dict, timeout: float | None) -> dict:
         """Send a request and wait for its routed response.
 
+        The caller's ``payload`` is never mutated; a copy gains the
+        request_id (addressed in review: no externally visible side
+        effects).
+
         timeout=None waits until the worker answers or dies (meeting
         path). With a timeout, expiry KILLS the worker (it is wedged but
         alive — unusable either way) and raises WorkerCrashedError so the
@@ -182,9 +186,9 @@ class TranscriptionWorker:
         with self._pending_lock:
             self._pending[request_id] = pending
         # Copy: never mutate the caller's dict (it may be reused/logged).
-        payload = {**payload, "request_id": request_id}
+        outgoing = {**payload, "request_id": request_id}  # caller dict untouched
         try:
-            self._request_q.put(payload)
+            self._request_q.put(outgoing)
         except Exception:
             with self._pending_lock:
                 self._pending.pop(request_id, None)
@@ -202,6 +206,8 @@ class TranscriptionWorker:
                     self._process.kill()
                     # Reap promptly so repeated timeouts cannot accumulate
                     # zombie children; stop()/restart() join again safely.
+                    # join reaps the killed child immediately (review:
+                    # repeated timeouts must not accumulate zombies).
                     self._process.join(timeout=3)
             except Exception:
                 pass
@@ -239,7 +245,9 @@ class TranscriptionWorker:
         Audio is transferred via a temp .npy file to avoid pickling large
         arrays. Dictations are short, so the timeout is real (Phase 6): a
         wedged worker is killed and WorkerCrashedError raised instead of
-        hanging the dictation thread forever.
+        hanging the dictation thread forever. The np.ndarray annotation
+        is a TYPE_CHECKING forward reference (review: keep type safety
+        without importing numpy at module scope).
         """
         import numpy as np
 

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -23,8 +23,12 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .logger import logger
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class WorkerCrashedError(RuntimeError):
@@ -177,7 +181,8 @@ class TranscriptionWorker:
         pending = _PendingRequest()
         with self._pending_lock:
             self._pending[request_id] = pending
-        payload["request_id"] = request_id
+        # Copy: never mutate the caller's dict (it may be reused/logged).
+        payload = {**payload, "request_id": request_id}
         try:
             self._request_q.put(payload)
         except Exception:
@@ -195,6 +200,9 @@ class TranscriptionWorker:
             try:
                 if self._process is not None and self._process.is_alive():
                     self._process.kill()
+                    # Reap promptly so repeated timeouts cannot accumulate
+                    # zombie children; stop()/restart() join again safely.
+                    self._process.join(timeout=3)
             except Exception:
                 pass
             raise WorkerCrashedError(
@@ -223,7 +231,8 @@ class TranscriptionWorker:
         logger.error("Worker startup timed out")
         return False
 
-    def transcribe_fast(self, audio_np, model_override: str | None = None,
+    def transcribe_fast(self, audio_np: "np.ndarray",
+                        model_override: str | None = None,
                         timeout: float = 60) -> str:
         """Send dictation audio to worker, return transcribed text.
 


### PR DESCRIPTION
## Context

Phase 6 of the stability rebuild plan (section 3.5, worker protocol).

## Problems in the old protocol

- Multiple threads raced `response_q.get()` (`wait_ready` vs
  `_wait_response`; dictation vs meeting paths). One consumer could
  swallow another's response; the second caller waited forever on a
  message that would never come.
- `_wait_response` accepted a timeout parameter and **ignored it**: a
  wedged-but-alive worker hung the calling thread indefinitely.

## New protocol

- **One reader thread per worker** owns the response queue. Requests
  register pending-slots keyed by request_id; the reader routes
  responses to their waiters, and on process death **fails ALL pending
  requests immediately** - no caller ever waits on a dead worker.
  Reader args are bound at spawn, so a restart's new process/queues
  never race the old loop.
- `transcribe_fast` regains a **real timeout** (dictations are short):
  expiry kills the wedged worker and raises WorkerCrashedError so the
  caller's existing crash handling respawns it.
- `transcribe` (meetings) intentionally stays unbounded by default -
  hard caps killed legitimate long transcriptions (removed in 4f3b307);
  worker death is still detected immediately via the reader.

*Architecture note: subprocess message SHAPES are unchanged - worker.py
needs no modification. Only the parent-side consumption model changed.*

## Validation

- 7 protocol tests against a fake process + plain queues: request_id
  routing, **out-of-order responses to concurrent callers**, stale
  drop, ready handling, startup-error path, **death fails all pending**,
  **timeout kills wedged worker**.
- System suite: **114 pass**.
- **Real-data E2E re-run against the new protocol** (`WS_E2E=1`,
  production worker subprocess, actual meeting recording): PASS in 64 s,
  full staged pipeline, worker alive afterward.

## Test plan

- [ ] Dictations + meetings work normally after update.
- [ ] Kill the worker process in Task Manager mid-meeting: pipeline
      fails fast with the crash toast + respawn instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)