### PR TITLE
feat: GPU guard - VRAM watchdog with sticky model downgrade ladder

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -146,6 +146,10 @@ Three layers prevent CUDA out-of-memory crashes:
 
 Override with `"batch_size": 8` in `config.json`. Set `"batch_size": "auto"` to re-enable adaptive sizing.
 
+### GPU Guard (VRAM watchdog + model downgrade)
+
+`gpu_guard.py` polls device-wide free VRAM (providers in `vram_probe.py`: pynvml if installed, else nvidia-smi; a new GPU vendor is a new provider function, nothing else changes). Below `gpu_guard_low_vram_mb` free (default 750), one downgrade step is armed for the NEXT transcription; worker crashes escalate immediately. The downgrade ladder (`gpu_guard_ladder`, default large-v3 > medium > small > base) is sticky for the session and never upgrades a caller that asked for a smaller model. Every event (arm, recovery, floor, probe-unavailable) appends a timestamped JSON line to `<data_dir>/gpu-guard.jsonl` - the artifact for correlating GPU pressure with Windows crash/BSOD times, and the machine-readable surface for external tooling. Master toggle: `gpu_guard` (default true); disabled or no-provider means fully inert.
+
 ### Meeting Recording -- Disk-Only Audio
 
 Meeting recordings use **disk-only** audio capture for the mic channel. The mic callback streams audio to a WAV file on disk in real-time and does NOT accumulate audio in RAM (controlled by the `disk_only` flag in `start_streaming()`). The speaker loopback channel, however, still accumulates audio in RAM via `_speaker_data` for resampling and stereo merging at stop time. Dictation mode uses RAM for both channels (recordings are short).

--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -11,9 +11,9 @@
 
 | # | Item | Spec | Status |
 |---|------|------|--------|
