### PR TITLE
ci: gate auto-merge on unresolved review threads, not commit-sha matching

### DIFF
--- a/.github/governance/policy.yaml
+++ b/.github/governance/policy.yaml
@@ -5,7 +5,11 @@
 merge_policy:
   auto_merge_enabled: true
   require_copilot_review: true
-  require_zero_suggestions: true
+  # Zero unresolved (and not outdated) Copilot review threads required.
+  # Addressed feedback is closed by replying with the fixing commit and
+  # resolving the thread; commit-sha matching is NOT used because GitHub
+  # remaps surviving comments onto new head commits.
+  require_zero_unresolved_threads: true
   manual_merge_prohibited: true
   # All merges must go through auto-merge workflow after Copilot review.
   # Manual gh pr merge or GitHub UI merge is a policy violation.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -161,9 +161,12 @@ jobs:
                   cursor
                 });
                 const threads = resp.repository.pullRequest.reviewThreads;
+                // GraphQL may return the bot login with or without the
+                // [bot] suffix depending on API surface; accept both.
+                const copilotLogins = ['copilot-pull-request-reviewer', 'copilot-pull-request-reviewer[bot]'];
                 unresolvedThreads += threads.nodes.filter(t =>
                   !t.isResolved && !t.isOutdated
-                  && t.comments.nodes[0]?.author?.login === 'copilot-pull-request-reviewer'
+                  && copilotLogins.includes(t.comments.nodes[0]?.author?.login)
                 ).length;
                 if (!threads.pageInfo.hasNextPage) break;
                 cursor = threads.pageInfo.endCursor;

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -126,28 +126,58 @@ jobs:
                 continue;
               }
 
-              // Check for unresolved inline suggestions
-              const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                per_page: 100
-              });
-              // Only count comments on the latest commit - old comments from
-              // previous pushes should not permanently block auto-merge.
-              const suggestions = reviewComments.filter(
-                c => c.user.login === 'copilot-pull-request-reviewer[bot]'
-                  && c.commit_id === prData.head.sha
-              );
+              // Check for unresolved Copilot review threads.
+              //
+              // Why thread state and not commit_id matching: when a push fixes
+              // a comment WITHOUT rewriting its exact anchored lines, GitHub
+              // remaps the surviving comment onto the new head commit and
+              // updates its commit_id, so `commit_id === head.sha` re-counts
+              // already-addressed feedback forever (PR #146). Thread state is
+              // the first-class signal: a thread blocks until it is resolved
+              // (reply citing the fixing commit, then resolve) or its anchor
+              // lines are rewritten (isOutdated).
+              let unresolvedThreads = 0;
+              let cursor = null;
+              while (true) {
+                const resp = await github.graphql(`
+                  query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            isResolved
+                            isOutdated
+                            comments(first: 1) { nodes { author { login } } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                `, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  number: prNumber,
+                  cursor
+                });
+                const threads = resp.repository.pullRequest.reviewThreads;
+                unresolvedThreads += threads.nodes.filter(t =>
+                  !t.isResolved && !t.isOutdated
+                  && t.comments.nodes[0]?.author?.login === 'copilot-pull-request-reviewer'
+                ).length;
+                if (!threads.pageInfo.hasNextPage) break;
+                cursor = threads.pageInfo.endCursor;
+              }
 
-              if (suggestions.length > 0) {
+              if (unresolvedThreads > 0) {
+                console.log(`PR #${prNumber}: ${unresolvedThreads} unresolved Copilot thread(s)`);
                 // Only comment once
                 if (!comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merge skipped'))) {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: prNumber,
-                    body: `## Auto-merge skipped\n\nCopilot found ${suggestions.length} suggestion(s). Push fixes and auto-merge will re-check.`
+                    body: `## Auto-merge skipped\n\nCopilot has ${unresolvedThreads} unresolved review thread(s). Push fixes, resolve each thread with a reply citing the fixing commit, and auto-merge will re-check.`
                   });
                 }
                 continue;
