### PR TITLE
feat: in-app single-instance lock and orphan worker reaping

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -150,9 +150,12 @@ Override with `"batch_size": 8` in `config.json`. Set `"batch_size": "auto"` to 
 
 Meeting recordings use **disk-only** audio capture for the mic channel. The mic callback streams audio to a WAV file on disk in real-time and does NOT accumulate audio in RAM (controlled by the `disk_only` flag in `start_streaming()`). The speaker loopback channel, however, still accumulates audio in RAM via `_speaker_data` for resampling and stereo merging at stop time. Dictation mode uses RAM for both channels (recordings are short).
 
-### Orphan Worker Cleanup
+### Orphan Worker Cleanup and Single Instance
 
-On Windows, `multiprocessing.spawn` workers can survive after the parent process dies. The `start.ps1` script kills orphans on every launch using parent PID matching and dead-parent detection.
+On Windows, `multiprocessing.spawn` workers can survive after the parent process dies. Two layers handle this:
+
+- **In-app (primary)**: `instance_guard.py` holds a named Win32 mutex for the process lifetime, so a second launch exits immediately with a toast instead of doubling VRAM load. Every spawned worker pid is recorded in `<data_dir>/worker-pids.json`; on startup (after winning the mutex) the app terminates any still-alive registered pid from a dead parent, with a python-image check guarding against PID reuse. Toggle: `gpu_guard_single_instance` (default `true`).
+- **Launcher (belt and braces)**: `start.ps1` also kills orphans on every launch using parent PID matching and dead-parent detection, covering workers older than the pid registry.
 
 ---
 

--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -1,0 +1,47 @@
+# Hardening Round - 2026-07-03
+
+> Status: ACTIVE
+> Intake: docs/specs/2026-07-03-owner-directive-verbatim.md (verbatim owner
+> directive) and the four companion specs dated 2026-07-03.
+> This doc is the state surface for the round: the table below is updated
+> as each item merges, and the progress log records results and decisions.
+> Any session (or person) can resume the round from this file alone.
+
+## Item status
+
+| # | Item | Spec | Status |
+|---|------|------|--------|
+| 2 | In-app single-instance lock + orphan worker reaping | gpu-guard-spec B4 | IN PIPELINE |
+| 9 | CI runs the system test suite on every PR | testing-and-docs-cleanup T1 | PENDING |
+| 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | PENDING |
+| 3 | Sleep/resume power event handling | hardware-resilience H1 | PENDING |
+| 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | PENDING |
+| 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | PENDING |
+| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | PENDING |
+| 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
+| 5 | Overlay dictation disk-first | hardware-resilience H3 | PENDING |
+| 7 | State machine transition table | architecture-validation A1 | PENDING |
+| 6 | __main__.py decomposition by workflow | architecture-validation A2 | PENDING |
+
+Execution order: 2, 9, 1, 3, 11+10, 8, 4, 5, 7, 6. Owner approved the
+full list 2026-07-03 with standing authorization to proceed item to item
+without further questions absent a large unforeseen blocker.
+
+Design constraint from the owner (applies to item 7): this app stays a
+very light, load-and-unload Python tray app (the API-first successor is a
+separate heavier application). The state machine must be reliable and
+easy to troubleshoot - a flat data table of allowed transitions checked
+in one place, not a branching if/then system and not a framework.
+
+## Progress log
+
+- **2026-07-03 (round start)**: Intake PR #155 merged (verbatim
+  directive + 4 specs). Round opened with item 2.
+
+- **2026-07-03 (item 2)**: instance_guard.py: named-mutex single
+  instance (fail-open if the mutex API itself fails), crash-survivable
+  worker pid registry wired into TranscriptionWorker start/stop, startup
+  reaping with PID-reuse guard (only python images are ever terminated)
+  and unkillable-pid retry. Toggle gpu_guard_single_instance (default
+  true). 10 tests (real named mutex on Windows; all process seams faked
+  for reap logic).

