### PR TITLE
feat: stability rebuild phase 5b - thread-safe ConfigStore

### DIFF
--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -1,0 +1,166 @@
+"""Tests for whisper_sync.config_store - lock-guarded config Mapping.
+
+The bug class this closes: the bare cfg dict was read by the tray menu,
+hotkey handlers, and pipeline threads while settings handlers wrote to
+it. ``config.save()`` could hit "dictionary changed size during
+iteration" and persist a torn view; nested hotkey writes were visible
+half-applied.
+"""
+
+import pickle
+import threading
+import unittest
+
+from whisper_sync.config_store import ConfigStore
+
+
+def _store():
+    return ConfigStore({
+        "model": "large-v3",
+        "paste_method": "keystrokes",
+        "hotkeys": {"dictation_toggle": "ctrl+shift+space",
+                    "meeting_toggle": "ctrl+shift+m"},
+    })
+
+
+class ConfigStoreMappingTests(unittest.TestCase):
+    def test_existing_read_idioms_work_unchanged(self):
+        cfg = _store()
+        self.assertEqual(cfg["model"], "large-v3")
+        self.assertEqual(cfg.get("missing", "fallback"), "fallback")
+        self.assertIn("paste_method", cfg)
+        self.assertEqual(cfg["hotkeys"]["meeting_toggle"], "ctrl+shift+m")
+        # Unpacking idioms used by backup_worker and worker_manager.
+        self.assertEqual({**cfg}["model"], "large-v3")
+        self.assertEqual(dict(cfg)["paste_method"], "keystrokes")
+        self.assertEqual(len(cfg), 3)
+        self.assertEqual(set(cfg.keys()), {"model", "paste_method", "hotkeys"})
+
+    def test_setitem_and_readback(self):
+        cfg = _store()
+        cfg["model"] = "base"
+        self.assertEqual(cfg["model"], "base")
+
+    def test_store_does_not_alias_initial_dict(self):
+        initial = {"hotkeys": {"dictation_toggle": "a"}}
+        cfg = ConfigStore(initial)
+        initial["hotkeys"]["dictation_toggle"] = "mutated"
+        self.assertEqual(cfg["hotkeys"]["dictation_toggle"], "a")
+
+
+class SetNestedTests(unittest.TestCase):
+    def test_set_nested_updates_value(self):
+        cfg = _store()
+        cfg.set_nested("hotkeys", "dictation_toggle", "f13")
+        self.assertEqual(cfg["hotkeys"]["dictation_toggle"], "f13")
+        self.assertEqual(cfg["hotkeys"]["meeting_toggle"], "ctrl+shift+m")
+
+    def test_set_nested_is_copy_on_write(self):
+        # A reader holding the old inner dict must keep a complete stale
+        # value, never see a half-applied write.
+        cfg = _store()
+        before = cfg["hotkeys"]
+        cfg.set_nested("hotkeys", "dictation_toggle", "f13")
+        self.assertEqual(before["dictation_toggle"], "ctrl+shift+space")
+        self.assertIsNot(cfg["hotkeys"], before)
+
+    def test_set_nested_rejects_non_dict_target(self):
+        cfg = _store()
+        with self.assertRaises(TypeError):
+            cfg.set_nested("model", "x", 1)
+
+
+class SnapshotTests(unittest.TestCase):
+    def test_snapshot_is_deep_and_isolated(self):
+        cfg = _store()
+        snap = cfg.snapshot()
+        snap["model"] = "tampered"
+        snap["hotkeys"]["dictation_toggle"] = "tampered"
+        self.assertEqual(cfg["model"], "large-v3")
+        self.assertEqual(cfg["hotkeys"]["dictation_toggle"], "ctrl+shift+space")
+
+    def test_store_refuses_pickle_snapshot_allows_it(self):
+        # The store holds a lock; passing it to multiprocessing must fail
+        # loudly, and the documented alternative must work.
+        cfg = _store()
+        with self.assertRaises(TypeError):
+            pickle.dumps(cfg)
+        restored = pickle.loads(pickle.dumps(cfg.snapshot()))
+        self.assertEqual(restored["model"], "large-v3")
+
+
+class ConcurrencyTests(unittest.TestCase):
+    def test_snapshot_never_tears_under_concurrent_writes(self):
+        # Writers flip two keys together; every snapshot must see them in
+        # agreement (the torn-save bug this store exists to prevent).
+        cfg = ConfigStore({"a": 0, "b": 0, "hotkeys": {}})
+        stop = threading.Event()
+        torn = []
+
+        def _writer():
+            i = 0
+            while not stop.is_set():
+                i += 1
+                with cfg.transaction():  # paired write, as the diarize swap does
+                    cfg["a"] = i
+                    cfg["b"] = i
+
+        def _reader():
+            while not stop.is_set():
+                snap = cfg.snapshot()
+                if snap["a"] != snap["b"]:
+                    torn.append(snap)
+                    return
+
+        w = threading.Thread(target=_writer, daemon=True)
+        readers = [threading.Thread(target=_reader, daemon=True) for _ in range(4)]
+        w.start()
+        for r in readers:
+            r.start()
+        threading.Event().wait(0.5)
+        stop.set()
+        w.join(timeout=2.0)
+        for r in readers:
+            r.join(timeout=2.0)
+        self.assertEqual(torn, [], "snapshot must be atomic across keys")
+
+    def test_concurrent_writers_and_iterators_do_not_crash(self):
+        # The classic failure: json.dump iterating the dict while another
+        # thread adds keys raises RuntimeError. The store's iteration is
+        # taken under the lock, so this must be exception-free.
+        cfg = ConfigStore({"seed": 0, "hotkeys": {}})
+        stop = threading.Event()
+        errors = []
+
+        def _writer(tag):
+            i = 0
+            while not stop.is_set():
+                i += 1
+                cfg[f"key_{tag}_{i % 50}"] = i
+                cfg.set_nested("hotkeys", f"hk_{tag}", i)
+
+        def _iterator():
+            while not stop.is_set():
+                try:
+                    dict(cfg)
+                    {**cfg}
+                    list(cfg.items())
+                except RuntimeError as e:
+                    errors.append(e)
+                    return
+
+        threads = [threading.Thread(target=_writer, args=(t,), daemon=True)
+                   for t in range(3)]
+        threads += [threading.Thread(target=_iterator, daemon=True)
+                    for _ in range(3)]
+        for t in threads:
+            t.start()
+        threading.Event().wait(0.5)
+        stop.set()
+        for t in threads:
+            t.join(timeout=2.0)
+        self.assertEqual(errors, [], "iteration must never race writers")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -41,6 +41,18 @@ class ConfigStoreMappingTests(unittest.TestCase):
         cfg["model"] = "base"
         self.assertEqual(cfg["model"], "base")
 