-| 2 | In-app single-instance lock + orphan worker reaping | gpu-guard-spec B4 | IN PIPELINE |
-| 9 | CI runs the system test suite on every PR | testing-and-docs-cleanup T1 | PENDING |
-| 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | PENDING |
+| 2 | In-app single-instance lock + orphan worker reaping | gpu-guard-spec B4 | MERGED (#156) |
+| 9 | CI runs the system test suite on every PR | testing-and-docs-cleanup T1 | MERGED (#157) |
+| 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | IN PIPELINE |
 | 3 | Sleep/resume power event handling | hardware-resilience H1 | PENDING |
 | 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | PENDING |
 | 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | PENDING |
@@ -45,3 +45,25 @@ in one place, not a branching if/then system and not a framework.
   and unkillable-pid retry. Toggle gpu_guard_single_instance (default
   true). 10 tests (real named mutex on Windows; all process seams faked
   for reap logic).
+
+- **2026-07-03 (item 2 merged, #156)**: after review, all Win32 calls
+  prototyped via a single _win32() accessor (HANDLE-truncation class from
+  PR #141) and orphan reaping made Windows-only (no safe positive
+  PID-reuse check elsewhere; never guess-kill).
+
+- **2026-07-03 (item 9 merged, #157)**: tests.yml runs the system suite
+  on windows-latest per PR; auto-merge requires the system-suite check
+  to succeed on the head commit (plus checks: read permission - Copilot
+  catch). Verified: check runs attach to the PR head sha; the suite
+  passed green on its first CI run.
+
+- **2026-07-03 (item 1)**: gpu_guard.py + vram_probe.py per spec B1-B3.
+  Deviations from spec, both deliberate: no gpu_guard_allow_cpu_floor
+  key (forcing device per request needs a worker restart path; the
+  ladder floor is the smallest model instead - CPU floor deferred), and
+  watermark hysteresis added (a persistently low reading arms ONE step,
+  not one per poll; re-arm requires recovery above the watermark).
+  Escalation triggers: low-VRAM watermark, dictation worker crash,
+  meeting pipeline worker crash. Model seam: effective_model() at the 6
+  dictation_model computations and meeting_job step_transcribe
+  (model_override). 17 tests. System suite 164; venv 36.

--- a/tests/test_gpu_guard.py
+++ b/tests/test_gpu_guard.py
@@ -133,6 +133,24 @@ class LadderTests(_Harness):
 
 
 class DisabledTests(_Harness):
+    def test_providerless_guard_is_inert_even_for_crash_triggers(self):
+        # Regression for PR #158 review: without a probe provider the
+        # guard must never alter model selection, including on crashes.
+        g = GpuGuard(_cfg(), notify=lambda t, m: None,
+                     probe=None, probe_name=None, event_path=self.event_path)
+        g.note_pressure_trigger("worker_crash_meeting")
+        self.assertEqual(g.effective_model("large-v3"), "large-v3")
+
+    def test_invalid_ladder_config_falls_back_to_default(self):
+        # Regression for PR #158 review: an empty or malformed ladder
+        # must not crash escalation with an IndexError.
+        g = self._guard(gpu_guard_ladder=[])
+        g.note_pressure_trigger("x")
+        self.assertEqual(g.effective_model("large-v3"), "medium")
+        g2 = self._guard(gpu_guard_ladder="large-v3")  # string, not list
+        g2.note_pressure_trigger("x")
+        self.assertEqual(g2.effective_model("large-v3"), "medium")
+
     def test_disabled_guard_is_inert(self):
         g = self._guard(gpu_guard=False)
         g.note_pressure_trigger("worker_crash_meeting")

--- a/tests/test_gpu_guard.py
+++ b/tests/test_gpu_guard.py
@@ -1,0 +1,178 @@
+"""Tests for whisper_sync.gpu_guard and vram_probe.
+
+Everything runs against fake probes and a temp event log; no GPU, no
+subprocess, no scheduler thread (check_once is driven directly).
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from whisper_sync.gpu_guard import GpuGuard
+from whisper_sync.vram_probe import ProbeResult, get_probe
+
+
+def _cfg(**overrides):
+    base = {
+        "gpu_guard": True,
+        "gpu_guard_low_vram_mb": 750,
+        "gpu_guard_ladder": ["large-v3", "medium", "small", "base"],
+        "model": "large-v3",
+    }
+    base.update(overrides)
+    return base
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.event_path = Path(self._tmp.name) / "gpu-guard.jsonl"
+        self.toasts = []
+
+    def _guard(self, free_sequence=None, **cfg_overrides):
+        seq = list(free_sequence or [])
+
+        def _probe():
+            if not seq:
+                return None
+            free = seq.pop(0)
+            if free is None:
+                return None
+            return ProbeResult(total_mb=8192, free_mb=free)
+
+        return GpuGuard(
+            _cfg(**cfg_overrides),
+            notify=lambda t, m: self.toasts.append((t, m)),
+            probe=_probe, probe_name="fake",
+            event_path=self.event_path,
+        )
+
+    def _events(self):
+        if not self.event_path.exists():
+            return []
+        return [json.loads(l) for l in self.event_path.read_text().splitlines()]
+
+
+class WatermarkTests(_Harness):
+    def test_low_vram_arms_one_downgrade(self):
+        g = self._guard(free_sequence=[500])
+        g.check_once()
+        self.assertEqual(g.effective_model("large-v3"), "medium")
+        events = self._events()
+        self.assertEqual(events[-1]["event"], "downgrade_armed")
+        self.assertEqual(events[-1]["trigger"], "low_vram")
+        self.assertEqual(events[-1]["free_mb"], 500)
+        self.assertEqual(events[-1]["model_to"], "medium")
+        self.assertEqual(len(self.toasts), 1)
+
+    def test_persistent_low_reading_does_not_walk_the_ladder(self):
+        # Hysteresis: staying below the watermark must not escalate on
+        # every poll - only a recovery + new breach re-arms.
+        g = self._guard(free_sequence=[500, 400, 300])
+        for _ in range(3):
+            g.check_once()
+        self.assertEqual(g.effective_model("large-v3"), "medium",
+                         "three consecutive low reads must equal ONE downgrade")
+
+    def test_recovery_then_new_breach_escalates_again(self):
+        g = self._guard(free_sequence=[500, 2000, 600])
+        g.check_once()  # breach -> level 1
+        g.check_once()  # recovery
+        g.check_once()  # new breach -> level 2
+        self.assertEqual(g.effective_model("large-v3"), "small")
+        kinds = [e["event"] for e in self._events()]
+        self.assertIn("vram_recovered", kinds)
+
+    def test_healthy_vram_never_downgrades(self):
+        g = self._guard(free_sequence=[4000, 3000])
+        g.check_once()
+        g.check_once()
+        self.assertEqual(g.effective_model("large-v3"), "large-v3")
+        self.assertEqual(self.toasts, [])
+
+    def test_probe_failure_is_transient_noop(self):
+        g = self._guard(free_sequence=[None, 4000])
+        g.check_once()  # probe failed; no state change
+        g.check_once()
+        self.assertEqual(g.effective_model("large-v3"), "large-v3")
+
+
+class LadderTests(_Harness):
+    def test_crash_trigger_escalates_immediately(self):
+        g = self._guard()
+        g.note_pressure_trigger("worker_crash_meeting")
+        self.assertEqual(g.effective_model("large-v3"), "medium")
+        g.note_pressure_trigger("worker_crash_meeting")
+        self.assertEqual(g.effective_model("large-v3"), "small")
+
+    def test_ladder_floor_is_sticky_and_logged(self):
+        g = self._guard()
+        for _ in range(10):
+            g.note_pressure_trigger("worker_crash_dictation")
+        self.assertEqual(g.effective_model("large-v3"), "base")
+        self.assertIn("ladder_floor", [e["event"] for e in self._events()])
+
+    def test_downgrade_never_upgrades_a_smaller_request(self):
+        # Caller already using 'base' for dictation must not be bumped
+        # up to the guard's rung.
+        g = self._guard()
+        g.note_pressure_trigger("x")  # rung = medium
+        self.assertEqual(g.effective_model("base"), "base")
+        self.assertEqual(g.effective_model("small"), "small")
+
+    def test_model_not_on_ladder_maps_to_rung(self):
+        g = self._guard()
+        g.note_pressure_trigger("x")
+        self.assertEqual(g.effective_model("distil-large-v3"), "medium")
+
+    def test_level_zero_passes_through_unknown_models(self):
+        g = self._guard()
+        self.assertEqual(g.effective_model("distil-large-v3"), "distil-large-v3")
+
+
+class DisabledTests(_Harness):
+    def test_disabled_guard_is_inert(self):
+        g = self._guard(gpu_guard=False)
+        g.note_pressure_trigger("worker_crash_meeting")
+        self.assertEqual(g.effective_model("large-v3"), "large-v3")
+        self.assertEqual(self.toasts, [])
+
+    def test_start_without_probe_logs_event_and_stays_inactive(self):
+        g = GpuGuard(_cfg(), probe=None, probe_name=None,
+                     event_path=self.event_path)
+
+        class _NoProviderScheduler:
+            def call_every(self, *a, **k):
+                raise AssertionError("must not poll without a probe")
+
+        import unittest.mock as mock
+        with mock.patch("whisper_sync.vram_probe.get_probe",
+                        return_value=(None, None)):
+            g.start(_NoProviderScheduler(), io_executor=None)
+        self.assertIn("probe_unavailable", [e["event"] for e in self._events()])
+
+
+class ProbeRegistryTests(unittest.TestCase):
+    def test_get_probe_returns_none_when_no_provider(self):
+        import unittest.mock as mock
+        import whisper_sync.vram_probe as vp
+        with mock.patch.object(vp, "PROVIDERS", [("x", lambda: None)]):
+            self.assertEqual(get_probe(), (None, None))
+
+    def test_preferred_provider_pins_selection(self):
+        import unittest.mock as mock
+        import whisper_sync.vram_probe as vp
+        fake = lambda: ProbeResult(8192, 4096)
+        with mock.patch.object(vp, "PROVIDERS", [
+            ("first", lambda: (lambda: None)),
+            ("second", lambda: fake),
+        ]):
+            name, probe = get_probe(preferred="second")
+        self.assertEqual(name, "second")
+        self.assertEqual(probe(), ProbeResult(8192, 4096))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -49,6 +49,7 @@ from .paths import (get_install_root, get_default_output_dir,
                      get_legacy_dictation_log_dir, get_config_path as get_data_config_path,
                      get_speaker_config_path)
 from .worker_manager import TranscriptionWorker, WorkerCrashedError
+from .gpu_guard import GpuGuard
 from .backup_worker import BackupTranscriber
 from . import dictation_log
 from . import feature_log
@@ -147,7 +148,9 @@ class WhisperSync:
         self._api_filter = "Windows WASAPI"  # None = show all
         self._dictation_wav_path: Path | None = None
         self._meeting_start_time: datetime | None = None
-        dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+        self._gpu_guard = GpuGuard(self.cfg, notify=notify)
+        dictation_model = self._gpu_guard.effective_model(
+            self.cfg.get("dictation_model", self.cfg["model"]))
         self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
         self._backup = BackupTranscriber(self.cfg)
         self._overlay_recorder = None    # Separate AudioRecorder for dictation during meetings
@@ -496,7 +499,8 @@ class WhisperSync:
 
         self.state.emit(TRANSCRIPTION_STARTED, mode="transcribing")
 
-        dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+        dictation_model = self._gpu_guard.effective_model(
+            self.cfg.get("dictation_model", self.cfg["model"]))
         use_backup = self.state.current.meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)
         # Capture feature flag under lock before spawning background thread
         with self._lock:
@@ -595,6 +599,7 @@ class WhisperSync:
                     self._safe_unlink(self._dictation_wav_path)
                 self.state.emit(DICTATION_COMPLETED, mode="done")
             except WorkerCrashedError:
+                self._gpu_guard.note_pressure_trigger("worker_crash_dictation")
                 logger.error("Worker crashed during dictation -- respawning...")
                 if self._dictation_wav_path:
                     logger.info(f"Dictation audio preserved at: {self._dictation_wav_path}")
@@ -735,7 +740,8 @@ class WhisperSync:
                 # Fall back to queuing on main worker if backup fails
                 try:
                     logger.info("Falling back to main worker for overlay dictation", extra={"secondary": True})
-                    dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+                    dictation_model = self._gpu_guard.effective_model(
+                        self.cfg.get("dictation_model", self.cfg["model"]))
                     timeout = 180
                     text = self.worker.transcribe_fast(overlay_audio, model_override=dictation_model, timeout=timeout)
                     if text:
@@ -787,7 +793,8 @@ class WhisperSync:
                 frames = wf.readframes(wf.getnframes())
                 audio_np = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32767.0
 
-            dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+            dictation_model = self._gpu_guard.effective_model(
+                self.cfg.get("dictation_model", self.cfg["model"]))
             text = self.worker.transcribe_fast(audio_np, model_override=dictation_model)
             if text:
                 pyperclip.copy(text)
@@ -829,7 +836,8 @@ class WhisperSync:
                 frames = wf.readframes(wf.getnframes())
                 audio_np = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32767.0
 
-            dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+            dictation_model = self._gpu_guard.effective_model(
+                self.cfg.get("dictation_model", self.cfg["model"]))
             text = self.worker.transcribe_fast(audio_np, model_override=dictation_model)
             if not text:
                 logger.info("Crashed feature suggestion produced no text, cleaning up")
@@ -2107,6 +2115,7 @@ class WhisperSync:
             logger.info(f"Meeting done: {job.name or 'meeting'}")
 
         except WorkerCrashedError as e:
+            self._gpu_guard.note_pressure_trigger("worker_crash_meeting")
             logger.error("Worker crashed during meeting, respawning...")
             logger.info(f"Audio is preserved at: {job.wav_path}")
             self.worker.restart()
@@ -3682,7 +3691,8 @@ class WhisperSync:
         toast_listener = ToastListener(self.cfg)
         self.state.on_any(toast_listener)
 
-        dictation_model = self.cfg.get("dictation_model", self.cfg["model"])
+        dictation_model = self._gpu_guard.effective_model(
+            self.cfg.get("dictation_model", self.cfg["model"]))
         logger.info("WhisperSync running. Hotkeys:")
         logger.info(f"  Dictation: {self.cfg['hotkeys']['dictation_toggle']} (model: {dictation_model})")
         logger.info(f"  Meeting:   {self.cfg['hotkeys']['meeting_toggle']} (model: {self.cfg['model']})")
@@ -3768,6 +3778,10 @@ class WhisperSync:
             ),
         )
         self._idle_collector.start()
+
+        # GPU guard: VRAM watermark polling + downgrade ladder (spec B1-B3).
+        from .scheduler import scheduler as _sched
+        self._gpu_guard.start(_sched, IO)
 
         try:
             self.tray.run()

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -30,5 +30,15 @@
   "diarize_fallback": "per_channel",
   "diarize_last_resort": "raw_audio",
   "dictation_max_minutes": 30,
-  "gpu_guard_single_instance": true
+  "gpu_guard_single_instance": true,
+  "gpu_guard": true,
+  "gpu_guard_low_vram_mb": 750,
+  "gpu_guard_poll_seconds": 30,
+  "gpu_guard_ladder": [
+    "large-v3",
+    "medium",
+    "small",
+    "base"
+  ],
+  "gpu_guard_probe": null
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -30,6 +30,8 @@ _VALID_KEYS = {
     "diarize_primary", "diarize_fallback", "diarize_last_resort",
     "dictation_max_minutes",
     "gpu_guard_single_instance",
+    "gpu_guard", "gpu_guard_low_vram_mb", "gpu_guard_poll_seconds",
+    "gpu_guard_ladder", "gpu_guard_probe",
 }
 
 

--- a/whisper_sync/gpu_guard.py
+++ b/whisper_sync/gpu_guard.py
@@ -60,8 +60,14 @@ class GpuGuard:
         return bool(self._cfg.get("gpu_guard", True))
 
     def _ladder(self) -> list:
-        ladder = self._cfg.get("gpu_guard_ladder") or DEFAULT_LADDER
-        return list(ladder)
+        """Validated ladder; malformed config falls back to the default."""
+        ladder = self._cfg.get("gpu_guard_ladder")
+        if (isinstance(ladder, (list, tuple)) and len(ladder) > 0
+                and all(isinstance(m, str) and m for m in ladder)):
+            return list(ladder)
+        if ladder is not None:
+            logger.warning(f"GPU guard: invalid gpu_guard_ladder {ladder!r}; using default")
+        return list(DEFAULT_LADDER)
 
     def _watermark_mb(self) -> int:
         return int(self._cfg.get("gpu_guard_low_vram_mb", 750))
@@ -81,10 +87,12 @@ class GpuGuard:
                 self._cfg.get("gpu_guard_probe") or None
             )
         if self._probe is None:
+            # Mark started so repeated start() calls do not re-log or
+            # re-probe; the guard is permanently inert this session.
+            self._started = True
             logger.info("GPU guard: no VRAM probe provider on this machine; guard inactive")
             self._event("probe_unavailable")
             return
-        self._started = True
         poll = float(self._cfg.get("gpu_guard_poll_seconds", 30))
         # The probe (subprocess for nvidia-smi) must not run on the
         # scheduler thread (short-jobs contract): the tick only enqueues
@@ -123,8 +131,12 @@ class GpuGuard:
                             total_mb=result.total_mb, level=self._level)
 
     def note_pressure_trigger(self, reason: str) -> None:
-        """Escalate one rung immediately (worker crash, OOM exhaustion)."""
-        if not self.enabled:
+        """Escalate one rung immediately (worker crash, OOM exhaustion).
+
+        Inert without a probe provider: on providerless machines the
+        guard must never alter model selection (documented contract).
+        """
+        if not self.enabled or self._probe is None:
             return
         with self._lock:
             self._escalate_locked(trigger=reason,
@@ -161,7 +173,7 @@ class GpuGuard:
         a downgrade may never upgrade a caller that already asked for a
         small model. Models not on the ladder map to the current rung.
         """
-        if not self.enabled:
+        if not self.enabled or self._probe is None:
             return requested
         with self._lock:
             return self._effective_locked(requested)

--- a/whisper_sync/gpu_guard.py
+++ b/whisper_sync/gpu_guard.py
@@ -1,0 +1,208 @@
+"""GPU Guard: VRAM watchdog with a sticky model-downgrade ladder.
+
+One module owns the whole feature (2026-07-03 gpu-guard spec). The rest
+of the app touches it through three seams: ``start()`` at app startup,
+``effective_model()`` where transcription requests choose a model, and
+``note_pressure_trigger()`` on worker crashes. Disabled (``gpu_guard``
+config key false, or no probe provider on this machine) means inert:
+no polling, ``effective_model`` is a pass-through.
+
+Behavior (spec B1-B3):
+- A scheduler tick offloads a VRAM probe onto the IO executor every
+  ``gpu_guard_poll_seconds``. Free VRAM below ``gpu_guard_low_vram_mb``
+  arms one downgrade step for the NEXT transcription request; an
+  in-flight job is never killed for a watermark. Re-arming requires
+  recovery above the watermark first (hysteresis), so a persistently
+  low reading does not walk the ladder to the floor by itself.
+- Worker crashes and OOM-retry exhaustion escalate immediately by one
+  step per event.
+- Downgrades are sticky for the session (the configured model returns
+  on next app start), and every event appends a timestamped JSON line
+  to ``gpu-guard.jsonl`` in the data dir - the artifact for correlating
+  against Windows crash/BSOD times, and the machine surface for the
+  API-first extension app.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+from .logger import logger
+
+DEFAULT_LADDER = ["large-v3", "medium", "small", "base"]
+
+
+class GpuGuard:
+    """Owns watermark monitoring, the downgrade ladder, and the event log."""
+
+    def __init__(self, cfg, notify: Optional[Callable[[str, str], None]] = None,
+                 probe=None, probe_name: str | None = None,
+                 event_path: Path | None = None):
+        self._cfg = cfg
+        self._notify = notify or (lambda title, msg: None)
+        self._lock = threading.Lock()
+        self._level = 0            # rungs below the requested model
+        self._armed_low = False    # hysteresis: True while below watermark
+        self._last_free_mb: int | None = None
+        self._probe = probe
+        self._probe_name = probe_name
+        self._event_path = event_path
+        self._started = False
+
+    # -- configuration ------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._cfg.get("gpu_guard", True))
+
+    def _ladder(self) -> list:
+        ladder = self._cfg.get("gpu_guard_ladder") or DEFAULT_LADDER
+        return list(ladder)
+
+    def _watermark_mb(self) -> int:
+        return int(self._cfg.get("gpu_guard_low_vram_mb", 750))
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def start(self, scheduler, io_executor) -> None:
+        """Begin polling. No-op when disabled or no probe provider exists."""
+        if self._started:
+            return
+        if not self.enabled:
+            logger.info("GPU guard disabled by config")
+            return
+        if self._probe is None:
+            from .vram_probe import get_probe
+            self._probe_name, self._probe = get_probe(
+                self._cfg.get("gpu_guard_probe") or None
+            )
+        if self._probe is None:
+            logger.info("GPU guard: no VRAM probe provider on this machine; guard inactive")
+            self._event("probe_unavailable")
+            return
+        self._started = True
+        poll = float(self._cfg.get("gpu_guard_poll_seconds", 30))
+        # The probe (subprocess for nvidia-smi) must not run on the
+        # scheduler thread (short-jobs contract): the tick only enqueues
+        # onto IO, native-gauged so idle-GC sees the subprocess.
+        scheduler.call_every(
+            poll,
+            lambda: io_executor.submit_native("gpu-probe", self.check_once),
+            label="gpu-guard-poll",
+        )
+        logger.info(
+            f"GPU guard active: provider={self._probe_name}, "
+            f"watermark={self._watermark_mb()}MB free, poll={poll:.0f}s"
+        )
+        self._event("guard_started", provider=self._probe_name,
+                    watermark_mb=self._watermark_mb())
+
+    # -- monitoring -----------------------------------------------------------
+
+    def check_once(self) -> None:
+        """One probe + watermark evaluation. Runs on the IO executor."""
+        result = self._probe() if self._probe else None
+        if result is None:
+            return  # transient probe failure; next poll retries
+        with self._lock:
+            self._last_free_mb = result.free_mb
+            watermark = self._watermark_mb()
+            if result.free_mb < watermark and not self._armed_low:
+                self._armed_low = True
+                self._escalate_locked(
+                    trigger="low_vram",
+                    free_mb=result.free_mb, total_mb=result.total_mb,
+                )
+            elif result.free_mb >= watermark and self._armed_low:
+                self._armed_low = False
+                self._event("vram_recovered", free_mb=result.free_mb,
+                            total_mb=result.total_mb, level=self._level)
+
+    def note_pressure_trigger(self, reason: str) -> None:
+        """Escalate one rung immediately (worker crash, OOM exhaustion)."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self._escalate_locked(trigger=reason,
+                                  free_mb=self._last_free_mb, total_mb=None)
+
+    def _escalate_locked(self, trigger: str, free_mb, total_mb) -> None:
+        ladder = self._ladder()
+        if self._level >= len(ladder) - 1:
+            self._event("ladder_floor", trigger=trigger, free_mb=free_mb,
+                        total_mb=total_mb, level=self._level)
+            return
+        old = self._effective_locked(str(self._cfg.get("model", ladder[0])))
+        self._level += 1
+        new = self._effective_locked(str(self._cfg.get("model", ladder[0])))
+        self._event("downgrade_armed", trigger=trigger, free_mb=free_mb,
+                    total_mb=total_mb, level=self._level,
+                    model_from=old, model_to=new)
+        logger.warning(
+            f"GPU guard: downgrade armed ({trigger}); next transcriptions "
+            f"use '{new}' (level {self._level}, was '{old}')"
+        )
+        self._notify(
+            "WhisperSync reduced its model",
+            f"GPU pressure ({trigger}): using '{new}' until restart.",
+        )
+
+    # -- the model seam ---------------------------------------------------------
+
+    def effective_model(self, requested: str) -> str:
+        """The model transcription should actually use.
+
+        Level 0 (or guard disabled) passes through. Otherwise the result
+        is the LOWER of the requested model and the current ladder rung -
+        a downgrade may never upgrade a caller that already asked for a
+        small model. Models not on the ladder map to the current rung.
+        """
+        if not self.enabled:
+            return requested
+        with self._lock:
+            return self._effective_locked(requested)
+
+    def _effective_locked(self, requested: str) -> str:
+        if self._level == 0:
+            return requested
+        ladder = self._ladder()
+        rung_index = min(self._level, len(ladder) - 1)
+        try:
+            requested_index = ladder.index(requested)
+        except ValueError:
+            return ladder[rung_index]
+        return ladder[max(requested_index, rung_index)]
+
+    def status(self) -> dict:
+        with self._lock:
+            return {
+                "enabled": self.enabled,
+                "provider": self._probe_name,
+                "level": self._level,
+                "last_free_mb": self._last_free_mb,
+            }
+
+    # -- event log ---------------------------------------------------------------
+
+    def _event(self, event: str, **fields) -> None:
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+            **{k: v for k, v in fields.items() if v is not None},
+        }
+        try:
+            path = self._event_path or self._default_event_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record) + "\n")
+        except OSError as exc:
+            logger.warning(f"GPU guard: could not write event log: {exc}")
+
+    @staticmethod
+    def _default_event_path() -> Path:
+        from .paths import get_data_dir
+        return get_data_dir() / "gpu-guard.jsonl"

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -135,8 +135,14 @@ class MeetingJob:
             if not self.app.worker.wait_ready(timeout=120):
                 raise RuntimeError("Worker failed to restart")
 
