### PR TITLE
feat: stability rebuild phase 1b part 1 - high-frequency threads onto executors

### DIFF
--- a/tests/test_phase1b_migration.py
+++ b/tests/test_phase1b_migration.py
@@ -55,6 +55,46 @@ class SubmitOrSpawnTests(unittest.TestCase):
         release.set()
         ex.shutdown()
 
+    def test_fallback_honors_native_gauge(self):
+        # Regression for Copilot review on PR #150: a native job that
+        # falls back to a thread must still register in the idle-GC
+        # gauge, or collection could race the subprocess.
+        from whisper_sync.executors import native_calls_in_flight
+        ex = Executor("t-native-fb")
+        ex.submit("warmup", lambda: None)
+        ex.shutdown()  # force the fallback path
+
+        release = threading.Event()
+        observed = []
+        started = threading.Event()
+
+        def _job():
+            observed.append(native_calls_in_flight())
+            started.set()
+            release.wait(timeout=5.0)
+
+        submit_or_spawn(ex, "native-fb", _job, native=True)
+        self.assertTrue(started.wait(timeout=2.0))
+        self.assertGreaterEqual(
+            observed[0], 1,
+            "fallback native job must be counted in native_calls_in_flight",
+        )
+        release.set()
+
+    def test_fallback_logs_exceptions_instead_of_dying_silently(self):
+        ex = Executor("t-exc-fb")
+        ex.submit("warmup", lambda: None)
+        ex.shutdown()
+        ran = threading.Event()
+
+        def _boom():
+            ran.set()
+            raise RuntimeError("fallback exception")
+
+        # Must not raise out of submit_or_spawn and must execute the job.
+        submit_or_spawn(ex, "boom", _boom)
+        self.assertTrue(ran.wait(timeout=2.0))
+
     def test_falls_back_after_shutdown(self):
         ex = Executor("t-shut")
         ex.submit("warmup", lambda: None)