+    def test_read_values_are_copies_not_live_references(self):
+        # Regression for Copilot review on PR #149: handing out the live
+        # inner dict/list would let callers mutate shared state without
+        # the lock. Reads of mutable containers must be isolated copies.
+        cfg = _store()
+        cfg["toast_events"] = ["a", "b"]
+        cfg["toast_events"].append("c")          # mutating a read copy...
+        self.assertEqual(cfg["toast_events"], ["a", "b"])  # ...never writes back
+        hk = cfg["hotkeys"]
+        hk["dictation_toggle"] = "tampered"
+        self.assertEqual(cfg["hotkeys"]["dictation_toggle"], "ctrl+shift+space")
+
     def test_store_does_not_alias_initial_dict(self):
         initial = {"hotkeys": {"dictation_toggle": "a"}}
         cfg = ConfigStore(initial)

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -34,6 +34,7 @@ import keyboard
 import pystray
 
 from . import config
+from .config_store import ConfigStore
 from .capture import AudioRecorder, get_default_devices, get_host_apis, list_devices, save_wav, save_stereo_wav
 from .icons import (idle_icon, build_icon, resolve_icon_key, ICON_REGISTRY,
                      IconAnimator)
@@ -133,7 +134,7 @@ def _get_cpu_name() -> str:
 class WhisperSync:
     def __init__(self):
         self._migrate_data()
-        self.cfg = config.load()
+        self.cfg = ConfigStore(config.load())
         set_console_level(self.cfg.get("log_window", "normal"))
         self.recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
         self.tray = None
@@ -2820,7 +2821,7 @@ class WhisperSync:
             refresher.request()
 
     def _save_and_refresh(self):
-        config.save(self.cfg)
+        config.save(self.cfg.snapshot())
         self._refresh_menu()
 
     # --- GitHub PR Status ---
@@ -3183,7 +3184,7 @@ class WhisperSync:
         old = self.cfg["hotkeys"].get(key)
         if old == hotkey:
             return
-        self.cfg["hotkeys"][key] = hotkey
+        self.cfg.set_nested("hotkeys", key, hotkey)
         self._save_and_refresh()
         self._restart()
 
@@ -3226,7 +3227,7 @@ class WhisperSync:
             return
 
         logger.info(f"Switching device: {old} -> {device} ({old_resolved} -> {new_resolved})")
-        self.worker.update_config(dict(self.cfg))
+        self.worker.update_config(self.cfg)
         _previous_device = old
         def _do_restart():
             self.worker.restart()
@@ -3286,16 +3287,17 @@ class WhisperSync:
     def _set_diarize_method(self, slot_key: str, method_id: str):
         """Set a diarization slot, swapping with any slot that already has this method."""
         from .transcribe import DIARIZE_METHODS
