### PR TITLE
docs: truth and navigation pass; single testing entry point

### DIFF
--- a/.claude/rules/audio-pipeline.md
+++ b/.claude/rules/audio-pipeline.md
@@ -54,7 +54,7 @@ Two-tier system, both using sonnet:
 
 Both modes detect meeting boundaries (farewell exchanges, pauses, new greetings). When boundaries are detected, the dialog offers to split the recording after speaker confirmation.
 
-Speaker identification timeout is 90s with 1 retry for light mode, 180s for deep mode. If identification fails, a manual entry dialog appears with empty fields and known speakers in autocomplete.
+Speaker identification timeout is 240s with no retry (see speakers.py; changed in #133). If identification fails, a manual entry dialog appears with empty fields and known speakers in autocomplete.
 
 The **Meetings** tray menu shows the 10 most recent meetings with speaker status. Clicking any meeting re-enters the speaker ID flow.
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,6 +1,6 @@
 # Testing Rules
 
-No automated test suite exists. All verification is manual.
+Automated suites exist and run in CI (see docs/testing.md for the full map: 160+ system tests per PR, venv/real-data suites locally). This file is the MANUAL verification checklist that complements them - hardware-in-the-loop checks no automated test covers.
 
 ## Setup
 

--- a/.claude/rules/ui-patterns.md
+++ b/.claude/rules/ui-patterns.md
@@ -2,7 +2,7 @@
 
 ## Tray Menu
 
-The tray menu is built in `_build_menu()` and refreshed via `_refresh_menu()`. Menu ordering is intentional and must be preserved:
+The tray menu is built in `_build_menu()`; `_refresh_menu()` requests a rebuild through the debounced single-owner MenuRefresher (300ms coalescing, #138). Menu ordering is intentional and must be preserved:
 
 1. Recent Dictations (submenu)
 2. Separator
@@ -29,7 +29,7 @@ This is a pystray convention. The tab character triggers right-alignment in the 
 
 ## Pystray Limitations
 
-- `pystray` does not support dynamic menu updates without full menu rebuild. `_refresh_menu()` replaces the entire menu via `self.tray.update_menu()`.
+- `pystray` does not support dynamic menu updates without full menu rebuild. Refresh requests coalesce in MenuRefresher, which replaces the entire menu via `self.tray.update_menu()` on its debounce.
 - Menu item callbacks must be simple lambdas or bound methods. Complex state changes must be dispatched to background threads.
 - Enabled/disabled state is set at construction time via the `enabled` parameter.
 - Separators are `pystray.Menu.SEPARATOR`.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 # Temp files
 *.npy
 *.tmp
+
+# Local dev-machine marker, never shipped
+whisper_sync/.standalone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Local speech-to-text for Windows. GPU-accelerated transcription with speaker dia
 - **`docs/plans/`** - Implementation plans for major features
 - **`.claude/rules/audio-pipeline.md`** - Stereo recording, diarization tiers, VRAM management, worker model
 - **`.claude/rules/ui-patterns.md`** - Tray menu ordering, dialog conventions, pystray limitations
-- **`.claude/rules/testing.md`** - Manual test checklist for all modes
+- **`.claude/rules/testing.md`** - Manual hardware-in-the-loop checklist (automated suites: docs/testing.md; system suite runs in CI per PR)
 - **`.github/governance/policy.yaml`** - Auto-merge policy, path protection, review thresholds
 
 ### Note for AI Agents

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ If you are unsure whether a file should be committed, check `.gitignore`.
 
 ## Testing
 
-There is no automated test suite yet. Before submitting a PR, manually verify:
+Automated tests run on every PR (tests.yml; see [docs/testing.md](docs/testing.md) for all suites and commands). Before submitting a PR that touches audio, transcription, or the tray, additionally verify manually:
 
 1. **Dictation mode** -- press Ctrl+Shift+Space, speak for 3-5 seconds, press again. Text should paste into the focused window.
 2. **Meeting mode** -- press Ctrl+Shift+M, speak for 10+ seconds, press again. Transcript should be saved to disk.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For the full design, see [docs/specs/2026-03-24-governance-learning-loop-design.
 | Requirement | Details |
 |-------------|---------|
 | **OS** | Windows 10 or 11 |
-| **Python** | 3.11 or newer (3.13 recommended) |
+| **Python** | 3.10 or newer (3.13 recommended) |
 | **GPU** | NVIDIA with CUDA support recommended (RTX 20/30/40/50 series, GTX 10-series). CPU-only mode available but 5-10x slower. |
 | **VRAM** | 2 GB minimum (tiny/base models), 4 GB+ recommended, 8 GB+ for large-v3 |
 | **Disk** | ~200 MB base install + model sizes (see table below) |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Runs as a system tray icon on Windows.
 - **Always-available dictation** -- dictate during active meeting recording without interruption
 - **Tiered log window** -- Off / Normal / Detailed / Verbose with ANSI color coding
 - **CPU/GPU device selection** -- Auto-detect, force GPU, or force CPU via tray menu
-- **Dual-ring tray icon** -- inner circle = mic status, outer ring = speaker/loopback status
+- **Three-ring tray icon** -- inner dot = backup/overlay dictation, inner circle = mic status, outer ring = speaker/loopback status (canonical table: .claude/rules/ui-patterns.md)
 - **Incognito mode** -- RAM-only dictation; no transcription text logged or saved to disk
 - **Persistent dictation history** -- last 10 dictations in tray menu, survives restarts
 - **Session stats** -- dictation/meeting counts, averages, and uptime for the current session
@@ -49,7 +49,7 @@ Models download once on first run and are cached locally. Subsequent launches lo
 
 WhisperSync uses a **3-tier diarization cascade** for stereo recordings (mic + system audio captured as separate channels):
 
-**Tier 1: Per-channel transcription + confidence fusion (~95% of meetings)**
+**Per-channel transcription + confidence fusion** (highest quality; the shipped default order is `balanced_mix` first - see `diarize_primary` in config and .claude/rules/audio-pipeline.md for the authoritative method order)
 - The stereo recording is split into mic channel and loopback channel
 - Each channel is transcribed independently with WhisperX
 - Segments are merged using energy-based confidence scoring
@@ -63,7 +63,7 @@ WhisperSync uses a **3-tier diarization cascade** for stereo recordings (mic + s
 - Used for mono recordings (single-channel mic, no loopback)
 - Standard PyAnnote diarization on the raw audio
 
-The cascade selects the highest-confidence tier automatically. Stereo recordings almost always resolve at Tier 1 because channel separation provides a strong speaker signal without relying on voice embeddings.
+The cascade falls through in the configured order (`diarize_primary` > `diarize_fallback` > `diarize_last_resort`, default balanced_mix > per_channel > raw_audio). Channel separation provides a strong speaker signal without relying on voice embeddings.
 
 ---
 
@@ -88,6 +88,13 @@ WhisperSync includes an agentic governance system that improves its own developm
 
 For the full design, see [docs/specs/2026-03-24-governance-learning-loop-design.md](docs/specs/2026-03-24-governance-learning-loop-design.md).
 
+## For Contributors
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) - branch naming, the PR pipeline (Copilot review + CI test gate + auto-merge), commit format
+- [docs/development.md](docs/development.md) - setup, debugging, running the test suites
+- [docs/testing.md](docs/testing.md) - the single testing entry point: automated suites, manual checklist, where results are recorded
+- [docs/plans/2026-07-03-hardening-round.md](docs/plans/2026-07-03-hardening-round.md) - current project state (the stability rebuild that preceded it: [docs/plans/2026-05-11-stability-rebuild.md](docs/plans/2026-05-11-stability-rebuild.md))
+
 ---
 
 ## System Requirements
@@ -95,7 +102,7 @@ For the full design, see [docs/specs/2026-03-24-governance-learning-loop-design.
 | Requirement | Details |
 |-------------|---------|
 | **OS** | Windows 10 or 11 |
-| **Python** | 3.10 or newer (3.13 recommended) |
+| **Python** | 3.11 or newer (3.13 recommended) |
 | **GPU** | NVIDIA with CUDA support recommended (RTX 20/30/40/50 series, GTX 10-series). CPU-only mode available but 5-10x slower. |
 | **VRAM** | 2 GB minimum (tiny/base models), 4 GB+ recommended, 8 GB+ for large-v3 |
 | **Disk** | ~200 MB base install + model sizes (see table below) |
@@ -146,7 +153,7 @@ Speaker diarization requires a free Hugging Face token. Skip this for dictation-
 
 ### Tray Icon
 
-A dual-ring icon appears in your system tray. Inner circle = mic state, outer ring = speaker/loopback state.
+A three-ring icon appears in your system tray. Inner dot = overlay/backup dictation, inner circle = mic state, outer ring = speaker/loopback state (full table in .claude/rules/ui-patterns.md).
 
 | Inner Circle | State |
 |--------------|-------|
@@ -204,7 +211,7 @@ If a meeting fails mid-pipeline (for example the speaker confirmation dialog cra
 | **medium** | ~1.5 GB | ~0.7s | ~33s | ~4 GB |
 | **large-v3** | ~3 GB | ~1.2s | ~39s | ~8 GB |
 
-*Benchmarked on RTX 3090 with float16. Run `python -m whisper_sync.benchmark` to test your hardware.*
+*Benchmarked 2026-03 on RTX 3090 with float16; figures are indicative, not current. Run `python -m whisper_sync.benchmark` to measure your hardware.*
 
 ---
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -19,7 +19,7 @@ Everything below is for developers modifying this app or for an AI assistant (li
 | `config.py` | **Config manager.** Loads `config.defaults.json`, deep-merges with user `config.json` overrides. | `load()` returns merged dict; `save(overrides)` writes config.json |
 | `paths.py` | **Path resolver.** Repo mode path resolution, model cache dir, output dir. | `get_install_root()`, `get_model_cache()`, `get_default_output_dir()` |
 | `model_status.py` | **Model management.** Download, cache validation, bootstrap (auto-download tiny+base, prompt for larger). | `get_model_status(name)` returns bool; `download_model(name)` downloads to HF cache; `bootstrap_models(config)` -- first-run setup |
-| `icons.py` | **Tray icon generator.** Creates colored 64x64 PNG circles with labels. No external assets needed. | `_circle_icon(color, label)` returns PIL Image |
+| `icons.py` | **Tray icon generator.** Declarative ICON_REGISTRY of IconSpec entries rendered by `build_icon()`; three-ring composition + IconAnimator (scheduler-driven flashes). No external assets needed. | `build_icon(ICON_REGISTRY[key])` returns PIL Image |
 | `paste.py` | **Text output.** Routes transcribed text to clipboard+Ctrl+V or simulated keystrokes. | `paste(text, method)`, `paste_clipboard(text)`, `paste_keystrokes(text)` |
 | `flatten.py` | **Transcript converter.** JSON to readable speaker-attributed text (~90% token reduction). | `flatten(transcript_path)` writes `transcript-readable.txt`; `PAUSE_THRESHOLD = 2.0` seconds |
 | `dictation_log.py` | **Dictation history.** Appends entries to daily markdown log files. | `append(text, duration)` writes to `<output_dir>/.whispersync/dictation-logs/YYYY-MM-DD.md` |

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 | Requirement | Details |
 |-------------|---------|
-| **Python** | 3.11 or newer (3.13 recommended) |
+| **Python** | 3.10 or newer (3.13 recommended) |
 | **NVIDIA GPU** | With CUDA support (RTX 20/30/40/50 series, GTX 10-series) |
 | **NVIDIA Drivers** | Up to date -- run `nvidia-smi` to verify |
 | **Git** | For cloning and contributing |

--- a/docs/plans/2026-03-20-automated-dev-pipeline.md
+++ b/docs/plans/2026-03-20-automated-dev-pipeline.md
@@ -1,5 +1,7 @@
 # WhisperSync Automated Development Pipeline
 
+> Status: SHIPPED (2026-03; review-pr.yml, auto-merge.yml, governance-analysis.yml, review-logger.yml). Checklist below is historical; the live process is documented in CONTRIBUTING.md.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build an automated bug-report → fix → review → merge pipeline for WhisperSync using GitHub Actions, GitHub CLI, and AI agents.

--- a/docs/plans/2026-03-20-github-status-in-tray.md
+++ b/docs/plans/2026-03-20-github-status-in-tray.md
@@ -1,5 +1,7 @@
 # GitHub Status in WhisperSync Tray — Feature Spec
 
+> Status: SHIPPED (2026-03; github_status.py + tray menu integration).
+
 **Goal:** Surface GitHub PR status (reviews, suggestions, auto-merges) directly in the WhisperSync tray icon without leaving the app or checking GitHub.
 
 ## Architecture

--- a/docs/plans/2026-03-24-backup-dictation-icons.md
+++ b/docs/plans/2026-03-24-backup-dictation-icons.md
@@ -1,0 +1,359 @@
+# Backup Dictation, Device Management, and Icon Redesign - Implementation Plan
+
+> Status: SHIPPED (2026-03; three-ring inner dot, icons.py). Committed 2026-07-03 (previously an untracked draft).
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix VRAM doubling during meeting dictation, add hotkey debounce with yellow flash, redesign tray icon to three concentric rings, fix device label bug.
+
+**Architecture:** The backup model always runs on CPU (config default changed from "auto" to "cpu"). Pre-loads when meeting starts via background thread. Icon uses outer ring (speaker) + middle circle (mic/status) + optional inner dot (dictation overlay). Yellow double-flash (150ms on/off/on) is the universal loading signal.
+
+**Tech Stack:** Python 3.13, PIL/Pillow, pystray, faster-whisper, numpy
+
+**Spec:** `docs/specs/2026-03-24-backup-dictation-icons-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `whisper_sync/backup_worker.py` | Modify | Remove _resolve_device() auto logic, force CPU, add preload() and is_loading |
+| `whisper_sync/__main__.py` | Modify | Pre-load on meeting start, debounce hotkey, yellow flash, fix device label |
+| `whisper_sync/icons.py` | Modify | Three-ring icon with outer/middle/inner dot geometry |
+| `whisper_sync/config.defaults.json` | Modify | Change backup_device default to "cpu" |
+| `.claude/rules/audio-pipeline.md` | Modify | Document backup lifecycle |
+| `.claude/rules/ui-patterns.md` | Modify | Document three-ring states, yellow flash |
+| `.claude/rules/testing.md` | Modify | Add backup dictation test checklist |
+
+---
+
+### Task 1: Force backup model to CPU
+
+**Files:**
+- Modify: `whisper_sync/backup_worker.py:118-166`
+- Modify: `whisper_sync/config.defaults.json`
+
+- [ ] **Step 1: Change config default**
+
+In `config.defaults.json`, change `"backup_device": "auto"` to `"backup_device": "cpu"`.
+
+- [ ] **Step 2: Simplify _resolve_device()**
+
+Replace the entire `_resolve_device()` method (lines 118-166) with:
+
+```python
+def _resolve_device(self) -> str:
+    """Determine device for backup model. Always CPU unless explicitly overridden."""
+    backup_device = self.cfg.get("backup_device", "cpu")
+
+    if backup_device in ("gpu", "cuda"):
+        # Respect explicit GPU override but warn if main model is also on GPU
+        main_device = self.cfg.get("device", "auto")
+        if main_device != "cpu":
+            logger.warning("Backup model on GPU while main model also on GPU - may cause VRAM pressure")
+        return "cuda"
+
+    return "cpu"
+```
+
+- [ ] **Step 3: Verify no other code references the old auto logic**
+
+Search for `VRAM_THRESHOLD`, `MODEL_VRAM_GB` in backup_worker.py. If they exist only for `_resolve_device()`, remove the constants too.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add whisper_sync/backup_worker.py whisper_sync/config.defaults.json
+git commit -m "fix: force backup model to CPU, remove VRAM auto logic"
+```
+
+---
+
+### Task 2: Add preload() and is_loading to BackupTranscriber
+
+**Files:**
+- Modify: `whisper_sync/backup_worker.py`
+
+- [ ] **Step 1: Add _loading flag and is_loading property**
+
+After `__init__`, add:
+
+```python
+self._loading = False
+
+@property
+def is_loading(self) -> bool:
+    return self._loading
+```
+
+- [ ] **Step 2: Add preload() method**
+
+```python
+def preload(self):
+    """Pre-load backup model in background thread. Called when meeting starts."""
+    if self._model is not None or self._loading:
+        return  # already loaded or loading
+    import threading
+    def _do_preload():
+        self._loading = True
+        try:
+            self._load()
+        finally:
+            self._loading = False
+    threading.Thread(target=_do_preload, daemon=True, name="backup-preload").start()
+```
+
+- [ ] **Step 3: Update _load() log messages**
+
+Change "Backup worker spawned" to "Backup model loading" and "Backup worker ready" to "Backup model ready" (if not already done).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add whisper_sync/backup_worker.py
+git commit -m "feat: add preload() and is_loading to BackupTranscriber"
+```
+
+---
+
+### Task 3: Pre-load backup on meeting start + debounce hotkey
+
+**Files:**
+- Modify: `whisper_sync/__main__.py:269-290` (toggle_dictation)
+- Modify: `whisper_sync/__main__.py:732+` (_start_meeting)
+
+- [ ] **Step 1: Add preload call to _start_meeting()**
+
+In `_start_meeting()` (line 732), after the meeting recording setup, add:
+
+```python
+# Pre-load backup model for dictation during meeting
+if self.cfg.get("always_available_dictation", True):
+    self._backup.preload()
+```
+
+- [ ] **Step 2: Add debounce check to toggle_dictation()**
+
+In `toggle_dictation()` (line 269), inside the meeting state branch, before `_start_overlay_dictation()`, add:
+
+```python
+if self._backup.is_loading:
+    logger.debug("Backup model still loading, triggering yellow flash")
+    self._yellow_flash()
+    return
+```
+
+- [ ] **Step 3: Implement _yellow_flash() method**
+
+Add to WhisperSync class:
+
+```python
+def _yellow_flash(self):
+    """Universal loading/queuing signal: two quick yellow flashes."""
+    import threading
+    def _flash():
+        from .icons import yellow_flash_icon
+        original = self.tray.icon
+        for _ in range(2):
+            self.tray.icon = yellow_flash_icon()
+            import time; time.sleep(0.15)
+            self.tray.icon = original
+            time.sleep(0.15)
+    threading.Thread(target=_flash, daemon=True).start()
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add whisper_sync/__main__.py
+git commit -m "feat: pre-load backup on meeting start, debounce with yellow flash"
+```
+
+---
+
+### Task 4: Fix device label bug
+
+**Files:**
+- Modify: `whisper_sync/__main__.py:2429+` (_get_device_label)
+
+- [ ] **Step 1: Fix _get_device_label()**
+
+Find `_get_device_label()` (line 2429). Update it to show the resolved active device, not always the GPU name:
+
+```python
+def _get_device_label(self) -> str:
+    device_setting = self.cfg.get("device", "auto")
+    if device_setting == "cpu":
+        return "CPU"
+    elif device_setting in ("gpu", "cuda"):
+        gpu_name = get_gpu_name()
+        return gpu_name if gpu_name else "GPU"
+    else:  # auto
+        gpu_name = get_gpu_name()
+        if gpu_name:
+            return f"Auto ({gpu_name})"
+        return "Auto (CPU)"
+```
+
+- [ ] **Step 2: Verify the Settings menu reflects the fix**
+
+Check that wherever `_get_device_label()` is called in menu building, it uses the updated method.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add whisper_sync/__main__.py
+git commit -m "fix: device label shows active device, not always GPU"
+```
+
+---
+
+### Task 5: Three-ring icon with inner dot
+
+**Files:**
+- Modify: `whisper_sync/icons.py`
+
+- [ ] **Step 1: Replace _make_dual_icon with _make_three_ring_icon**
+
+Replace `_make_dual_icon()` (line 23) with:
+
+```python
+def _make_three_ring_icon(outer_color: str, middle_color: str,
+                          inner_color: str | None = None, size: int = 64) -> Image.Image:
+    """Generate icon with outer ring + middle filled circle + optional inner dot.
+
+    - Outer ring: 3px wide, 2px margin
+    - Gap: 2px transparent
+    - Middle circle: filled, remaining space
+    - Inner dot: ~4px radius, centered (only for overlay dictation)
+    """
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    margin = 2
+    ring_width = 3
+    gap = 2
+
+    # Outer ring
+    outer_r = size - margin
+    draw.ellipse([margin, margin, outer_r - 1, outer_r - 1], fill=outer_color)
+    inner_of_ring = margin + ring_width
+    draw.ellipse(
+        [inner_of_ring, inner_of_ring,
+         outer_r - 1 - ring_width, outer_r - 1 - ring_width],
+        fill=(0, 0, 0, 0),
+    )
+
+    # Middle filled circle (after gap)
+    mid_start = margin + ring_width + gap
+    mid_end = size - margin - ring_width - gap
+    if mid_end > mid_start:
+        draw.ellipse([mid_start, mid_start, mid_end - 1, mid_end - 1], fill=middle_color)
+
+    # Inner dot (overlay dictation indicator)
+    if inner_color is not None:
+        dot_radius = 4
+        cx, cy = size // 2, size // 2
+        draw.ellipse(
+            [cx - dot_radius, cy - dot_radius, cx + dot_radius, cy + dot_radius],
+            fill=inner_color,
+        )
+
+    return img
+```
+
+- [ ] **Step 2: Add yellow_flash_icon function**
+
+```python
+def yellow_flash_icon(size: int = 64) -> Image.Image:
+    return _make_three_ring_icon("#FFCC00", "#FFCC00", size=size)
+```
+
+- [ ] **Step 3: Update all public icon functions**
+
+Update each function to use `_make_three_ring_icon()` with the color states from the spec table. Example:
+
+```python
+def recording_icon(speaker_ok: bool = True, size: int = 64) -> Image.Image:
+    outer = "#CC3333" if speaker_ok else "#FFAA00"
+    return _make_three_ring_icon(outer, "#FF4444", size=size)
+
+def dictation_during_recording_icon(speaker_ok: bool = True, size: int = 64) -> Image.Image:
+    outer = "#CC3333" if speaker_ok else "#FFAA00"
+    return _make_three_ring_icon(outer, "#FF4444", inner_color="#4488FF", size=size)
+```
+
+Apply the same pattern for all 11 public functions per the spec color table.
+
+- [ ] **Step 4: Remove old _make_dual_icon and _make_overlay_icon**
+
+Delete `_make_dual_icon()` and `_make_overlay_icon()`. Update `_circle_icon()` legacy wrapper to use `_make_three_ring_icon(color, color)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add whisper_sync/icons.py
+git commit -m "feat: three-ring icon with outer/middle/inner dot"
+```
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `.claude/rules/audio-pipeline.md`
+- Modify: `.claude/rules/ui-patterns.md`
+- Modify: `.claude/rules/testing.md`
+
+- [ ] **Step 1: Update audio-pipeline.md**
+
+Add section on backup model lifecycle:
+- Pre-loads on meeting start (background thread, CPU)
+- Stays in memory until app closes
+- backup_device always CPU unless explicitly overridden
+- Backup model tiers by VRAM (tiny/base/small table)
+
+- [ ] **Step 2: Update ui-patterns.md**
+
+Add:
+- Three-ring icon geometry and color state table
+- Yellow double-flash convention (150ms on/off/on)
+- Inner dot = overlay dictation only
+
+- [ ] **Step 3: Update testing.md**
+
+Add backup dictation test checklist:
+- Start meeting, press Ctrl+Shift+Space, verify dictation works on CPU
+- Verify meeting recording continues uninterrupted
+- Verify yellow flash on rapid hotkey presses during model load
+- Verify device label shows correct device in Settings
+- Verify icon shows three rings during meeting + dictation
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/rules/
+git commit -m "docs: update rules for backup dictation, icons, yellow flash"
+```
+
+---
+
+### Task 7: Create PR and verify
+
+- [ ] **Step 1: Push branch and create PR**
+
+```bash
+git push -u origin fix/backup-vram-debounce-icon
+gh pr create --base dev --title "fix: backup dictation VRAM, debounce, three-ring icon" --body "..."
+```
+
+- [ ] **Step 2: Wait for Copilot review**
+
+Check with `gh pr view <number> --json reviews`
+
+- [ ] **Step 3: Address any Copilot suggestions**
+
+Fix and push. Repeat until clean review.
+
+- [ ] **Step 4: Verify auto-merge or merge manually**

--- a/docs/plans/2026-03-24-backup-subprocess.md
+++ b/docs/plans/2026-03-24-backup-subprocess.md
@@ -1,0 +1,211 @@
+# Backup Dictation Subprocess Implementation Plan
+
+> Status: SHIPPED (2026-03; backup_worker.py, always-available dictation). Committed 2026-07-03 (previously an untracked draft).
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the crashing in-process BackupTranscriber with a subprocess-based worker that can safely load CTranslate2 models.
+
+**Architecture:** Spawn a second TranscriptionWorker subprocess (CPU, small model) on first meeting start. The backup worker uses the same worker_main entry point and queue protocol as the primary worker. Main process never imports torch/CTranslate2.
+
+**Tech Stack:** Python multiprocessing (spawn context), existing TranscriptionWorker, existing worker_main
+
+**Spec:** `docs/specs/2026-03-24-backup-subprocess-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `whisper_sync/backup_worker.py` | Rewrite | BackupTranscriber wraps TranscriptionWorker for CPU |
+| `whisper_sync/__main__.py` | Modify | Wire overlay dictation to backup subprocess |
+
+No changes to `worker_manager.py` or `worker.py`.
+
+---
+
+### Task 1: Rewrite BackupTranscriber as subprocess wrapper
+
+**Files:**
+- Rewrite: `whisper_sync/backup_worker.py`
+
+- [ ] **Step 1: Replace BackupTranscriber class**
+
+Replace the entire class with:
+
+```python
+"""Backup transcription worker for dictation during meetings.
+
+Spawns a second TranscriptionWorker subprocess on CPU with a smaller model.
+The subprocess uses the same worker_main entry point as the primary worker.
+Main process never imports torch/CTranslate2 (avoids segfaults).
+"""
+
+import threading
+
+import numpy as np
+
+from .logger import logger
+from . import config
+
+
+class BackupTranscriber:
+    """Manages a backup transcription subprocess for dictation during meetings.
+
+    Spawned on first meeting start. Stays alive until app closes.
+    Uses TranscriptionWorker (same as primary) but configured for CPU.
+    """
+
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self._worker = None
+        self._spawning = False
+        self._spawn_lock = threading.Lock()
+
+    def preload(self):
+        """Spawn backup subprocess and pre-load model. Called on meeting start.
+
+        Idempotent: does nothing if already spawned or spawning.
+        Runs spawn in a background thread so it doesn't block meeting start.
+        """
+        if self._worker is not None or self._spawning:
+            return
+
+        def _do_spawn():
+            with self._spawn_lock:
+                if self._worker is not None:
+                    return
+                self._spawning = True
+                try:
+                    from .worker_manager import TranscriptionWorker
+
+                    backup_model = self.cfg.get("backup_model", "base")
+                    backup_cfg = {**self.cfg}
+                    backup_cfg["device"] = "cpu"
+                    backup_cfg["model"] = backup_model
+                    backup_cfg["compute_type"] = "int8"
+
+                    logger.info(f"Spawning backup worker (CPU, {backup_model})...")
+                    worker = TranscriptionWorker(backup_cfg, preload_model=backup_model)
+                    worker.start()
+
+                    if worker.wait_ready(timeout=30):
+                        self._worker = worker
+                        logger.info(f"Backup worker ready (CPU, {backup_model})")
+                    else:
+                        logger.warning("Backup worker failed to start within 30s")
+                        worker.stop()
+                finally:
+                    self._spawning = False
+
+        threading.Thread(target=_do_spawn, daemon=True, name="backup-spawn").start()
+
+    @property
+    def is_loading(self) -> bool:
+        """True while subprocess is spawning or model is loading."""
+        return self._spawning
+
+    @property
+    def is_ready(self) -> bool:
+        """True when backup worker is alive and model is loaded."""
+        return self._worker is not None and self._worker.is_ready()
+
+    def transcribe(self, audio_np: np.ndarray) -> str:
+        """Transcribe audio using the backup subprocess.
+
+        Sends a transcribe_fast request to the backup worker.
+        Raises RuntimeError if backup worker is not available.
+        """
+        if self._worker is None:
+            raise RuntimeError("Backup worker not started")
+        if not self._worker.is_ready():
+            raise RuntimeError("Backup worker not ready")
+
+        return self._worker.transcribe_fast(audio_np)
+
+    def stop(self):
+        """Shut down the backup subprocess."""
+        if self._worker is not None:
+            logger.info("Stopping backup worker...")
+            self._worker.stop()
+            self._worker = None
+
+    @staticmethod
+    def is_enabled(cfg: dict = None) -> bool:
+        """Check if always-available dictation is enabled."""
+        if cfg is None:
+            cfg = config.load()
+        return cfg.get("always_available_dictation", True)
+```
+
+- [ ] **Step 2: Remove old imports and constants**
+
+Remove any remaining `MODEL_VRAM_GB`, `VRAM_THRESHOLD`, `get_vram_warning`, `faster_whisper`, or `whisperx` imports that are no longer needed. The backup_worker.py should only import from `.logger`, `.config`, `.worker_manager`, `threading`, and `numpy`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add whisper_sync/backup_worker.py
+git commit -m "feat: rewrite BackupTranscriber as subprocess wrapper"
+```
+
+---
+
+### Task 2: Wire overlay dictation to backup subprocess
+
+**Files:**
+- Modify: `whisper_sync/__main__.py`
+
+- [ ] **Step 1: Update _stop_overlay_dictation to use subprocess**
+
+Find `_stop_overlay_dictation()`. The current code calls `self._backup.transcribe(audio_np)` which was the in-process call. This should now work unchanged because the new `BackupTranscriber.transcribe()` delegates to the subprocess. But verify:
+
+1. The audio_np is passed correctly (float32 or int16)
+2. The fallback path (when backup fails) still works - it should queue on the primary worker
+3. The `RuntimeError` from `transcribe()` is caught and triggers the fallback
+
+If the fallback catch is missing, add:
+
+```python
+try:
+    text = self._backup.transcribe(audio_np)
+except Exception as e:
+    logger.warning(f"Backup transcription failed, falling back to primary: {e}")
+    # Queue on primary worker instead
+    text = self._worker.transcribe_fast(audio_np)
+```
+
+- [ ] **Step 2: Verify preload call in _start_meeting**
+
+Confirm that `_start_meeting()` still calls `self._backup.preload()`. This was added in the previous PR and should still be there.
+
+- [ ] **Step 3: Verify debounce in toggle_dictation**
+
+Confirm that `toggle_dictation()` checks `self._backup.is_loading` before starting overlay dictation. This was added in the previous PR.
+
+- [ ] **Step 4: Update app shutdown**
+
+Find the app shutdown/cleanup code. Add `self._backup.stop()` to ensure the backup subprocess is terminated on app close. Look for where `self._worker.stop()` is called (primary worker shutdown) and add the backup stop nearby.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add whisper_sync/__main__.py
+git commit -m "feat: wire overlay dictation to backup subprocess"
+```
+
+---
+
+### Task 3: Push PR and verify
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+git push -u origin fix/backup-vram-debounce-icon
+gh pr create --base dev --title "feat: backup dictation via subprocess (fixes segfault)" --body "..."
+```
+
+- [ ] **Step 2: Wait for Copilot review, address suggestions**
+
+- [ ] **Step 3: Verify merge**

--- a/docs/plans/2026-04-02-speaker-fingerprinting.md
+++ b/docs/plans/2026-04-02-speaker-fingerprinting.md
@@ -1,5 +1,7 @@
 # Speaker Fingerprinting Pipeline - Implementation Plan
 
+> Status: PARKED (app integration deferred until voice profiles are validated; branch feat/speaker-fingerprinting holds the exploration).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build a speaker fingerprinting system that extracts timing/vocabulary metrics from transcripts, uses Sonnet for matching with a 95% confidence gate, and auto-escalates to Opus for deep analysis with persistent profile updates.

--- a/docs/plans/2026-05-11-stability-rebuild.md
+++ b/docs/plans/2026-05-11-stability-rebuild.md
@@ -1,8 +1,29 @@
 # WhisperSync Stability Rebuild — Architecture Review and Plan
 
-> Status: ACTIVE. This document persists context across Claude sessions.
-> Each implementation session appends to the Progress Log at the bottom.
+> Status: COMPLETE (all six phases shipped as PRs #137-#152; pipeline
+> fix #147; docs #145/#148/#151/#153/#154). This document persists
+> context across Claude sessions; the Progress Log at the bottom is the
+> historical record. Successor effort: docs/plans/2026-07-03-hardening-round.md.
 > Written 2026-05-11 after a full read of the runtime codebase (~8k lines).
+
+## Phase status (final)
+
+| Phase | Scope | Landed |
+|-------|-------|--------|
+| 1 | Scheduler, executors, idle GC | #137 |
+| 1b | Ephemeral thread migration | #150, #152 |
+| 2 | Debounced tray menu refresh | #138 |
+| 3 | Persistent Tk root (dialog churn) | #142 |
+| 4 | Memory: speaker disk streaming, RSS heartbeat, dictation cap | #139, #141 |
+| 5 | State: try_transition, SessionStats, ConfigStore | #144, #149 |
+| 6 | Single-reader worker protocol | #146 |
+
+## Open - awaiting production evidence
+
+The five-signal production validation checklist (see the final Progress
+Log entry) is still unfilled: it needs results from the UPDATED running
+app (tray > Settings > Update > Labs/dev > restart). Record findings in
+the Progress Log or the hardening-round doc.
 
 ## 1. What this app is
 

--- a/docs/specs/2026-03-24-backup-dictation-icons-design.md
+++ b/docs/specs/2026-03-24-backup-dictation-icons-design.md
@@ -1,0 +1,117 @@
+# Backup Dictation, Device Management, and Icon Redesign
+
+> Status: SHIPPED (2026-03; icons.py ICON_REGISTRY). Committed 2026-07-03 (previously an untracked draft).
+
+> **Date**: 2026-03-24
+> **Status**: Approved
+> **Scope**: Fix VRAM doubling, add debounce, redesign tray icon, fix device label bug
+
+## 1. Backup Model Defaults
+
+Backup model always runs on CPU. Auto-detection based on GPU VRAM sets the default backup model during install:
+
+| GPU VRAM | Default backup_model | backup_device |
+|----------|---------------------|---------------|
+| No GPU | base | cpu |
+| < 8 GB | tiny | cpu |
+| 8-12 GB | small | cpu |
+| 13-24 GB | small | cpu |
+| 24+ GB | small | cpu |
+
+User can override both settings manually. If user explicitly sets backup_device to gpu, respect it but log a warning when main model is also on GPU.
+
+**Config change**: `config.defaults.json` changes `backup_device` from `"auto"` to `"cpu"`. The `_resolve_device()` auto logic is removed - backup always returns CPU unless explicitly overridden. The installer writes `backup_model` to user config based on detected VRAM tier. `config.defaults.json` ships `"base"` as safe universal default.
+
+## 2. Backup Model Lifecycle
+
+### Pre-load on meeting start (Option C)
+1. Meeting recording starts
+2. Background thread loads backup model (small on CPU, ~1s)
+3. Model stays in memory until app closes (no unload timer - 500 MB RAM is negligible, SSD reads are free, 1s reload not worth timer complexity)
+
+**Implementation**: `_start_meeting()` calls `self._backup.preload()` (new method). Preload spawns a background thread, sets `_backup_loading=True`, loads model, sets `_backup_loading=False` when done.
+
+### Hotkey behavior during meeting
+- Model loaded: transcribe immediately (~2s for 20s clip on CPU)
+- Model still loading: yellow double-flash icon (150ms on, 150ms off, 150ms on). Ignore additional presses until ready.
+- always_available_dictation disabled: log info, ignore press
+
+### Debounce
+- `_backup_loading` flag: True during model load, checked before accepting hotkey
+- No timer-based debounce needed, flag is sufficient
+
+## 3. Primary Model Merging
+
+### Rule
+Dictation and meeting share one primary model instance. If dictation_model and model (meeting) are the same, one loaded instance serves both. If they differ, meeting model takes priority during active meetings.
+
+The backup model is always separate. Never shares with primary.
+
+### Device switch lifecycle
+1. User changes device in Settings (e.g., GPU to CPU)
+2. Current primary model unloads (torch.cuda.empty_cache if leaving GPU)
+3. New model loads on new device
+4. Same model name = no re-download, just re-initialize on new device
+5. During idle: switch immediately
+6. During meeting recording: queue switch, apply after meeting ends
+
+### Bug fix: device label
+Auto label in Settings shows GPU name even when CPU is selected. Fix: show the active resolved device, not the detected GPU. CPU selected = show "CPU". Auto selected = show resolved device name.
+
+## 4. Yellow Double-Flash Convention
+
+Universal "loading/queuing" signal across the app:
+- Two quick flashes: 150ms yellow on, 150ms off, 150ms yellow on
+- Full icon turns yellow (all rings)
+- Used for: backup model loading, device switching in progress, any async user-triggered operation
+- After flash completes, icon returns to current state
+
+## 5. Three Concentric Ring Icon
+
+### Geometry (64x64 canvas)
+- Outer ring: 3px wide, starts at 2px margin from edge (radius 30 to 27)
+- Gap: 2px transparent
+- Middle circle: filled, remaining space (radius ~22, the standard inner circle from current dual-ring)
+- Inner dot: small filled circle, ~4px radius, centered (overlay dictation indicator only)
+
+Note: The current implementation's small blue dot already works visually at tray size. The main change is making the outer ring thicker (3px) so it's visible. The middle circle stays as the current "inner circle." This is an adjustment, not a full redesign.
+
+### Color states
+
+| State | Outer | Middle | Inner |
+|-------|-------|--------|-------|
+| Idle | gray (#808080) | gray (#808080) | none |
+| Meeting recording | dark red (#CC3333) | light red (#FF4444) | none |
+| Meeting + dictation overlay | dark red (#CC3333) | light red (#FF4444) | blue (#4488FF) |
+| Dictation only | gray (#CCCCCC) | blue (#4488FF) | none |
+| Transcribing meeting | dark amber (#CC8800) | light amber (#FFAA00) | none |
+| Transcribing + dictation overlay | dark amber (#CC8800) | light amber (#FFAA00) | blue (#4488FF) |
+| Done | green (#44CC44) | green (#66FF66) | none |
+| Yellow flash (loading) | yellow (#FFCC00) | yellow (#FFCC00) | none |
+| Speaker loopback fail | yellow (#FFAA00) | light red (#FF4444) | none |
+| Error | magenta (#CC44CC) | magenta (#FF66FF) | none |
+
+### Backward compatibility
+States without overlay dictation (idle, done, error, etc.) use outer + middle rings only. No inner dot. Visual is similar to current dual-ring.
+
+## 6. Benchmark Data (for defaults validation)
+
+Tested on RTX 3090 desktop (7800X3D CPU), 20-second speech clips, CPU int8:
+
+| Model | Avg transcribe time | Match vs large-v3 |
+|-------|--------------------|--------------------|
+| tiny | 0.37s | 88.9% |
+| base | 0.76s | 97.1% |
+| small | 1.96s | 98.4% |
+
+Small was chosen as default for 8+ GB systems because the 98.4% accuracy justifies the ~2s delay during meetings. Tiny is for constrained systems where speed matters more than accuracy.
+
+## 7. Documentation updates
+
+The following must be updated in the same PR:
+- CLAUDE.md: backup model architecture
+- .claude/rules/audio-pipeline.md: backup lifecycle, device switching
+- .claude/rules/ui-patterns.md: three-ring icon states, yellow flash convention
+- .claude/rules/testing.md: backup dictation test checklist
+- config.defaults.json: backup_model default
+- README.md: always-available dictation section

--- a/docs/specs/2026-03-24-backup-subprocess-design.md
+++ b/docs/specs/2026-03-24-backup-subprocess-design.md
@@ -1,0 +1,76 @@
+# Backup Dictation Subprocess Design
+
+> Status: SHIPPED (2026-03; backup_worker.py). Committed 2026-07-03 (previously an untracked draft).
+
+> **Date**: 2026-03-24
+> **Status**: Approved
+> **Scope**: Replace in-process BackupTranscriber with subprocess-based worker
+
+## Problem
+
+CTranslate2 cannot initialize in a process that already has a worker subprocess with its own CTranslate2 context. Both whisperx.load_model and faster_whisper.WhisperModel segfault when loaded in the main process. The backup model must run in its own subprocess.
+
+## Architecture
+
+```
+Main process (UI, hotkeys, tray - never imports torch/CTranslate2)
+  |
+  +-- Primary worker subprocess (GPU, large-v3, meetings + normal dictation)
+  |     request_queue / response_queue
+  |
+  +-- Backup worker subprocess (CPU, small, dictation-during-meeting only)
+        backup_request_queue / backup_response_queue
+        Spawned on first meeting start. Stays alive until app closes.
+```
+
+Both workers use the same `worker_main()` entry point from `worker.py`. The only difference is the config snapshot: backup gets `device=cpu`, `model=backup_model`, `compute_type=int8`.
+
+## Lifecycle
+
+1. App starts - only primary worker spawns
+2. First meeting starts - backup subprocess spawns, pre-loads backup model
+3. Dictation hotkey during meeting - request to backup worker queue
+4. Backup worker transcribes on CPU, returns text via response queue
+5. Meeting ends - backup worker stays alive
+6. Next meeting - backup worker already ready
+7. App closes - both workers shut down
+
+## File changes
+
+| File | Change |
+|------|--------|
+| `backup_worker.py` | Replace BackupTranscriber. New class wraps TranscriptionWorker configured for CPU. |
+| `__main__.py` | Overlay dictation sends transcribe_fast to backup worker via queue. |
+| `worker_manager.py` | No changes. Already supports configurable model/device. |
+| `worker.py` | No changes. Already handles transcribe_fast. |
+
+## BackupTranscriber rewrite
+
+Thin wrapper around TranscriptionWorker:
+
+- `preload()`: Spawn subprocess with CPU config, pre-load model. Idempotent.
+- `is_loading`: True while spawning or model loading in subprocess.
+- `transcribe(audio_np)`: Send transcribe_fast to subprocess, return text.
+- `stop()`: Shut down subprocess.
+
+Config snapshot for backup worker:
+- `device`: "cpu"
+- `model`: value of `backup_model` config (default "base")
+- `compute_type`: "int8"
+- All other config inherited from main config
+
+## Error handling
+
+- Backup worker crash: fall back to queueing on primary worker
+- Timeout (>10s): fall back to primary worker
+- Yellow flash during spawning/model load (existing)
+- `is_loading` checks both spawning flag and worker ready state
+
+## What this does NOT change
+
+- Primary worker architecture (unchanged)
+- worker.py / worker_main (unchanged)
+- TranscriptionWorker class (unchanged)
+- Icon behavior (unchanged, already implemented)
+- Yellow flash (unchanged, already implemented)
+- Debounce (unchanged, already implemented)

--- a/docs/specs/2026-03-24-governance-learning-loop-design.md
+++ b/docs/specs/2026-03-24-governance-learning-loop-design.md
@@ -1,0 +1,172 @@
+# Agentic Governance Learning Loop - Design Spec
+
+> Status: SHIPPED (2026-03; governance-analysis.yml + review-logger.yml + policy.yaml). Committed 2026-07-03 - this file was referenced by README but never committed.
+
+> **Date**: 2026-03-24
+> **Status**: Approved
+> **Scope**: WhisperSync repo (POC, generalizable to other repos)
+
+## Summary
+
+Every PR teaches the system. The system automatically proposes governance improvements based on what it learns. No human goes to GitHub. Everything flows through Claude Code conversations and automated agents.
+
+## Architecture
+
+### Governance Files (YAML - deterministic, machine-parsed)
+
+**`.github/governance/policy.yaml`** - Single file for all deterministic rules:
+
+```yaml
+merge_policy:
+  auto_merge_enabled: true
+  require_copilot_review: true
+  require_zero_suggestions: true
+  complexity_gates:
+    low: auto
+    medium: auto
+    high: auto  # learning mode
+
+review_thresholds:
+  complexity:
+    low_max_lines: 50
+    medium_max_lines: 200
+    high_above: 200
+
+path_protection:
+  - pattern: "whisper_sync/transcribe.py"
+    reason: "Core audio pipeline"
+    require: architecture_note
+  - pattern: "whisper_sync/worker.py"
+    reason: "Multiprocessing model"
+    require: architecture_note
+  - pattern: ".github/workflows/**"
+    reason: "CI/CD pipeline"
+    require: architecture_note
+  - pattern: ".github/governance/**"
+    reason: "Governance rules"
+    require: architecture_note
+
+analysis:
+  schedule: weekly
+  min_prs_for_analysis: 3
+  suggestion_categories:
+    - dead-code
+    - missing-function
+    - error-handling
+    - security
+    - style
+    - performance
+    - naming
+    - documentation
+```
+
+### Guidance Files (Markdown - interpretive, LLM-read)
+
+**`CLAUDE.md`** - Under 200 lines, high-level architecture and conventions
+
+**`.claude/rules/audio-pipeline.md`** - Audio processing rules:
+- How stereo recording works (mic ch0, loopback ch1)
+- Per-channel diarization architecture
+- Balanced mono fallback chain
+- Model loading and VRAM management
+
+**`.claude/rules/ui-patterns.md`** - Tray menu and dialog conventions:
+- Menu item ordering (Recent Dictations, Dictation, Meeting, Settings)
+- Right-aligned state labels
+- Pystray limitations (no colored dots, no split click/hover)
+- Dark theme for dialogs
+
+**`.claude/rules/testing.md`** - Verification approach:
+- Manual test checklist (dictation, meeting, device switch)
+- What to verify after each change category
+- How to restart and test from dev branch
+
+### Logging (JSONL - learning data)
+
+**`docs/review-log.jsonl`** - One line per merged PR, Qodo-style attribution:
+
+```json
+{
+  "pr": 54,
+  "title": "feat: per-channel transcription",
+  "complexity": "high",
+  "files": ["channel_merge.py", "transcribe.py"],
+  "lines_changed": 539,
+  "copilot": {
+    "reviewed": true,
+    "suggestions": [
+      {
+        "id": "s1",
+        "file": "transcribe.py",
+        "line": 559,
+        "category": "dead-code",
+        "body": "_per_channel_result set but never read",
+        "confidence": "low",
+        "resolution": "accepted",
+        "fix_commit": "67c970b"
+      }
+    ],
+    "suggestions_accepted": 3,
+    "suggestions_dismissed": 0
+  },
+  "push_cycles": 3,
+  "duration_minutes": 45,
+  "merge_method": "auto",
+  "protected_paths_touched": ["whisper_sync/transcribe.py"],
+  "outcome": "auto-merged"
+}
+```
+
+### Analysis Agent
+
+Runs weekly via GitHub Actions schedule (or on-demand via `/ws-analyze` skill).
+
+**Input**: review-log.jsonl + policy.yaml + CLAUDE.md + .claude/rules/*.md
+
+**Process**:
+1. Read all merged PRs since last analysis
+2. Categorize Copilot suggestions (real bugs vs noise)
+3. Calculate metrics (true positive rate, common categories, complexity correlation)
+4. Identify patterns (what guidance is missing, what rules are stale)
+5. Propose changes to governance files
+
+**Output**: A PR containing:
+- `docs/analysis/YYYY-MM-DD-review-analysis.md` (pattern report)
+- Diffs to `policy.yaml` (threshold adjustments)
+- Diffs to `CLAUDE.md` (guidance gaps)
+- New `.claude/rules/*.md` files (if domain rules emerge)
+- Explanation of each proposed change with data backing
+
+### Feedback Loop
+
+```
+Code -> PR -> Copilot reviews (reads CLAUDE.md + rules)
+  -> Auto-merge (reads policy.yaml)
+  -> Logged to review-log.jsonl
+
+Weekly:
+  -> Analysis agent reads log + current governance
+  -> Proposes governance PR
+  -> Copilot reviews the governance PR
+  -> Auto-merges
+  -> Next week's PRs use updated governance
+```
+
+## Implementation Order
+
+1. Create governance file structure (policy.yaml, rules/*.md)
+2. Update workflows to read from policy.yaml
+3. Fix review-logger to capture rich suggestion data (100% capture rate)
+4. Backfill missing PR entries in review-log.jsonl
+5. Trim CLAUDE.md to under 200 lines, move content to rules
+6. Create analysis agent workflow
+7. Create /ws-analyze skill for on-demand analysis
+8. Test end-to-end with next batch of PRs
+
+## Success Criteria
+
+- 100% PR capture rate in review-log.jsonl
+- Analysis agent produces actionable governance PRs
+- Copilot true positive rate improves over 4-week period
+- CLAUDE.md stays under 200 lines
+- No guardrail contradictions (drift detection)

--- a/docs/specs/2026-03-24-secondary-log-color-design.md
+++ b/docs/specs/2026-03-24-secondary-log-color-design.md
@@ -1,0 +1,30 @@
+# Secondary Log Color Design
+
+> Status: SHIPPED (2026-03; logger.py secondary color). Committed 2026-07-03 (previously an untracked draft).
+
+> **Date**: 2026-03-24
+> **Status**: Approved
+> **Scope**: Color-code backup/secondary log lines in light purple
+> **Issue**: #62
+
+## Design
+
+Add a `secondary` flag to log records. When set, the text portion renders in light purple (ANSI `\033[95m`) instead of white. This distinguishes backup/secondary subsystem operations from primary operations at a glance.
+
+## Changes
+
+### logger.py
+- Add `COLOR_SECONDARY = "\033[95m"` constant
+- In the formatter, check `getattr(record, "secondary", False)`. If True, use `COLOR_SECONDARY` for the text portion instead of white/default.
+
+### backup_worker.py
+- All `logger.*()` calls use `extra={"secondary": True}`
+
+### __main__.py
+- All overlay dictation log lines (in `_start_overlay_dictation`, `_stop_overlay_dictation`) use `extra={"secondary": True}`
+
+## What stays the same
+- Timestamps, [WhisperSync] prefix, and color coding for those elements are unchanged
+- Primary log lines stay white
+- All tiers affected equally (normal, detailed, verbose)
+- File log handler is unaffected (no ANSI in file logs)

--- a/docs/specs/2026-03-24-state-manager-design.md
+++ b/docs/specs/2026-03-24-state-manager-design.md
@@ -1,5 +1,7 @@
 # WhisperSync Notification & State Management System
 
+> Status: SHIPPED (2026-03; state_manager.py). Line counts and code excerpts below reflect the codebase at design time.
+
 > **Date**: 2026-03-24
 > **Status**: Design
 > **Repo**: `https://github.com/Pendentive/whisper-sync`

--- a/docs/specs/2026-04-02-speaker-fingerprinting-design.md
+++ b/docs/specs/2026-04-02-speaker-fingerprinting-design.md
@@ -1,5 +1,7 @@
 # Speaker Fingerprinting Pipeline
 
+> Status: PARKED (see the paired plan; deferred until profiles validated).
+
 > Issue: #114
 > Component: speaker-id
 > Date: 2026-04-02

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,39 @@
+# Testing - the single entry point
+
+Everything about verifying WhisperSync, in one place. If a doc and this
+page disagree, fix the other doc.
+
+## The suites
+
+| Suite | What | Where it runs | Command |
+|-------|------|---------------|---------|
+| System suite | 160+ tests: worker protocol, state, scheduler/executors, config store, GPU guard, instance guard, meeting pipeline, icons, notifications, heartbeat, lifecycle | **CI on every PR** (tests.yml; auto-merge requires it green on the head commit) and locally | see [development.md](development.md) "Running the Test Suites" |
+| Venv suite | 36 tests: audio capture (open ladder, downmix, speaker streaming) + real-data harness | Local only (needs numpy/scipy in whisper-env) | see development.md |
+| Real-data harness | `flatten()` reproduced byte-for-byte against real shipped meetings | Local only; discovers via `WS_MEETINGS_DIR`, skips cleanly when absent. **Private audio never enters this repo.** | part of the venv suite |
+| End-to-end | Production worker subprocess on the smallest real recording (~1 min) | Local, opt-in (`WS_E2E=1`); run after worker-protocol or pipeline changes | see development.md |
+| Manual checklist | Hardware-in-the-loop checks no automated test covers (real mic, hotkeys, tray, GPU) | Local, before releases and after audio/tray changes | [.claude/rules/testing.md](../.claude/rules/testing.md) |
+
+## Where results and decisions are recorded
+
+Test results and the decisions made on them live in the active plan
+doc's progress log - the pattern established by the stability rebuild:
+pass counts per session, bugs the suites caught, and what was decided.
+
+- Current: [plans/2026-07-03-hardening-round.md](plans/2026-07-03-hardening-round.md)
+- Historical: [plans/2026-05-11-stability-rebuild.md](plans/2026-05-11-stability-rebuild.md)
+  (its progress log records, e.g., the E2E harness catching the
+  stage_finalize zero-stats production bug, and per-phase pass counts)
+
+## Open validation work
+
+The stability rebuild's five-signal production validation checklist
+(final entry of its progress log) is awaiting evidence from the updated
+running app: clean exits, real meeting word counts, flat rss=NMB
+heartbeat, mic-array + dictation cap behavior, worker respawn recovery.
+
+## Benchmarks
+
+README's model table was measured 2026-03 on an RTX 3090 (float16) and
+is indicative only. Regenerate for your hardware with
+`python -m whisper_sync.benchmark`; if you update the README table,
+date-stamp it.

--- a/retranscribe_tier2.py
+++ b/retranscribe_tier2.py
@@ -46,32 +46,35 @@ def main():
 
     diarize_path = balanced_path or audio_path
 
-    # Step 2: Prepare (load models + audio)
-    print("[2/5] Loading models and preparing audio...")
-    ctx = transcribe.stage_prepare(diarize_path)
+    try:
+        # Step 2: Prepare (load models + audio). Transcription and
+        # alignment run on the ORIGINAL recording, matching the main
+        # pipeline; the balanced mono is only a diarization input.
+        print("[2/5] Loading models and preparing audio...")
+        ctx = transcribe.stage_prepare(audio_path)
 
-    # Step 3: Transcribe
-    print("[3/5] Transcribing (this is the longest step)...")
-    result = transcribe.stage_transcribe(ctx)
+        # Step 3: Transcribe
+        print("[3/5] Transcribing (this is the longest step)...")
+        result = transcribe.stage_transcribe(ctx)
 
-    # Step 4: Align
-    print("[4/5] Aligning word-level timestamps...")
-    result = transcribe.stage_align(ctx, result)
+        # Step 4: Align
+        print("[4/5] Aligning word-level timestamps...")
+        result = transcribe.stage_align(ctx, result)
 
-    # Step 5: Diarize with PyAnnote on the balanced mono
-    print("[5/5] Running PyAnnote diarization on balanced mono...")
-    with transcribe._lock:
-        pipeline = transcribe._load_diarize_pipeline()
-    diarize_result = pipeline(diarize_path)
+        # Step 5: Diarize with PyAnnote on the balanced mono
+        print("[5/5] Running PyAnnote diarization on balanced mono...")
+        with transcribe._lock:
+            pipeline = transcribe._load_diarize_pipeline()
+        diarize_result = pipeline(diarize_path)
 
-    # Assign speakers
-    import whisperx
-    result = whisperx.assign_word_speakers(diarize_result, result)
-
-    # Clean up temp balanced file
-    if balanced_path and os.path.exists(balanced_path):
-        os.unlink(balanced_path)
-        print(f"  Cleaned up temp file")
+        # Assign speakers
+        import whisperx
+        result = whisperx.assign_word_speakers(diarize_result, result)
+    finally:
+        # Clean up temp balanced file even when a stage raises
+        if balanced_path and os.path.exists(balanced_path):
+            os.unlink(balanced_path)
+            print("  Cleaned up temp file")
 
     # Save
     with open(output_path, "w") as f:

--- a/retranscribe_tier2.py
+++ b/retranscribe_tier2.py
@@ -1,0 +1,92 @@
+"""Re-transcribe a recording using forced Tier 2 (RMS-balanced mono + PyAnnote).
+
+Usage:
+    python retranscribe_tier2.py <path_to_recording.wav> [--output <path>]
+
+Saves transcript-tier2.json alongside the original recording if no --output given.
+"""
+
+import argparse
+import json
+import sys
+import os
+
+# Add whisper_sync package to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Force Tier 2 re-transcription")
+    parser.add_argument("audio", help="Path to recording.wav")
+    parser.add_argument("--output", help="Output JSON path (default: transcript-tier2.json next to input)")
+    args = parser.parse_args()
+
+    audio_path = os.path.normpath(args.audio)
+    if not os.path.exists(audio_path):
+        print(f"Error: {audio_path} not found")
+        sys.exit(1)
+
+    output_path = args.output or os.path.join(
+        os.path.dirname(audio_path), "transcript-tier2.json"
+    )
+
+    print(f"Audio: {audio_path}")
+    print(f"Output: {output_path}")
+    print()
+
+    from whisper_sync import transcribe
+
+    # Step 1: Create RMS-balanced mono
+    print("[1/5] Creating RMS-balanced mono mix...")
+    balanced_path = transcribe._create_balanced_mono(audio_path)
+    if balanced_path:
+        print(f"  Balanced mono saved to temp: {balanced_path}")
+    else:
+        print("  No balancing needed (mono input or identical channels), using original")
+
+    diarize_path = balanced_path or audio_path
+
+    # Step 2: Prepare (load models + audio)
+    print("[2/5] Loading models and preparing audio...")
+    ctx = transcribe.stage_prepare(diarize_path)
+
+    # Step 3: Transcribe
+    print("[3/5] Transcribing (this is the longest step)...")
+    result = transcribe.stage_transcribe(ctx)
+
+    # Step 4: Align
+    print("[4/5] Aligning word-level timestamps...")
+    result = transcribe.stage_align(ctx, result)
+
+    # Step 5: Diarize with PyAnnote on the balanced mono
+    print("[5/5] Running PyAnnote diarization on balanced mono...")
+    with transcribe._lock:
+        pipeline = transcribe._load_diarize_pipeline()
+    diarize_result = pipeline(diarize_path)
+
+    # Assign speakers
+    import whisperx
+    result = whisperx.assign_word_speakers(diarize_result, result)
+
+    # Clean up temp balanced file
+    if balanced_path and os.path.exists(balanced_path):
+        os.unlink(balanced_path)
+        print(f"  Cleaned up temp file")
+
+    # Save
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2, default=str)
+    print(f"\nDone! Saved to: {output_path}")
+
+    # Quick summary
+    from collections import Counter
+    segments = result.get("segments", [])
+    speaker_counts = Counter(seg.get("speaker", "UNKNOWN") for seg in segments)
+    print(f"\nSpeakers found: {len(speaker_counts)}")
+    for spk, count in sorted(speaker_counts.items()):
+        words = sum(len(seg.get("text", "").split()) for seg in segments if seg.get("speaker") == spk)
+        print(f"  {spk}: {count} segments, ~{words} words")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Hardening round items 11+10 (docs/specs/2026-07-03-testing-and-docs-cleanup.md T2-T4 + D1-D5)

From the 2026-07-03 full docs inventory. Everything here is documentation truth or navigation; no behavior changes.

**Truth**: three docs claimed no automated tests exist (178 run in CI); README's dual-ring icon, inverted diarization order, broken spec link, python-floor drift; stale speaker-ID timeout, icons API, menu-refresh wording; benchmark table now date-stamped.

**Navigation**: README For Contributors section; docs/testing.md as the single testing entry point; stability plan header COMPLETE + phase table + explicit open-work section (it said ACTIVE while its own log said COMPLETE).

**Stragglers**: six never-committed draft docs committed with SHIPPED stamps (one was README-linked and 404ed on fresh clones), three shipped plans/specs stamped, fingerprinting pair stamped PARKED, retranscribe_tier2.py recovery utility committed, .standalone gitignored.