### PR TITLE
feat: stability rebuild phase 1b part 2 - idle blink chain onto scheduler

### DIFF
--- a/tests/test_idle_reset.py
+++ b/tests/test_idle_reset.py
@@ -6,6 +6,7 @@ times when asked, and abort the blink silently if a new recording
 starts mid-chain.
 """
 
+import threading
 import time
 import unittest
 from types import SimpleNamespace
@@ -17,14 +18,16 @@ from whisper_sync.state_manager import IDLE
 
 
 class _FakeState:
-    """Records emits and tracks mode the way StateManager would."""
+    """Records emits (and their thread) and tracks mode like StateManager."""
 
     def __init__(self, mode="done"):
         self.current = SimpleNamespace(mode=mode)
         self.events = []
+        self.emit_threads = []
 
     def emit(self, event_type, mode=None, **_kw):
         self.events.append((event_type, mode))
+        self.emit_threads.append(threading.current_thread())
         self.current.mode = mode
 
 
@@ -101,10 +104,15 @@ class BlinkChainTests(unittest.TestCase):
     def test_caller_does_not_emit_synchronously(self):
         # The first frame goes through the scheduler: pipeline
         # finally-blocks must not re-enter state.emit on their own stack.
+        # Assert on the emitting thread rather than on timing - the
+        # scheduler may legitimately fire before the caller's next line.
         state = _FakeState(mode="done")
         schedule_idle_reset(state, 0.02, blink=True)
-        self.assertEqual(state.events, [], "no emit on the caller's stack")
         self.assertTrue(_wait_for(lambda: state.events))
+        self.assertNotIn(
+            threading.current_thread(), state.emit_threads,
+            "emits must never run on the caller's stack",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_idle_reset.py
+++ b/tests/test_idle_reset.py
@@ -1,0 +1,111 @@
+"""Tests for whisper_sync.idle_reset - scheduler-based return-to-idle.
+
+The behavioral contract carried over from the thread version: never
+overwrite a mode the user set during the delay, blink done/None three
+times when asked, and abort the blink silently if a new recording
+starts mid-chain.
+"""
+
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from whisper_sync import idle_reset
+from whisper_sync.idle_reset import schedule_idle_reset
+from whisper_sync.state_manager import IDLE
+
+
+class _FakeState:
+    """Records emits and tracks mode the way StateManager would."""
+
+    def __init__(self, mode="done"):
+        self.current = SimpleNamespace(mode=mode)
+        self.events = []
+
+    def emit(self, event_type, mode=None, **_kw):
+        self.events.append((event_type, mode))
+        self.current.mode = mode
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class PlainDelayTests(unittest.TestCase):
+    def test_resets_to_idle_after_delay(self):
+        state = _FakeState(mode="done")
+        schedule_idle_reset(state, 0.02)
+        self.assertTrue(_wait_for(lambda: state.events))
+        self.assertEqual(state.events, [(IDLE, None)])
+
+    def test_does_not_overwrite_new_recording(self):
+        state = _FakeState(mode="done")
+        schedule_idle_reset(state, 0.05)
+        state.current.mode = "dictation"  # user started something new
+        time.sleep(0.15)
+        self.assertEqual(state.events, [], "non-terminal mode must not be reset")
+
+    def test_blink_true_without_done_mode_degrades_to_plain_delay(self):
+        state = _FakeState(mode="error")
+        schedule_idle_reset(state, 0.02, blink=True)
+        self.assertTrue(_wait_for(lambda: state.events))
+        self.assertEqual(state.events, [(IDLE, None)])
+
+
+class BlinkChainTests(unittest.TestCase):
+    def setUp(self):
+        # Real blink timing is 2.1s; compress it for tests.
+        patches = [
+            mock.patch.object(idle_reset, "BLINK_ON_S", 0.01),
+            mock.patch.object(idle_reset, "BLINK_OFF_S", 0.01),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_blink_emits_three_cycles_then_resets(self):
+        state = _FakeState(mode="done")
+        schedule_idle_reset(state, 0.02, blink=True)
+        # 6 blink frames (done/None x3) + the final reset.
+        self.assertTrue(
+            _wait_for(lambda: len(state.events) >= 7),
+            f"expected 7 emits, saw {state.events}",
+        )
+        modes = [m for _, m in state.events]
+        self.assertEqual(modes, ["done", None, "done", None, "done", None, None])
+        self.assertTrue(all(e == IDLE for e, _ in state.events))
+
+    def test_blink_aborts_when_user_starts_new_recording(self):
+        state = _FakeState(mode="done")
+        schedule_idle_reset(state, 0.02, blink=True)
+        self.assertTrue(_wait_for(lambda: len(state.events) >= 1))
+        state.current.mode = "meeting"  # mid-chain interruption
+        events_at_abort = len(state.events)
+        time.sleep(0.3)
+        self.assertLessEqual(
+            len(state.events), events_at_abort + 1,
+            "blink chain must stop once the mode leaves done/None",
+        )
+        self.assertLess(len(state.events), 7, "chain must not run to completion")
+        self.assertNotEqual(
+            state.current.mode, None,
+            "aborted chain must not fire the final reset",
+        )
+
+    def test_caller_does_not_emit_synchronously(self):
+        # The first frame goes through the scheduler: pipeline
+        # finally-blocks must not re-enter state.emit on their own stack.
+        state = _FakeState(mode="done")
+        schedule_idle_reset(state, 0.02, blink=True)
+        self.assertEqual(state.events, [], "no emit on the caller's stack")
+        self.assertTrue(_wait_for(lambda: state.events))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -36,6 +36,7 @@ import pystray
 from . import config
 from .config_store import ConfigStore
 from .executors import DICTATION, IO, submit_or_spawn
+from .idle_reset import schedule_idle_reset
 from .capture import AudioRecorder, get_default_devices, get_host_apis, list_devices, save_wav, save_stereo_wav
 from .icons import (idle_icon, build_icon, resolve_icon_key, ICON_REGISTRY,
                      IconAnimator)
@@ -277,32 +278,10 @@ class WhisperSync:
     def _schedule_idle(self, seconds: float, blink: bool = False):
         """Return to idle after a delay. If blink=True, blink done 3 times first.
 