-        current = self.cfg.get(slot_key, "balanced_mix")
-        if current == method_id:
-            return
-        # Find if another slot already uses this method and swap
-        all_slots = ["diarize_primary", "diarize_fallback", "diarize_last_resort"]
-        for other_slot in all_slots:
-            if other_slot != slot_key and self.cfg.get(other_slot, "balanced_mix") == method_id:
-                self.cfg[other_slot] = current  # swap
-                break
-        self.cfg[slot_key] = method_id
+        with self.cfg.transaction():
+            current = self.cfg.get(slot_key, "balanced_mix")
+            if current == method_id:
+                return
+            # Find if another slot already uses this method and swap
+            all_slots = ["diarize_primary", "diarize_fallback", "diarize_last_resort"]
+            for other_slot in all_slots:
+                if other_slot != slot_key and self.cfg.get(other_slot, "balanced_mix") == method_id:
+                    self.cfg[other_slot] = current  # swap
+                    break
+            self.cfg[slot_key] = method_id
         label = DIARIZE_METHODS.get(method_id, method_id)
         logger.info(f"Diarization {slot_key}: {label}", extra={"secondary": True})
         self._save_and_refresh()

--- a/whisper_sync/config_store.py
+++ b/whisper_sync/config_store.py
@@ -39,7 +39,16 @@ class ConfigStore(Mapping):
 
     def __getitem__(self, key):
         with self._lock:
-            return self._data[key]
+            value = self._data[key]
+            # Mutable containers are returned as deep copies: handing out
+            # the live inner object would let callers mutate it without
+            # the lock, defeating the guarantees this class exists for.
+            # Config values are small, so the copy is cheap. In-place
+            # mutation of a read value therefore does NOT write back;
+            # use __setitem__/set_nested.
+            if isinstance(value, (dict, list)):
+                return copy.deepcopy(value)
+            return value
 
     def __iter__(self) -> Iterator:
         with self._lock:

