### PR TITLE
ci: run system test suite on every PR and gate auto-merge on it

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -126,6 +126,24 @@ jobs:
                 continue;
               }
 
+              // Require the test suite to have PASSED on the head commit.
+              // The Tests workflow (tests.yml) runs the system suite on
+              // every PR; a missing or failed run blocks the merge. Named
+              // check runs are matched by the job name 'system-suite'.
+              const { data: checkData } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: prData.head.sha,
+                per_page: 100
+              });
+              const testRuns = checkData.check_runs.filter(c => c.name === 'system-suite');
+              const testsPassed = testRuns.some(c => c.conclusion === 'success');
+              if (!testsPassed) {
+                const state = testRuns.length === 0 ? 'has not run' : 'has not passed';
+                console.log(`PR #${prNumber}: test suite ${state} on head ${prData.head.sha}; skipping`);
+                continue;
+              }
+
               // Check for unresolved Copilot review threads.
               //
               // Why thread state and not commit_id matching: when a push fixes

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,6 +21,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  checks: read
 
 jobs:
   auto-merge:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,9 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install test dependencies
-        # pytest is the runner; pillow is needed by icons.py (imported
-        # via state_manager); windows-toasts by the notification tests.
+        # pytest is the runner; pillow is needed because the tests import
+        # whisper_sync.icons directly (IconAnimator); windows-toasts by
+        # the notification tests.
         run: python -m pip install pytest pillow windows-toasts
       - name: Run system suite
         run: python -m pytest tests/ --ignore=tests/test_capture_recorder.py --ignore=tests/test_capture_open_input.py --ignore=tests/test_capture_speaker_streaming.py --ignore=tests/test_capture_mic_downmix.py --ignore=tests/test_real_meeting_data.py --ignore=tests/test_e2e_real_transcription.py -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+# Runs the system-python test suite (no CUDA, no audio hardware, no
+# private data - see docs/development.md "Running the Test Suites") on
+# every PR. The auto-merge workflow requires this check to succeed on
+# the head commit before merging. The venv capture/real-data suites and
+# the WS_E2E end-to-end run stay local-only: they need a GPU and real
+# meeting audio that must never enter this public repo.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  system-suite:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        # pytest is the runner; pillow is needed by icons.py (imported
+        # via state_manager); windows-toasts by the notification tests.
+        run: python -m pip install pytest pillow windows-toasts
+      - name: Run system suite
+        run: python -m pytest tests/ --ignore=tests/test_capture_recorder.py --ignore=tests/test_capture_open_input.py --ignore=tests/test_capture_speaker_streaming.py --ignore=tests/test_capture_mic_downmix.py --ignore=tests/test_real_meeting_data.py --ignore=tests/test_e2e_real_transcription.py -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Use a prefix that describes the type of change:
 1. **Create a branch** from `dev` with the appropriate prefix
 2. **Make your changes** -- keep PRs focused on a single concern
 3. **Open a PR** against `dev`
-4. **Automated review runs** -- the CI workflow classifies your PR by complexity, Copilot reviews the code
+4. **Automated review runs** -- the CI workflow classifies your PR by complexity, Copilot reviews the code, and the system test suite runs (tests.yml; must pass before auto-merge)
 5. **Auto-merge** once Copilot has reviewed and no Copilot review threads remain unresolved. A clean first review merges immediately; if Copilot left suggestions, address them, push, and resolve each thread with a reply citing the fixing commit - no fresh clean review run is required.
 
 ### Automated Review


### PR DESCRIPTION
## Hardening round item 9 (docs/specs/2026-07-03-testing-and-docs-cleanup.md T1)

178 automated tests exist; none ran on PRs. Copilot review was the only merge gate.

- **tests.yml (new)**: system suite (150 tests, no CUDA/audio/private data) on windows-latest for every PR.
- **auto-merge.yml** (architecture note, protected path): merging now requires BOTH zero unresolved Copilot threads AND a successful system-suite check run on the head commit. Missing run = blocked, so the gate cannot be raced by merging before tests report.
- Venv/real-data/E2E suites stay local-only by design (GPU + private audio); documented in the workflow header and docs/development.md already covers their commands.

This PR validates itself: the tests.yml check must pass here for auto-merge to merge it.