-        Only resets mode if it's still in a terminal state (done/error/None).
-        If the user started a new recording during the delay, the mode will be
-        'dictation' or 'meeting' and we must NOT overwrite it.
+        Delegates to idle_reset.schedule_idle_reset (scheduler jobs, no
+        per-event thread). Mode is only reset if still terminal.
         """
-        import time
-
-        def _reset():
-            if blink and self.state.current.mode == "done":
-                for _ in range(3):
-                    if self.state.current.mode not in ("done", None):
-                        return  # User started something new - abort blink
-                    self.state.emit(IDLE, mode="done")
-                    time.sleep(0.4)
-                    if self.state.current.mode not in ("done", None):
-                        return
-                    self.state.emit(IDLE, mode=None)
-                    time.sleep(0.3)
-            else:
-                time.sleep(seconds)
-            # Only reset to idle if mode is still in a terminal state
-            if self.state.current.mode in ("done", "error", None):
-                self.state.emit(IDLE, mode=None)
-            else:
-                logger.debug(f"_schedule_idle: skipped reset - mode is '{self.state.current.mode}' (not terminal)")
-
-        threading.Thread(target=_reset, daemon=True).start()
+        schedule_idle_reset(self.state, seconds, blink)
 
     @staticmethod
     def _safe_unlink(path: Path, retries: int = 2, delay: float = 0.5):

--- a/whisper_sync/idle_reset.py
+++ b/whisper_sync/idle_reset.py
@@ -24,11 +24,14 @@ BLINK_OFF_S = 0.3
 
 
 def schedule_idle_reset(state, seconds: float, blink: bool = False) -> None:
-    """Return ``state`` to idle after ``seconds``; optionally blink first.
+    """Return ``state`` to idle, plain-delayed or via the done-blink.
 
-    ``blink=True`` only blinks when the mode is currently ``done``
-    (matching the original behavior); otherwise it degrades to the
-    plain delayed reset.
+    With ``blink=False``, resets after ``seconds``. With ``blink=True``
+    and the mode currently ``done``, runs the fixed blink choreography
+    instead - ``seconds`` is ignored and the total time is the
+    BLINK_CYCLES * (BLINK_ON_S + BLINK_OFF_S) chain (matching the
+    historical thread version). ``blink=True`` in any other mode
+    degrades to the plain ``seconds`` delay.
     """
 
     def _finish():