@@ -176,7 +206,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  body: `## Auto-merged\n\nCopilot reviewed (${complexity}), no suggestions. Merged automatically.\n\n**${changedLines} lines** across: ${fileList}`
+                  body: `## Auto-merged\n\nCopilot reviewed (${complexity}), no unresolved review threads. Merged automatically.\n\n**${changedLines} lines** across: ${fileList}`
                 });
                 console.log(`PR #${prNumber} auto-merged`);
               } catch (err) {

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -190,87 +190,9 @@ jobs:
               body: body
             });
 
-  auto-merge:
-    runs-on: ubuntu-latest
-    needs: triage
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-    if: github.event_name == 'pull_request_review' && github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
-    steps:
-      - name: Auto-merge if Copilot approved
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const { data: prData } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            if (prData.state !== 'open' || prData.merged) return;
 
-            // Dedup
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: prNumber
-            });
-            if (comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merged'))) return;
-
-            // Check Copilot reviewed
-            const { data: reviews } = await github.rest.pulls.listReviews({
-              owner: context.repo.owner, repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            if (!reviews.some(r => r.user.login === 'copilot-pull-request-reviewer[bot]')) {
-              console.log(`PR #${prNumber}: no Copilot review yet`);
-              return;
-            }
-
-            // Check for inline suggestions
-            const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            // Only count comments on the latest commit -- old comments from
-            // previous pushes should not permanently block auto-merge.
-            const suggestions = reviewComments.filter(
-              c => c.user.login === 'copilot-pull-request-reviewer[bot]'
-                && c.commit_id === prData.head.sha
-            );
-            if (suggestions.length > 0) {
-              if (!comments.some(c => c.user.login === 'github-actions[bot]' && c.body.includes('Auto-merge skipped'))) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: prNumber,
-                  body: `## Auto-merge skipped\n\nCopilot found ${suggestions.length} suggestion(s).`
-                });
-              }
-              return;
-            }
-
-            // Merge
-            const labels = prData.labels.map(l => l.name);
-            const complexity = labels.find(l => l.startsWith('complexity:')) || 'unknown';
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner, repo: context.repo.repo,
-              pull_number: prNumber, per_page: 100
-            });
-            const changedLines = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
-            const fileList = files.map(f => f.filename).join(', ');
-
-            try {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner, repo: context.repo.repo,
-                pull_number: prNumber, merge_method: 'squash'
-              });
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: prNumber,
-                body: `## Auto-merged\n\nCopilot reviewed (${complexity}), no suggestions.\n\n**${changedLines} lines** across: ${fileList}`
-              });
-              console.log(`PR #${prNumber} auto-merged`);
-            } catch (err) {
-              console.log(`PR #${prNumber} merge failed: ${err.message}`);
-            }
+  # NOTE: the auto-merge job that previously lived here was removed.
+  # It duplicated .github/workflows/auto-merge.yml with a stale gate
+  # (commit-sha comment matching) that could merge past unresolved
+  # Copilot threads or post conflicting skip comments. auto-merge.yml
+  # covers the pull_request_review trigger this job listened to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ output_dir/
 - **Text style**: No em dash characters. Use single hyphens for asides.
 - **Author**: `--author="Pendentive <pendentive.info@gmail.com>"` for all commits.
 - **PRs**: Always wait for Copilot review before merging. Update docs in the same PR.
+- **Review threads**: After pushing a fix for a Copilot comment, reply on the thread citing the fixing commit, then resolve it (GraphQL resolveReviewThread). Auto-merge blocks on unresolved Copilot threads; outdated threads (anchor lines rewritten) clear automatically.
 - **Merging**: NEVER merge manually (gh pr merge, GitHub UI). All merges go through auto-merge workflow after Copilot review. No exceptions without explicit user approval in conversation first. See `.github/governance/policy.yaml`.
 - **Spec first**: Use superpowers:brainstorming to define spec, get user approval, then implement via PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Use a prefix that describes the type of change:
 2. **Make your changes** -- keep PRs focused on a single concern
 3. **Open a PR** against `dev`
 4. **Automated review runs** -- the CI workflow classifies your PR by complexity, Copilot reviews the code