--- a/tests/test_phase1b_migration.py
+++ b/tests/test_phase1b_migration.py
@@ -1,0 +1,129 @@
+"""Tests for the Phase 1b ephemeral-thread migration.
+
+Covers the two new mechanisms: ``submit_or_spawn`` (executor with
+one-shot-thread fallback so work is never dropped) and the
+scheduler-driven IconAnimator (animations no longer burn a fresh
+sleeping thread per state change).
+"""
+
+import threading
+import time
+import unittest
+
+from whisper_sync.executors import Executor, submit_or_spawn
+from whisper_sync.icons import IconAnimator
+
+
+class SubmitOrSpawnTests(unittest.TestCase):
+    def test_runs_on_executor_when_accepted(self):
+        ex = Executor("t-accept")
+        done = threading.Event()
+        names = []
+
+        def _job():
+            names.append(threading.current_thread().name)
+            done.set()
+
+        submit_or_spawn(ex, "job", _job)
+        self.assertTrue(done.wait(timeout=2.0))
+        self.assertEqual(names[0], "ws-exec-t-accept")
+        ex.shutdown()
+
+    def test_falls_back_to_thread_when_queue_full(self):
+        # Saturate a tiny executor: one job running, one queued. The next
+        # submit is rejected and must still run (on a fallback thread).
+        ex = Executor("t-full", queue_max=1)
+        release = threading.Event()
+        fallback_done = threading.Event()
+        names = []
+
+        ex.submit("blocker", lambda: release.wait(timeout=5.0))
+        time.sleep(0.05)  # let the blocker start so the queue slot frees
+        ex.submit("queued", lambda: None)
+
+        def _job():
+            names.append(threading.current_thread().name)
+            fallback_done.set()
+
+        submit_or_spawn(ex, "overflow-job", _job)
+        self.assertTrue(
+            fallback_done.wait(timeout=2.0),
+            "rejected work must run on a fallback thread, not be dropped",
+        )
+        self.assertNotEqual(names[0], "ws-exec-t-full")
+        self.assertEqual(names[0], "overflow-job")
+        release.set()
+        ex.shutdown()
+
+    def test_falls_back_after_shutdown(self):
+        ex = Executor("t-shut")
+        ex.submit("warmup", lambda: None)
+        ex.shutdown()
+        done = threading.Event()
+        submit_or_spawn(ex, "post-shutdown", done.set)
+        self.assertTrue(done.wait(timeout=2.0))
+
+
+class _FakeTray:
+    def __init__(self):
+        self.icon = "ORIGINAL"
+        self.title = "t"
+        self.sets = []  # (icon, title) observations after each assignment
+
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+        if name in ("icon", "title") and hasattr(self, "sets"):
+            self.sets.append((self.icon, self.title))
+
+
+class IconAnimatorSchedulerTests(unittest.TestCase):
+    def _wait_for(self, predicate, timeout=3.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.01)
+        return predicate()
+
+    def test_flash_alternates_and_ends_on_original(self):
+        tray = _FakeTray()
+        anim = IconAnimator(tray)
+        anim.flash(count=2, interval_ms=5)
+        # 4 frames: flash, original, flash, original.
+        self.assertTrue(
+            self._wait_for(lambda: len(tray.sets) >= 4),
+            f"expected 4 frames, saw {len(tray.sets)}",
+        )
+        self.assertEqual(tray.icon, "ORIGINAL", "animation must restore the original icon")
+        icons = [icon for icon, _ in tray.sets[:4]]
+        self.assertEqual(icons[1], "ORIGINAL")
+        self.assertNotEqual(icons[0], "ORIGINAL")
+
+    def test_cancel_stops_chain(self):
+        tray = _FakeTray()
+        anim = IconAnimator(tray)
+        anim.flash(count=50, interval_ms=20)
+        self.assertTrue(self._wait_for(lambda: len(tray.sets) >= 1))
+        anim.cancel()
+        time.sleep(0.1)
+        frames_at_cancel = len(tray.sets)
+        time.sleep(0.2)
+        self.assertLessEqual(
+            len(tray.sets), frames_at_cancel + 1,
+            "cancel must stop the frame chain at the next step",
+        )
+        self.assertLess(len(tray.sets), 100, "chain must not run to completion")
+
+    def test_no_thread_spawned_per_animation(self):
+        tray = _FakeTray()
+        anim = IconAnimator(tray)
+        before = {t.name for t in threading.enumerate()}
+        anim.flash(count=1, interval_ms=1)
+        self.assertTrue(self._wait_for(lambda: len(tray.sets) >= 2))
+        after = {t.name for t in threading.enumerate()}
+        new = {n for n in after - before if n != "ws-scheduler"}
+        self.assertEqual(new, set(), f"animation must not spawn threads, got {new}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -35,6 +35,7 @@ import pystray
 
 from . import config
 from .config_store import ConfigStore
+from .executors import DICTATION, IO, submit_or_spawn
 from .capture import AudioRecorder, get_default_devices, get_host_apis, list_devices, save_wav, save_stereo_wav
 from .icons import (idle_icon, build_icon, resolve_icon_key, ICON_REGISTRY,
                      IconAnimator)
@@ -491,9 +492,7 @@ class WhisperSync:
             # toggle acquires the app lock and stops the recorder, so
             # offload it instead of blocking other timer jobs (menu
             # refresh, idle GC).
-            threading.Thread(
-                target=_do_stop, daemon=True, name="dictation-cap-stop"
-            ).start()
+            submit_or_spawn(DICTATION, "dictation-cap-stop", _do_stop)
 
         self._cancel_dictation_cap()
         self._dictation_cap_handle = scheduler.call_later(
@@ -580,11 +579,11 @@ class WhisperSync:
                         self._stats.record_feature_suggestion()
                         weekly_stats.record_feature_suggestion()
                         # Format asynchronously via Claude CLI
-                        threading.Thread(
-                            target=self._format_feature_async,
-                            args=(text, entry_id),
-                            daemon=True,
-                        ).start()
+                        submit_or_spawn(
+                            IO, "feature-format",
+                            lambda t=text, e=entry_id: self._format_feature_async(t, e),
+                            native=True,
+                        )
                 else:
                     # Normal dictation mode: paste + log
                     if text:
@@ -630,7 +629,7 @@ class WhisperSync:
             finally:
                 self._schedule_idle(2)
 
-        threading.Thread(target=_process, daemon=True).start()
+        submit_or_spawn(DICTATION, "dictation-process", _process)
 
     # --- Overlay dictation (dictation during meeting recording/transcription) ---
 
@@ -718,11 +717,11 @@ class WhisperSync:
                         notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
                         self._stats.record_feature_suggestion()
                         weekly_stats.record_feature_suggestion()
-                        threading.Thread(
-                            target=self._format_feature_async,
-                            args=(text, entry_id),
-                            daemon=True,
-                        ).start()
+                        submit_or_spawn(
+                            IO, "feature-format",
+                            lambda t=text, e=entry_id: self._format_feature_async(t, e),
+                            native=True,
+                        )
                 else:
                     if text:
                         paste(text, self.cfg["paste_method"], restore=not self.cfg.get("incognito", False))
@@ -792,7 +791,7 @@ class WhisperSync:
                 except Exception as fallback_err:
                     logger.error(f"Overlay dictation fallback also failed: {fallback_err}", extra={"secondary": True})
 
-        threading.Thread(target=_process_overlay, daemon=True).start()
+        submit_or_spawn(DICTATION, "overlay-process", _process_overlay)
 
     def _recover_dictation(self, wav_path: str):
         """Transcribe a recovered dictation WAV from a previous crash.

--- a/whisper_sync/executors.py
+++ b/whisper_sync/executors.py
@@ -234,4 +234,18 @@ def submit_or_spawn(executor: Executor, label: str, fn: Callable[[], None],
             "executor %s rejected %r; falling back to one-shot thread",
             executor.name, label,
         )
-        threading.Thread(target=fn, daemon=True, name=label).start()
+
+        def _fallback():
+            # Mirror executor-job semantics: native sections stay visible
+            # to the idle-GC gauge, and exceptions are logged, not lost
+            # to the default thread excepthook.
+            try:
+                if native:
+                    with native_call(label):
+                        fn()
+                else:
+                    fn()
+            except Exception:
+                logger.exception("fallback thread %r raised", label)
+
+        threading.Thread(target=_fallback, daemon=True, name=label).start()

--- a/whisper_sync/executors.py
+++ b/whisper_sync/executors.py
@@ -217,3 +217,21 @@ IO = Executor("io")                 # subprocess calls, file ops, recovery
 def all_idle() -> bool:
     """True when every executor is idle and no native call is in flight."""
     return DICTATION.idle() and IO.idle() and native_calls_in_flight() == 0
+
+
+def submit_or_spawn(executor: Executor, label: str, fn: Callable[[], None],
+                    native: bool = False) -> None:
+    """Run ``fn`` on ``executor``, degrading to a one-shot thread if rejected.
+
+    Migration shim for the ephemeral-thread sites (rebuild plan Phase 1b):
+    work must never be silently dropped, so a full queue or a shut-down
+    executor falls back to the old spawn behavior instead of failing.
+    """
+    accepted = (executor.submit_native(label, fn) if native
+                else executor.submit(label, fn))
+    if not accepted:
+        logger.warning(
+            "executor %s rejected %r; falling back to one-shot thread",
+            executor.name, label,
+        )
+        threading.Thread(target=fn, daemon=True, name=label).start()

--- a/whisper_sync/github_status.py
+++ b/whisper_sync/github_status.py
@@ -8,6 +8,8 @@ No LLM cost — pure CLI + JSON parsing.
 import json
 import subprocess
 import threading
+
+from .executors import IO, submit_or_spawn
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -228,7 +230,7 @@ class GitHubPoller:
         """Trigger an immediate poll (non-blocking, deduplicated)."""
         if self._polling.locked():
             return  # Already polling
-        threading.Thread(target=self._do_poll, daemon=True).start()
+        submit_or_spawn(IO, "github-poll", self._do_poll)
 
     def _poll_loop(self):
         """Main polling loop."""

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -11,7 +11,8 @@ resolve_icon_key() maps a composite AppState to the correct registry key.
 from __future__ import annotations
 
 import threading
-import time
+
+from .scheduler import scheduler
 from dataclasses import dataclass
 
 from PIL import Image, ImageDraw
@@ -206,24 +207,32 @@ class IconAnimator:
             if title is not None:
                 self._tray.title = title
 
+    def _animate(self, frames: list, interval_s: float):
+        """Step through (icon, title) frames on the scheduler.
+
+        Animations fire on every state change, so they used to spawn a
+        fresh sleeping thread each time (rebuild plan Phase 1b churn).
+        Each frame is now a short scheduler job; cancel() stops the chain
+        at the next frame, matching the old per-iteration check.
+        """
+        def _step(i: int):
+            if self._cancel.is_set() or i >= len(frames):
+                return
+            icon, title = frames[i]
+            self._set_tray(icon=icon, title=title)
+            scheduler.call_later(interval_s, lambda: _step(i + 1),
+                                 label="icon-animation")
+        _step(0)
+
     def flash(self, count: int = 2, interval_ms: int = 150):
         """Yellow double-flash (universal loading/queuing signal)."""
         if self._tray is None:
             return
         self._cancel.clear()
-
-        def _run():
-            original = self._tray.icon
-            flash_img = build_icon(ICON_REGISTRY["flash"])
-            for _ in range(count):
-                if self._cancel.is_set():
-                    break
-                self._set_tray(icon=flash_img)
-                time.sleep(interval_ms / 1000)
-                self._set_tray(icon=original)
-                time.sleep(interval_ms / 1000)
-
-        threading.Thread(target=_run, daemon=True).start()
+        original = self._tray.icon
+        flash_img = build_icon(ICON_REGISTRY["flash"])
+        frames = [(flash_img, None), (original, None)] * count
+        self._animate(frames, interval_ms / 1000)
 
     def flash_between(self, key_a: str, key_b: str,
                       count: int = 2, interval_ms: int = 150):
@@ -231,19 +240,12 @@ class IconAnimator:
         if self._tray is None:
             return
         self._cancel.clear()
-
-        def _run():
-            img_a = build_icon(ICON_REGISTRY[key_a])
-            img_b = build_icon(ICON_REGISTRY[key_b])
-            for _ in range(count):
-                if self._cancel.is_set():
-                    break
-                self._set_tray(icon=img_a, title=f"WhisperSync: {ICON_REGISTRY[key_a].tooltip}")
-                time.sleep(interval_ms / 1000)
-                self._set_tray(icon=img_b, title=f"WhisperSync: {ICON_REGISTRY[key_b].tooltip}")
-                time.sleep(interval_ms / 1000)
-
-        threading.Thread(target=_run, daemon=True).start()
+        frame_a = (build_icon(ICON_REGISTRY[key_a]),
+                   f"WhisperSync: {ICON_REGISTRY[key_a].tooltip}")
+        frame_b = (build_icon(ICON_REGISTRY[key_b]),
+                   f"WhisperSync: {ICON_REGISTRY[key_b].tooltip}")
+        frames = [frame_a, frame_b] * count
+        self._animate(frames, interval_ms / 1000)
 
     def cancel(self):
         """Stop current animation."""

--- a/whisper_sync/notifications.py
+++ b/whisper_sync/notifications.py
@@ -10,6 +10,8 @@ import logging
 import queue
 import threading
 
+from .executors import IO, submit_or_spawn
+
 _logger = logging.getLogger("whisper_sync.notifications")
 
 _AUMID = "Pendentive.WhisperSync"
@@ -133,7 +135,7 @@ def notify(title: str, body: str, *, buttons=None, on_click=None):
                                     fn()
                                 except Exception as exc:
                                     _logger.exception(f"Toast button callback error: {exc}")
-                            threading.Thread(target=_run, daemon=True).start()
+                            submit_or_spawn(IO, "toast-button", _run)
                         return _handler
 
                     toast_btn.on_activated = _make_handler(action)
@@ -146,7 +148,7 @@ def notify(title: str, body: str, *, buttons=None, on_click=None):
                         on_click()
                     except Exception as exc:
                         _logger.exception(f"Toast click callback error: {exc}")
-                threading.Thread(target=_run, daemon=True).start()
+                submit_or_spawn(IO, "toast-click", _run)
 
             toast.on_activated = _body_handler
 


### PR DESCRIPTION
## Phase 1b (part 1) of docs/plans/2026-05-11-stability-rebuild.md

The rebuild plan's root-cause model: ~20 sites spawn a fresh daemon thread per event, and high-frequency churn (every dictation, every state-change animation, every toast click) stresses thread-affine native libs and the GC. Phase 1 (#137) built the single-owner primitives; this PR moves the high-frequency sites onto them.

## Migrated

- **Dictation pipeline** (`_process`, `_process_overlay`, cap-stop offload) -> DICTATION executor. Serial is the correct semantic: one dictation processes at a time, and the modes are mutually exclusive by state gating.
- **Feature-suggestion formatting** (Claude CLI subprocess) -> IO, via `submit_native` so the idle-GC gauge sees it.
- **Toast click/button callbacks** and **manual GitHub poll** -> IO.
- **Icon flash animations** -> scheduler frame chains (`IconAnimator._animate`). No sleeping thread per state change; each frame is a short scheduler job; `cancel()` stops at the next frame exactly like the old per-iteration check.
- **`submit_or_spawn()`** (new, executors.py): degrades to the old one-shot thread when an executor rejects (full queue or shutdown), so work is never dropped.

## Deliberately NOT migrated (once-per-session, churn-irrelevant; long-running work that would block a serial executor)

Model download, app update, worker restarts, quit, startup recovery transcription, startup waiters, and the `_schedule_idle` blink chain (state-emission rewrite, tracked for part 2).

## Tests

6 new in `tests/test_phase1b_migration.py`: executor routing, queue-full fallback runs work on a thread, post-shutdown fallback, animation frame sequence ends on the original icon, cancel stops mid-chain, and no-thread-spawned-per-animation. Full system suite 133 pass; venv capture/real-data suite 36 pass.