--- a/whisper_sync/config_store.py
+++ b/whisper_sync/config_store.py
@@ -1,0 +1,101 @@
+"""Thread-safe configuration store.
+
+The app previously shared one bare cfg dict across the tray menu thread,
+hotkey handlers, the scheduler, executor workers, and the meeting
+pipeline (stability rebuild plan, Phase 5). Writes raced with reads, and
+``config.save()`` iterated the dict while other threads mutated it, which
+can raise "dictionary changed size during iteration" and persist a
+half-updated view.
+
+``ConfigStore`` is a ``Mapping`` over the config data, so every existing
+read site (``cfg["model"]``, ``cfg.get(...)``, ``{**cfg}``, ``dict(cfg)``)
+keeps working unchanged. Writes go through ``__setitem__``/``set_nested``
+under a lock, and ``snapshot()`` returns an atomic deep copy for
+persistence and for crossing process boundaries (a ConfigStore holds a
+lock and must not be pickled; pass ``snapshot()`` to subprocesses).
+
+Nested updates are copy-on-write: ``set_nested("hotkeys", k, v)``
+replaces the inner dict rather than mutating it, so a concurrent reader
+holding the old inner dict sees a complete (if stale) value, never a
+half-written one.
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+
+class ConfigStore(Mapping):
+    """Lock-guarded Mapping over the app configuration."""
+
+    def __init__(self, initial: Mapping):
+        self._lock = threading.RLock()
+        self._data: dict = copy.deepcopy(dict(initial))
+
+    # -- reads (Mapping interface: get/keys/items/values/contains derive) ----
+
+    def __getitem__(self, key):
+        with self._lock:
+            return self._data[key]
+
+    def __iter__(self) -> Iterator:
+        with self._lock:
+            return iter(tuple(self._data))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return f"ConfigStore({self._data!r})"
+
+    # -- writes ---------------------------------------------------------------
+
+    def __setitem__(self, key, value) -> None:
+        with self._lock:
+            self._data[key] = value
+
+    def set_nested(self, key, subkey, value) -> None:
+        """Set ``cfg[key][subkey] = value`` without mutating the inner dict.
+
+        Copy-on-write: readers that already fetched ``cfg[key]`` keep a
+        complete stale dict; the store swaps in a fresh one atomically.
+        """
+        with self._lock:
+            inner = self._data.get(key)
+            if not isinstance(inner, dict):
+                raise TypeError(
+                    f"set_nested requires cfg[{key!r}] to be a dict, "
+                    f"got {type(inner).__name__}"
+                )
+            replacement = dict(inner)
+            replacement[subkey] = value
+            self._data[key] = replacement
+
+    @contextmanager
+    def transaction(self):
+        """Hold the lock across a multi-key read-modify-write.
+
+        Use for compound updates that must be atomic as a group, e.g.
+        swapping two diarization slots. The lock is reentrant, so normal
+        reads and writes on the store work inside the block.
+        """
+        with self._lock:
+            yield self
+
+    # -- snapshots --------------------------------------------------------------
+
+    def snapshot(self) -> dict:
+        """Atomic deep copy, safe to persist, iterate, or pickle."""
+        with self._lock:
+            return copy.deepcopy(self._data)
+
+    def __reduce__(self):
+        raise TypeError(
+            "ConfigStore holds a lock and must not be pickled; "
+            "pass snapshot() across process boundaries instead"
+        )

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -386,7 +386,7 @@ class MeetingJob:
                 dont_show = self.app._show_llm_unavailable()
                 if dont_show:
                     self.app.cfg["suppress_llm_warning"] = True
-                    config.save(self.app.cfg)
+                    config.save(self.app.cfg.snapshot())
             logger.warning("Claude CLI not available, skipping summarize")
             return
 

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -118,7 +118,8 @@ class TranscriptionWorker:
         # (a Mapping holding a lock, which must not cross into the
         # subprocess). Snapshotting here also means a worker restart picks
         # up the latest settings, as the live-dict version did.
-        cfg = self._cfg.snapshot() if hasattr(self._cfg, "snapshot") else dict(self._cfg)
+        snapshot = getattr(self._cfg, "snapshot", None)
+        cfg = snapshot() if callable(snapshot) else dict(self._cfg)
         self._process = ctx.Process(
             target=worker_main,
             args=(self._request_q, self._response_q, cfg, self._preload_model),

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -114,9 +114,14 @@ class TranscriptionWorker:
         # Fresh generation per spawn: the reader binds to THIS generation,
         # so a lingering previous reader cannot touch the new state.
         self._gen = _WorkerGeneration()
+        # Snapshot at the pickle boundary: _cfg may be a live ConfigStore
+        # (a Mapping holding a lock, which must not cross into the
+        # subprocess). Snapshotting here also means a worker restart picks
+        # up the latest settings, as the live-dict version did.
+        cfg = self._cfg.snapshot() if hasattr(self._cfg, "snapshot") else dict(self._cfg)
         self._process = ctx.Process(
             target=worker_main,
-            args=(self._request_q, self._response_q, self._cfg, self._preload_model),
+            args=(self._request_q, self._response_q, cfg, self._preload_model),
             daemon=True,
         )
         self._process.start()
@@ -335,8 +340,14 @@ class TranscriptionWorker:
     def is_ready(self) -> bool:
         return self._gen.ready_ok and self.is_alive()
 
-    def update_config(self, cfg: dict):
-        """Update the config snapshot for the next worker spawn."""
+    def update_config(self, cfg) -> None:
+        """Rebind the config source used at the next worker spawn.
+
+        Accepts the live ConfigStore (preferred - respawns then always
+        see current settings; start() snapshots at the pickle boundary)
+        or a plain dict to pin a frozen config, as the backup
+        transcriber does.
+        """
         self._cfg = cfg
 
     def restart(self) -> None:


### PR DESCRIPTION
## Phase 5b of docs/plans/2026-05-11-stability-rebuild.md

The shared cfg dict is read by the tray menu thread, hotkey handlers, the scheduler, and pipeline threads while settings handlers write to it with no lock. `config.save()` iterates the dict mid-write (RuntimeError: dictionary changed size during iteration, plus a torn persisted view), and nested hotkey writes are visible half-applied.

## Changes

- **`config_store.py` (new)**: `ConfigStore(Mapping)` - every existing read idiom (`cfg[k]`, `cfg.get`, `{**cfg}`, `dict(cfg)`) works unchanged; writes go through a lock; `set_nested()` is copy-on-write so readers never see a half-applied inner dict; `snapshot()` is an atomic deep copy; `transaction()` holds the lock across compound updates. Pickling the store raises TypeError with a pointer to `snapshot()`.
- **`__main__.py`**: `self.cfg = ConfigStore(config.load())`; hotkey write uses `set_nested`; diarize slot swap (cross-key read-check-swap) wrapped in `transaction()`; `config.save(self.cfg.snapshot())`.
- **`meeting_job.py`**: save via snapshot.
- **`worker_manager.py`** (architecture note - protected path): `start()` snapshots the config at the pickle boundary (the store holds a lock and must not cross into the subprocess; snapshotting at spawn also means restarts pick up current settings). `update_config()` now rebinds the live store instead of a frozen dict copy - previously a device switch pinned a stale copy and later settings changes never reached worker respawns. The backup transcriber still pins its frozen per-worker dict intentionally.

## Tests

10 new in `tests/test_config_store.py`: Mapping idioms used across the codebase, copy-on-write nested set, snapshot isolation, pickle refusal + snapshot picklability, multi-key snapshot atomicity under concurrent writers, and iteration-never-races-writers (the json.dump failure mode). Full system suite 126 pass; venv capture/real-data suite 36 pass.