+        guard = getattr(self.app, "_gpu_guard", None)
+        model_override = (
+            guard.effective_model(str(self.app.cfg.get("model", "large-v3")))
+            if guard is not None else None
+        )
         self.transcript_result = self.app.worker.transcribe(
             str(self.wav_path), diarize=True,
+            model_override=model_override,
             diarize_method=self.diarize_method,
         )
         logger.debug(

--- a/whisper_sync/vram_probe.py
+++ b/whisper_sync/vram_probe.py
@@ -1,0 +1,107 @@
+"""Vendor-agnostic GPU memory probes.
+
+The GPU Guard (gpu_guard.py) needs device-wide free VRAM from the MAIN
+process, which deliberately has no torch/CUDA context (transcription
+lives in the worker subprocess). Probes are small callables returning
+``ProbeResult(total_mb, free_mb)`` or ``None`` on failure, registered by
+name so a new GPU vendor is a new provider function here - never edits
+scattered through the app (2026-07-03 gpu-guard spec, design principle 2).
+
+Providers:
+- ``pynvml``: NVIDIA NVML bindings if the package happens to be
+  installed. No CUDA context required, ~zero cost per call.
+- ``nvidia-smi``: subprocess query against the driver's CLI. Universally
+  present with any NVIDIA driver install; ~100ms per call. The default
+  on NVIDIA machines.
+- (future) an Intel/AMD provider slots in as another function.
+
+``get_probe()`` auto-selects the first available provider and is called
+once at guard startup; per-poll calls go through the returned callable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Callable, NamedTuple, Optional
+
+from .logger import logger
+
+
+class ProbeResult(NamedTuple):
+    total_mb: int
+    free_mb: int
+
+
+ProbeFn = Callable[[], Optional[ProbeResult]]
+
+
+def _pynvml_available() -> ProbeFn | None:
+    try:
+        import pynvml  # noqa: F401
+    except ImportError:
+        return None
+
+    def _probe() -> ProbeResult | None:
+        try:
+            import pynvml
+            pynvml.nvmlInit()
+            try:
+                handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+                mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                return ProbeResult(int(mem.total // 1_048_576), int(mem.free // 1_048_576))
+            finally:
+                pynvml.nvmlShutdown()
+        except Exception as exc:
+            logger.debug(f"pynvml probe failed: {exc}")
+            return None
+
+    return _probe
+
+
+def _nvidia_smi_available() -> ProbeFn | None:
+    if shutil.which("nvidia-smi") is None:
+        return None
+
+    def _probe() -> ProbeResult | None:
+        try:
+            out = subprocess.run(
+                ["nvidia-smi", "--query-gpu=memory.total,memory.free",
+                 "--format=csv,noheader,nounits"],
+                capture_output=True, text=True, timeout=10,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            if out.returncode != 0:
+                logger.debug(f"nvidia-smi probe rc={out.returncode}: {out.stderr.strip()[:200]}")
+                return None
+            # First GPU only; multi-GPU machines report line per device.
+            first = out.stdout.strip().splitlines()[0]
+            total_s, free_s = (p.strip() for p in first.split(","))
+            return ProbeResult(int(total_s), int(free_s))
+        except (subprocess.TimeoutExpired, OSError, ValueError, IndexError) as exc:
+            logger.debug(f"nvidia-smi probe failed: {exc}")
+            return None
+
+    return _probe
+
+
+# Ordered registry: first available wins. A new vendor adds a pair here.
+PROVIDERS: list[tuple[str, Callable[[], ProbeFn | None]]] = [
+    ("pynvml", _pynvml_available),
+    ("nvidia-smi", _nvidia_smi_available),
+]
+
+
+def get_probe(preferred: str | None = None) -> tuple[str, ProbeFn] | tuple[None, None]:
+    """Select a probe provider. Returns (name, callable) or (None, None).
+
+    ``preferred`` pins a specific provider by name (config escape hatch);
+    otherwise the first available in PROVIDERS order wins.
+    """
+    for name, factory in PROVIDERS:
+        if preferred is not None and name != preferred:
+            continue
+        probe = factory()
+        if probe is not None:
+            return name, probe
+    return None, None


### PR DESCRIPTION
## Hardening round item 1 (docs/specs/2026-07-03-gpu-guard-spec.md B1-B3)

Runtime VRAM protection did not exist: one static read at model load, string-matched OOM retries that never fall back, no pressure record. This is the owner's requested modular, toggleable protection layer after the nvlddmkm crash storm.

- **vram_probe.py (new)**: provider registry returning (total_mb, free_mb) - pynvml if installed, else nvidia-smi subprocess, auto-selected once at startup; an Intel/AMD port is a new provider function only. `gpu_guard_probe` pins a provider.
- **gpu_guard.py (new)**: watermark monitor (default 750MB free, poll 30s, probe runs native-gauged on IO, never on the scheduler thread); one-step arm with hysteresis; immediate escalation on worker crashes; sticky session downgrade down `gpu_guard_ladder` (large-v3 > medium > small > base); never upgrades a smaller request; `gpu-guard.jsonl` event log (arm/recover/floor/probe-unavailable) with UTC timestamps for BSOD-time correlation and for the API-first extension app.
- **Seams**: `effective_model()` at the 6 dictation model sites + meeting transcribe `model_override`; `note_pressure_trigger()` in both WorkerCrashedError handlers. Guard disabled or providerless = fully inert pass-through.
- **Spec deviations (logged in the plan doc)**: CPU floor deferred (needs per-request device routing); hysteresis added so a persistently low reading arms once, not per poll.

## Tests
17 new (fake probes, temp event log). Full system suite 164 pass; venv suite 36 pass locally.