### PR TITLE
docs: test-suite run commands and production validation checklist

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -204,3 +204,34 @@ The automatic VRAM-tier sizing:
 ```
 
 See the CUDA Version table in README.md for your GPU family's correct index URL.
+
+
+## Running the Test Suites
+
+Two suites, split by dependency weight:
+
+**System-python suite** (no numpy/sounddevice; protocol, state, scheduler,
+executors, config store, and all other pure-python modules; 141 tests as of
+2026-06-11):
+
+```powershell
+python -m pytest tests/ --ignore=tests/test_capture_recorder.py --ignore=tests/test_capture_open_input.py --ignore=tests/test_capture_speaker_streaming.py --ignore=tests/test_capture_mic_downmix.py --ignore=tests/test_real_meeting_data.py --ignore=tests/test_e2e_real_transcription.py -q
+```
+
+**Venv suite** (capture + real-data; needs the whisper-env with numpy and
+scipy; 36 tests):
+
+```powershell
+.\whisper-env\Scripts\python.exe -m unittest tests.test_real_meeting_data tests.test_capture_mic_downmix tests.test_capture_open_input tests.test_capture_recorder tests.test_capture_speaker_streaming
+```
+
+**Real-data harness**: `tests/test_real_meeting_data.py` discovers real
+meeting folders via the `WS_MEETINGS_DIR` env var (or a known sibling path)
+and proves `flatten()` reproduces the shipped `transcript-readable.txt`
+byte-for-byte. Tests skip cleanly when no meetings are present, so CI and
+fresh clones pass without private data. Never commit meeting data to this
+repo.
+
+**Opt-in end-to-end**: `WS_E2E=1` runs the production worker subprocess on
+the smallest discovered real recording (about a minute of runtime). Run it
+after any change to the worker protocol or transcription pipeline.

--- a/docs/development.md
+++ b/docs/development.md
@@ -212,7 +212,10 @@ Two suites, split by dependency weight:
 
 **System-python suite** (no numpy/sounddevice; protocol, state, scheduler,
 executors, config store, and all other pure-python modules; 141 tests as of
-2026-06-11):
+2026-06-11). Requires pytest on the system python (one-time
+`python -m pip install pytest`); the tests themselves are plain
+unittest.TestCase, pytest is only the runner that makes the ignore list
+manageable:
 
 ```powershell
 python -m pytest tests/ --ignore=tests/test_capture_recorder.py --ignore=tests/test_capture_open_input.py --ignore=tests/test_capture_speaker_streaming.py --ignore=tests/test_capture_mic_downmix.py --ignore=tests/test_real_meeting_data.py --ignore=tests/test_e2e_real_transcription.py -q
@@ -232,6 +235,13 @@ byte-for-byte. Tests skip cleanly when no meetings are present, so CI and
 fresh clones pass without private data. Never commit meeting data to this
 repo.
 
-**Opt-in end-to-end**: `WS_E2E=1` runs the production worker subprocess on
-the smallest discovered real recording (about a minute of runtime). Run it
-after any change to the worker protocol or transcription pipeline.
+**Opt-in end-to-end**: setting the `WS_E2E` env var to `1` runs the
+production worker subprocess on the smallest discovered real recording
+(about a minute of runtime). Run it after any change to the worker protocol
+or transcription pipeline:
+
+```powershell
+$env:WS_E2E = "1"; .\whisper-env\Scripts\python.exe -m unittest tests.test_e2e_real_transcription
+```
+
+(cmd.exe: `set WS_E2E=1` first; bash: `WS_E2E=1 python -m unittest ...`.)

--- a/docs/plans/2026-05-11-stability-rebuild.md
+++ b/docs/plans/2026-05-11-stability-rebuild.md
@@ -394,3 +394,21 @@ Repo convention: unittest + fake modules in `sys.modules` (see
   should start from production evidence: the heartbeat `rss=NMB`
   time series and
   crash-free run duration on the updated build.
+
+- **2026-06-11 (production validation checklist)**: the rebuild is
+  code-complete; what remains is evidence from the updated running app
+  (tray > Settings > Update > Labs/dev > restart; the long-running
+  instance was on stale build e1982a7 throughout the rebuild). Signals
+  to check after real use:
+  1. Clean exits: no tkinter `__del__` access violations or 0x80000003
+     fatals in the logs (the dominant pre-rebuild crash family).
+  2. Real word counts and speaker counts in meeting completion toasts
+     (the stage_finalize stats bug fixed in #141).
+  3. Flat `rss=NMB` heartbeat series across a 1h+ meeting (speaker disk
+     streaming, #139) and across many dictations (idle GC, #137).
+  4. Laptop 4-mic array dictation works (channel ladder + downmix,
+     #143); dictation auto-stops with a toast at dictation_max_minutes.
+  5. Worker kill/respawn recovery still works (kill the worker process;
+     the app should detect and respawn per the Phase 6 protocol).
+  Report findings here in the progress log; future stability work
+  starts from this evidence, not from new refactors.


### PR DESCRIPTION
Moves durable session context into the repo where it belongs: docs/development.md gains a Running the Test Suites section (system suite, venv suite, real-data harness rules, WS_E2E opt-in), and the stability plan progress log gains the production validation checklist for the updated build.