-5. **Auto-merge** if Copilot finds no issues and complexity is low/medium. Otherwise, address suggestions and push again.
+5. **Auto-merge** if Copilot finds no issues and complexity is low/medium. Otherwise, address suggestions, push, and resolve each review thread with a reply citing the fixing commit.
 
 ### Automated Review
 
@@ -33,7 +33,7 @@ The [review-pr workflow](.github/workflows/review-pr.yml) runs on every PR:
 | `complexity:medium` | 50-200 lines, 3-5 files | Automated review comment, merge-ready |
 | `complexity:high` | >200 lines or >5 files | Copilot reviews thoroughly, auto-merge if clean |
 
-All PRs are machine-reviewed by Copilot Code Review. If Copilot finds inline suggestions, address them and push. Auto-merge fires when Copilot has no suggestions.
+All PRs are machine-reviewed by Copilot Code Review. If Copilot finds inline suggestions, address them, push, and resolve the threads (reply with the fixing commit, then resolve). Auto-merge fires when Copilot has no unresolved review threads. Threads whose anchor lines were rewritten by the fix become outdated and clear automatically; threads fixed elsewhere in the file must be resolved explicitly, because GitHub remaps surviving comments onto new head commits.
 
 ## Labels
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Use a prefix that describes the type of change:
 2. **Make your changes** -- keep PRs focused on a single concern
 3. **Open a PR** against `dev`
 4. **Automated review runs** -- the CI workflow classifies your PR by complexity, Copilot reviews the code
-5. **Auto-merge** if Copilot finds no issues and complexity is low/medium. Otherwise, address suggestions, push, and resolve each review thread with a reply citing the fixing commit.
+5. **Auto-merge** once Copilot has reviewed and no Copilot review threads remain unresolved. A clean first review merges immediately; if Copilot left suggestions, address them, push, and resolve each thread with a reply citing the fixing commit - no fresh clean review run is required.
 
 ### Automated Review
 


### PR DESCRIPTION
## Problem

PR #146 is permanently blocked by auto-merge even though every Copilot comment is addressed. The gate counts Copilot review comments whose `commit_id` matches the head sha. When a fix commit does NOT rewrite the exact anchored lines, GitHub remaps the surviving comment onto the new head commit and updates its `commit_id`, so already-addressed feedback re-counts on every push, forever.

This is structural, not a one-off: it recurs any time a fix lands near (but not on) the commented lines. Previous PRs never hit it because their fixes happened to rewrite the anchored lines, which marks comments outdated (commit_id stays on the old sha) and the old filter ignored them.

## Fix

Gate on GitHub's first-class review state instead: block only on Copilot review threads that are **unresolved AND not outdated** (GraphQL `reviewThreads`, paginated).

- Common case unchanged: a fix that rewrites the anchored lines makes the thread outdated and it clears automatically.
- Remap case now has an explicit close-out: reply on the thread citing the fixing commit, then resolve it. Resolution survives remapping.
- Skip comment and merge comment updated to describe the new gate.

## Architecture note (protected path .github/**)

The merge gate moves from sha-coincidence to review-thread state, which is the durable signal GitHub itself maintains across pushes and position remaps. Governance semantics preserved: Copilot review still required, zero open feedback still required, manual merge still prohibited. Policy key renamed `require_zero_suggestions` -> `require_zero_unresolved_threads` (grep confirms no workflow parses the key by name).

## Docs

CONTRIBUTING.md review flow and CLAUDE.md agent rules updated in this PR.

## Validation

- YAML parses (PyYAML), embedded script passes `node --check`.
- GraphQL query shape and author login (`copilot-pull-request-reviewer`) verified live against PR #146: the 4 blocking remapped ghosts are `isResolved: false, isOutdated: false` and the new gate plus thread resolution unblocks it.