--- a/whisper_sync/idle_reset.py
+++ b/whisper_sync/idle_reset.py
@@ -1,0 +1,64 @@
+"""Scheduler-based return-to-idle with optional done-blink.
+
+Retires the last per-event ephemeral thread from the stability rebuild
+plan (Phase 1b part 2): ``_schedule_idle`` spawned a fresh sleeping
+thread after every completed dictation and meeting just to wait out a
+delay (and optionally blink the done icon) before resetting state. The
+delay and each blink frame are now short scheduler jobs.
+
+Semantics preserved exactly from the thread version: the mode is only
+reset if still terminal (done/error/None) - a recording the user
+started during the delay must never be overwritten - and the blink
+chain aborts silently as soon as the mode leaves done/None.
+"""
+
+from __future__ import annotations
+
+from .logger import logger
+from .scheduler import scheduler
+from .state_manager import IDLE
+
+BLINK_CYCLES = 3
+BLINK_ON_S = 0.4
+BLINK_OFF_S = 0.3
+
+
+def schedule_idle_reset(state, seconds: float, blink: bool = False) -> None:
+    """Return ``state`` to idle after ``seconds``; optionally blink first.
+
+    ``blink=True`` only blinks when the mode is currently ``done``
+    (matching the original behavior); otherwise it degrades to the
+    plain delayed reset.
+    """
+
+    def _finish():
+        if state.current.mode in ("done", "error", None):
+            state.emit(IDLE, mode=None)
+        else:
+            logger.debug(
+                f"idle reset skipped - mode is '{state.current.mode}' (not terminal)"
+            )
+
+    if not (blink and state.current.mode == "done"):
+        scheduler.call_later(seconds, _finish, label="idle-reset")
+        return
+
+    total_steps = BLINK_CYCLES * 2
+
+    def _step(i: int):
+        if i >= total_steps:
+            _finish()
+            return
+        if state.current.mode not in ("done", None):
+            return  # user started something new - abort the blink
+        if i % 2 == 0:
+            state.emit(IDLE, mode="done")
+            delay = BLINK_ON_S
+        else:
+            state.emit(IDLE, mode=None)
+            delay = BLINK_OFF_S
+        scheduler.call_later(delay, lambda: _step(i + 1), label="idle-blink")
+
+    # First frame goes through the scheduler too, so the caller (often a
+    # pipeline finally-block) never emits synchronously.
+    scheduler.call_later(0.0, lambda: _step(0), label="idle-blink")


### PR DESCRIPTION
## Phase 1b part 2 (final item) of docs/plans/2026-05-11-stability-rebuild.md

`_schedule_idle` was the last per-event ephemeral thread: after every completed dictation and meeting it spawned a thread that slept through a delay (and optionally a 3-cycle done-icon blink) before resetting state to idle.

## Changes

- **`idle_reset.py` (new)**: `schedule_idle_reset(state, seconds, blink)` - the delay and each blink frame are short scheduler jobs (same pattern as the IconAnimator frames in #150). Extracted to a module so the logic is unit-testable without the heavy `__main__` imports.
- **`__main__.py`**: `_schedule_idle` delegates.

Semantics preserved exactly: terminal-mode guard (a recording started during the delay is never overwritten), silent blink abort when the mode leaves done/None with no final reset, blink-without-done degrades to the plain delay. One deliberate refinement: the first blink frame also goes through the scheduler, so pipeline finally-blocks never re-enter `state.emit` on their own stack.

## Tests

6 new in `tests/test_idle_reset.py` (blink timing compressed via patched constants): plain delay reset, non-terminal skip, blink degrade, full done/None x3 + reset sequence, mid-chain abort without final reset, no synchronous emit on the caller's stack. Full system suite 141 pass; venv suite 36 pass.

This completes Phase 1b - every high-frequency and per-event spawn site is now on the Phase 1 primitives. Remaining dedicated threads (download, update, restart, quit, recovery, long-lived loops) are by-design exclusions documented in #150.