--- a/tests/test_instance_guard.py
+++ b/tests/test_instance_guard.py
@@ -1,0 +1,125 @@
+"""Tests for whisper_sync.instance_guard - single-instance lock + orphan reaping.
+
+The mutex tests use a real named Win32 mutex (unique per test run) on
+Windows and are skipped elsewhere. The reaping tests replace the
+process-inspection seams so no real process is ever touched.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+from unittest import mock
+
+from whisper_sync import instance_guard
+from whisper_sync.instance_guard import (
+    acquire_single_instance, register_worker_pid, unregister_worker_pid,
+    reap_orphans,
+)
+
+
+class MutexTests(unittest.TestCase):
+    @unittest.skipUnless(os.name == "nt", "named mutex is Windows-only")
+    def test_second_acquire_of_same_name_fails(self):
+        name = f"Global\\WhisperSyncTest-{uuid.uuid4()}"
+        self.assertTrue(acquire_single_instance(name), "first acquire must win")
+        self.assertFalse(acquire_single_instance(name), "second acquire must lose")
+
+    def test_non_windows_degrades_to_acquired(self):
+        with mock.patch.object(os, "name", "posix"):
+            self.assertTrue(acquire_single_instance("irrelevant"))
+
+
+class _RegistryHarness(unittest.TestCase):
+    """Points the registry at a temp file for each test."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.reg_path = Path(self._tmp.name) / "worker-pids.json"
+        patcher = mock.patch.object(
+            instance_guard, "_registry_path", lambda: self.reg_path
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _registry(self):
+        if not self.reg_path.exists():
+            return {}
+        return json.loads(self.reg_path.read_text())
+
+
+class RegistryTests(_RegistryHarness):
+    def test_register_and_unregister_roundtrip(self):
+        register_worker_pid(12345, kind="transcription")
+        self.assertEqual(self._registry()["12345"]["kind"], "transcription")
+        self.assertEqual(self._registry()["12345"]["parent"], os.getpid())
+        unregister_worker_pid(12345)
+        self.assertNotIn("12345", self._registry())
+
+    def test_corrupt_registry_treated_as_empty(self):
+        self.reg_path.write_text("{not json")
+        register_worker_pid(1, kind="x")  # must not raise
+        self.assertIn("1", self._registry())
+
+
+class ReapTests(_RegistryHarness):
+    def _seed(self, pid, parent):
+        register_worker_pid(pid, kind="transcription")
+        data = self._registry()
+        data[str(pid)]["parent"] = parent
+        self.reg_path.write_text(json.dumps(data))
+
+    def test_reaps_alive_python_orphan_from_dead_parent(self):
+        self._seed(111, parent=999999)  # not our pid
+        killed = []
+        with mock.patch.object(instance_guard, "_pid_alive", lambda p: True), \
+             mock.patch.object(instance_guard, "_is_python_process", lambda p: True), \
+             mock.patch.object(instance_guard, "_terminate",
+                               lambda p: killed.append(p) or True):
+            reaped = reap_orphans()
+        self.assertEqual(reaped, [111])
+        self.assertEqual(killed, [111])
+        self.assertNotIn("111", self._registry(), "reaped entry must be removed")
+
+    def test_skips_own_children(self):
+        self._seed(222, parent=os.getpid())
+        with mock.patch.object(instance_guard, "_terminate",
+                               lambda p: self.fail("must not touch own child")):
+            reaped = reap_orphans()
+        self.assertEqual(reaped, [])
+        self.assertIn("222", self._registry(), "own child entry must survive")
+
+    def test_drops_dead_pid_without_terminating(self):
+        self._seed(333, parent=999999)
+        with mock.patch.object(instance_guard, "_pid_alive", lambda p: False), \
+             mock.patch.object(instance_guard, "_terminate",
+                               lambda p: self.fail("dead pid must not be terminated")):
+            reaped = reap_orphans()
+        self.assertEqual(reaped, [])
+        self.assertNotIn("333", self._registry(), "stale entry must be dropped")
+
+    def test_pid_reuse_guard_refuses_non_python_process(self):
+        self._seed(444, parent=999999)
+        with mock.patch.object(instance_guard, "_pid_alive", lambda p: True), \
+             mock.patch.object(instance_guard, "_is_python_process", lambda p: False), \
+             mock.patch.object(instance_guard, "_terminate",
+                               lambda p: self.fail("reused pid must not be terminated")):
+            reaped = reap_orphans()
+        self.assertEqual(reaped, [])
+        self.assertNotIn("444", self._registry(), "reused-pid entry must be dropped")
+
+    def test_unkillable_pid_stays_registered_for_next_run(self):
+        self._seed(555, parent=999999)
+        with mock.patch.object(instance_guard, "_pid_alive", lambda p: True), \
+             mock.patch.object(instance_guard, "_is_python_process", lambda p: True), \
+             mock.patch.object(instance_guard, "_terminate", lambda p: False):
+            reaped = reap_orphans()
+        self.assertEqual(reaped, [])
+        self.assertIn("555", self._registry(), "unkillable pid must be retried next start")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3818,6 +3818,22 @@ def main():
     gc.disable()
     logger.info("Cycle GC disabled; explicit gc.collect() at safe checkpoints")
 
+    # Single-instance guard + orphan reaping (gpu-guard spec B4). Runs
+    # before any model/worker spawn so a duplicate launch never doubles
+    # VRAM load and a previous crash's worker never survives us starting.
+    from .instance_guard import acquire_single_instance, reap_orphans
+    if config.load().get("gpu_guard_single_instance", True):
+        if not acquire_single_instance():
+            logger.info("Another WhisperSync instance is already running; exiting")
+            try:
+                notify("WhisperSync already running", "This launch will exit; the existing tray instance keeps running.")
+            except Exception:
+                pass
+            return
+        orphans = reap_orphans()
+        if orphans:
+            logger.info(f"Reaped {len(orphans)} orphan worker process(es): {orphans}")
+
     heartbeat = Heartbeat(logger, interval=60.0)
     try:
         lifecycle.log_startup_banner(logger)

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -29,5 +29,6 @@
   "diarize_primary": "balanced_mix",
   "diarize_fallback": "per_channel",
   "diarize_last_resort": "raw_audio",
-  "dictation_max_minutes": 30
+  "dictation_max_minutes": 30,
+  "gpu_guard_single_instance": true
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -29,6 +29,7 @@ _VALID_KEYS = {
     "toast_events",
     "diarize_primary", "diarize_fallback", "diarize_last_resort",
     "dictation_max_minutes",
+    "gpu_guard_single_instance",
 }
 
 

--- a/whisper_sync/instance_guard.py
+++ b/whisper_sync/instance_guard.py
@@ -16,8 +16,9 @@ worker subprocess holding a CUDA context until the NEXT launcher run
   and not owned by the current process tree.
 
 Non-Windows platforms: the mutex degrades to always-acquired and
-reaping still works (pid registry is portable; termination uses
-os.kill). The app is Windows-first; this keeps imports safe elsewhere.
+orphan reaping no-ops (no safe positive PID-reuse check exists there,
+and the spawn-orphan problem is Windows-specific). The pid registry
+itself is portable. This keeps imports safe everywhere.
 """
 
 from __future__ import annotations
@@ -34,6 +35,40 @@ _mutex_handle = None  # held for process lifetime; never closed deliberately
 _registry_lock = threading.Lock()
 
 ERROR_ALREADY_EXISTS = 183
+_kernel32 = None
+
+
+def _win32():
+    """kernel32 with every prototype declared once.
+
+    Explicit argtypes/restype on all calls: without them, 64-bit HANDLEs
+    are truncated to 32-bit ints by ctypes' default int marshaling (the
+    exact bug class fixed for GetProcessMemoryInfo in PR #141).
+    """
+    global _kernel32
+    if _kernel32 is not None:
+        return _kernel32
+    import ctypes
+    from ctypes import wintypes
+
+    k = ctypes.WinDLL("kernel32", use_last_error=True)
+    k.CreateMutexW.restype = wintypes.HANDLE
+    k.CreateMutexW.argtypes = (wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR)
+    k.OpenProcess.restype = wintypes.HANDLE
+    k.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    k.CloseHandle.restype = wintypes.BOOL
+    k.CloseHandle.argtypes = (wintypes.HANDLE,)
+    k.QueryFullProcessImageNameW.restype = wintypes.BOOL
+    k.QueryFullProcessImageNameW.argtypes = (
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD),
+    )
+    k.GetExitCodeProcess.restype = wintypes.BOOL
+    k.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    k.TerminateProcess.restype = wintypes.BOOL
+    k.TerminateProcess.argtypes = (wintypes.HANDLE, wintypes.UINT)
+    _kernel32 = k
+    return k
 
 
 def acquire_single_instance(name: str = _MUTEX_NAME) -> bool:
@@ -46,12 +81,8 @@ def acquire_single_instance(name: str = _MUTEX_NAME) -> bool:
     if os.name != "nt":
         return True
     import ctypes
-    from ctypes import wintypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    kernel32.CreateMutexW.restype = wintypes.HANDLE
-    kernel32.CreateMutexW.argtypes = (wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR)
-
+    kernel32 = _win32()
     handle = kernel32.CreateMutexW(None, False, name)
     if not handle:
         # Could not even create the mutex (unexpected): fail open so a
@@ -110,15 +141,16 @@ def unregister_worker_pid(pid: int) -> None:
 
 
 def _is_python_process(pid: int) -> bool:
-    """PID-reuse guard: only ever terminate a process whose image is python."""
-    if os.name != "nt":
-        return True  # rely on the registry alone off-Windows
+    """PID-reuse guard: only ever terminate a process whose image is python.
+
+    Windows-only (reap_orphans no-ops elsewhere), so a positive image
+    check is always available; there is no trust-the-registry fallback.
+    """
     import ctypes
     from ctypes import wintypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32 = _win32()
     PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-    kernel32.OpenProcess.restype = wintypes.HANDLE
     handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
         return False
@@ -135,18 +167,11 @@ def _is_python_process(pid: int) -> bool:
 
 
 def _pid_alive(pid: int) -> bool:
-    if os.name != "nt":
-        try:
-            os.kill(pid, 0)
-            return True
-        except OSError:
-            return False
     import ctypes
     from ctypes import wintypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32 = _win32()
     PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-    kernel32.OpenProcess.restype = wintypes.HANDLE
     handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
         return False
@@ -161,19 +186,10 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _terminate(pid: int) -> bool:
-    if os.name != "nt":
-        try:
-            import signal
-            os.kill(pid, signal.SIGKILL)
-            return True
-        except OSError:
-            return False
     import ctypes
-    from ctypes import wintypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32 = _win32()
     PROCESS_TERMINATE = 0x0001
-    kernel32.OpenProcess.restype = wintypes.HANDLE
     handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
     if not handle:
         return False
@@ -193,6 +209,12 @@ def reap_orphans() -> list:
     python (PID reuse). Returns the list of pids terminated.
     """
     reaped = []
+    if os.name != "nt":
+        # Reaping is Windows-only: the spawn-orphan problem it solves is
+        # Windows-specific, and without QueryFullProcessImageName there
+        # is no safe positive PID-reuse check - never guess-kill.
+        logger.debug("instance guard: orphan reaping is Windows-only; skipping")
+        return reaped
     with _registry_lock:
         path = _registry_path()
         data = _load_registry(path)

--- a/whisper_sync/instance_guard.py
+++ b/whisper_sync/instance_guard.py
@@ -1,0 +1,223 @@
+"""Single-instance lock and orphan worker reaping.
+
+Two protections that previously lived only in start.ps1, meaning any
+launch path that bypassed the launcher (updater restart, direct
+shortcut, python -m) could run a second instance - doubling VRAM and
+CPU load with a second CUDA worker - and a crashed parent left its
+worker subprocess holding a CUDA context until the NEXT launcher run
+(2026-07-03 gpu-guard spec, B4).
+
+- ``acquire_single_instance()``: a named Win32 mutex held for the
+  process lifetime. Second acquisition anywhere on the machine fails.
+- Worker PID registry: TranscriptionWorker registers each spawned
+  worker pid in ``worker-pids.json`` in the data dir and unregisters on
+  clean stop. ``reap_orphans()`` at startup terminates any registered
+  pid that is still alive, still a python process (PID-reuse guard),
+  and not owned by the current process tree.
+
+Non-Windows platforms: the mutex degrades to always-acquired and
+reaping still works (pid registry is portable; termination uses
+os.kill). The app is Windows-first; this keeps imports safe elsewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+
+from .logger import logger
+
+_MUTEX_NAME = "Global\\WhisperSyncV1Instance"
+_mutex_handle = None  # held for process lifetime; never closed deliberately
+_registry_lock = threading.Lock()
+
+ERROR_ALREADY_EXISTS = 183
+
+
+def acquire_single_instance(name: str = _MUTEX_NAME) -> bool:
+    """Try to become the single running instance. True if we are it.
+
+    Holds a named Win32 mutex for the life of the process. Returns True
+    on non-Windows platforms (no-op degrade).
+    """
+    global _mutex_handle
+    if os.name != "nt":
+        return True
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateMutexW.restype = wintypes.HANDLE
+    kernel32.CreateMutexW.argtypes = (wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR)
+
+    handle = kernel32.CreateMutexW(None, False, name)
+    if not handle:
+        # Could not even create the mutex (unexpected): fail open so a
+        # guard malfunction never blocks the app itself.
+        logger.warning(f"instance guard: CreateMutexW failed (err={ctypes.get_last_error()}); proceeding")
+        return True
+    if ctypes.get_last_error() == ERROR_ALREADY_EXISTS:
+        kernel32.CloseHandle(handle)
+        return False
+    _mutex_handle = handle
+    return True
+
+
+# -- worker pid registry ------------------------------------------------------
+
+
+def _registry_path() -> Path:
+    from .paths import get_data_dir
+    return get_data_dir() / "worker-pids.json"
+
+
+def _load_registry(path: Path) -> dict:
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_registry(path: Path, data: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+    except OSError as exc:
+        logger.warning(f"instance guard: could not write pid registry: {exc}")
+
+
+def register_worker_pid(pid: int, kind: str = "worker") -> None:
+    """Record a spawned worker subprocess pid (crash-survivable)."""
+    with _registry_lock:
+        path = _registry_path()
+        data = _load_registry(path)
+        data[str(pid)] = {"kind": kind, "parent": os.getpid()}
+        _save_registry(path, data)
+
+
+def unregister_worker_pid(pid: int) -> None:
+    """Remove a pid after a clean worker stop."""
+    with _registry_lock:
+        path = _registry_path()
+        data = _load_registry(path)
+        if data.pop(str(pid), None) is not None:
+            _save_registry(path, data)
+
+
+def _is_python_process(pid: int) -> bool:
+    """PID-reuse guard: only ever terminate a process whose image is python."""
+    if os.name != "nt":
+        return True  # rely on the registry alone off-Windows
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return False
+    try:
+        buf = ctypes.create_unicode_buffer(1024)
+        size = wintypes.DWORD(len(buf))
+        ok = kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size))
+        if not ok:
+            return False
+        name = Path(buf.value).name.lower()
+        return name in ("python.exe", "pythonw.exe")
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _pid_alive(pid: int) -> bool:
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+            return True
+        except OSError:
+            return False
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return False
+    try:
+        STILL_ACTIVE = 259
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _terminate(pid: int) -> bool:
+    if os.name != "nt":
+        try:
+            import signal
+            os.kill(pid, signal.SIGKILL)
+            return True
+        except OSError:
+            return False
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    PROCESS_TERMINATE = 0x0001
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+    if not handle:
+        return False
+    try:
+        return bool(kernel32.TerminateProcess(handle, 1))
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def reap_orphans() -> list:
+    """Terminate registered worker pids left behind by a dead parent.
+
+    Called once at startup, after acquire_single_instance() succeeds (so
+    the registry cannot belong to a healthy sibling instance). Skips
+    pids whose recorded parent is the current process, pids no longer
+    alive (registry entry just removed), and pids whose image is not
+    python (PID reuse). Returns the list of pids terminated.
+    """
+    reaped = []
+    with _registry_lock:
+        path = _registry_path()
+        data = _load_registry(path)
+        if not data:
+            return reaped
+        remaining = {}
+        for pid_str, meta in data.items():
+            try:
+                pid = int(pid_str)
+            except ValueError:
+                continue
+            if meta.get("parent") == os.getpid():
+                remaining[pid_str] = meta
+                continue
+            if not _pid_alive(pid):
+                continue  # stale entry; drop
+            if not _is_python_process(pid):
+                logger.warning(
+                    f"instance guard: pid {pid} in registry is not python (PID reuse); dropping entry"
+                )
+                continue
+            if _terminate(pid):
+                logger.info(f"instance guard: reaped orphan worker pid {pid} ({meta.get('kind', '?')})")
+                reaped.append(pid)
+            else:
+                remaining[pid_str] = meta  # could not kill; keep for next time
+        _save_registry(path, remaining)
+    return reaped

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -126,6 +126,14 @@ class TranscriptionWorker:
             daemon=True,
         )
         self._process.start()
+        # Crash-survivable pid registry: if this parent dies uncleanly,
+        # the next app start reaps this worker instead of leaving a CUDA
+        # context orphaned until the next launcher run (instance_guard).
+        try:
+            from .instance_guard import register_worker_pid
+            register_worker_pid(self._process.pid, kind="transcription")
+        except Exception:
+            logger.debug("worker pid registration failed", exc_info=True)
         self._reader = threading.Thread(
             target=self._reader_loop,
             args=(self._process, self._response_q, self._gen),
@@ -385,6 +393,12 @@ class TranscriptionWorker:
             if self._process.is_alive():
                 self._process.kill()
                 self._process.join(timeout=3)
+        try:
+            from .instance_guard import unregister_worker_pid
+            if self._process.pid:
+                unregister_worker_pid(self._process.pid)
+        except Exception:
+            logger.debug("worker pid unregistration failed", exc_info=True)
         # Even if not alive, ensure the process object is reaped
         try:
             self._process.close()


### PR DESCRIPTION
## Hardening round item 2 (docs/specs/2026-07-03-gpu-guard-spec.md B4)

Only start.ps1 protects against duplicate instances today; any launch bypassing it can double VRAM with a second CUDA worker, and a crashed parent's worker survives until the NEXT launcher run. This is the leading suspect for the owner-reported system drag.

- **instance_guard.py (new)**: named Win32 mutex (second launch toasts and exits; fail-open on mutex API failure), worker pid registry in the data dir, startup reaping with PID-reuse guard (python-image check) and unkillable-pid retry.
- **worker_manager.py** (architecture note, protected path): start()/stop() register/unregister the worker pid inside try/except; registry failures cannot affect the worker lifecycle or protocol.
- **__main__.py**: guard runs before any model/worker activity; toggle `gpu_guard_single_instance` (default true).
- **Docs**: TECHNICAL.md orphan-cleanup section now documents the two-layer model; hardening-round plan doc added as the round's state surface.

## Tests
10 new in tests/test_instance_guard.py: real named-mutex double-acquire on Windows, registry roundtrip + corrupt-file tolerance, reap matrix (orphan reaped, own children skipped, dead pids dropped, PID-reuse refused, unkillable retained). Full system suite 150 pass.