### PR TITLE
feat: suspend/resume awareness with worker recovery

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -150,6 +150,10 @@ Override with `"batch_size": 8` in `config.json`. Set `"batch_size": "auto"` to 
 
 `gpu_guard.py` polls device-wide free VRAM (providers in `vram_probe.py`: pynvml if installed, else nvidia-smi; a new GPU vendor is a new provider function, nothing else changes). Below `gpu_guard_low_vram_mb` free (default 750), one downgrade step is armed for the NEXT transcription; worker crashes escalate immediately. The downgrade ladder (`gpu_guard_ladder`, default large-v3 > medium > small > base) is sticky for the session and never upgrades a caller that asked for a smaller model. Every event (arm, recovery, floor, probe-unavailable) appends a timestamped JSON line to `<data_dir>/gpu-guard.jsonl` - the artifact for correlating GPU pressure with Windows crash/BSOD times, and the machine-readable surface for external tooling. Master toggle: `gpu_guard` (default true); disabled or no-provider means fully inert.
 
+### Suspend/Resume Handling
+
+`power_events.py` registers for system suspend/resume notifications (RegisterSuspendResumeNotification, callback-based - broadcasts never reach message-only windows). Both transitions are appended to `gpu-guard.jsonl` for crash-time correlation; on resume the app verifies the worker subprocess survived sleep and restarts it with a toast if not.
+
 ### Meeting Recording -- Disk-Only Audio
 
 Meeting recordings use **disk-only** audio capture for the mic channel. The mic callback streams audio to a WAV file on disk in real-time and does NOT accumulate audio in RAM (controlled by the `disk_only` flag in `start_streaming()`). The speaker loopback channel, however, still accumulates audio in RAM via `_speaker_data` for resampling and stereo merging at stop time. Dictation mode uses RAM for both channels (recordings are short).

--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -13,10 +13,10 @@
 |---|------|------|--------|
 | 2 | In-app single-instance lock + orphan worker reaping | gpu-guard-spec B4 | MERGED (#156) |
 | 9 | CI runs the system test suite on every PR | testing-and-docs-cleanup T1 | MERGED (#157) |
-| 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | IN PIPELINE |
-| 3 | Sleep/resume power event handling | hardware-resilience H1 | PENDING |
-| 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | PENDING |
-| 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | PENDING |
+| 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | MERGED (#158) |
+| 3 | Sleep/resume power event handling | hardware-resilience H1 | IN PIPELINE |
+| 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | MERGED (#159) |
+| 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | MERGED (#159) |
 | 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | PENDING |
 | 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
 | 5 | Overlay dictation disk-first | hardware-resilience H3 | PENDING |
@@ -67,3 +67,21 @@ in one place, not a branching if/then system and not a framework.
   meeting pipeline worker crash. Model seam: effective_model() at the 6
   dictation_model computations and meeting_job step_transcribe
   (model_override). 17 tests. System suite 164; venv 36.
+
+- **2026-07-03 (item 1 merged, #158)**: review hardening: providerless
+  machines fully inert (crash triggers included), invalid ladder config
+  falls back to default instead of IndexError. 16 tests.
+
+- **2026-07-03 (items 11+10 merged, #159)**: docs truth/navigation pass
+  + docs/testing.md entry point; review caught a real quality bug in the
+  committed retranscribe utility (transcription must run on the ORIGINAL
+  recording, balanced mono is diarization-only) plus a temp-file leak;
+  python floor aligned to installer truth (3.10).
+
+- **2026-07-03 (item 3)**: power_events.py using
+  RegisterSuspendResumeNotification with DEVICE_NOTIFY_CALLBACK (a
+  message-only window would never receive WM_POWERBROADCAST - broadcasts
+  do not reach HWND_MESSAGE windows). Suspend and resume land in
+  gpu-guard.jsonl via GpuGuard.log_external_event (one correlation
+  timeline); resume verifies the worker survived sleep and restarts it
+  off-thread with a toast if not. Callbacks stay cheap on the OS thread.

--- a/tests/test_power_events.py
+++ b/tests/test_power_events.py
@@ -1,0 +1,69 @@
+"""Tests for whisper_sync.power_events - suspend/resume dispatch.
+
+Dispatch logic is driven directly through handle_power_event (no OS
+registration needed); the registration itself gets a real
+register/unregister roundtrip on Windows.
+"""
+
+import os
+import unittest
+
+from whisper_sync.power_events import (
+    PowerEventListener, PBT_APMSUSPEND, PBT_APMRESUMEAUTOMATIC,
+)
+
+PBT_APMRESUMESUSPEND = 0x0007
+
+
+class DispatchTests(unittest.TestCase):
+    def test_suspend_dispatches_on_suspend(self):
+        calls = []
+        l = PowerEventListener(on_suspend=lambda: calls.append("s"),
+                               on_resume=lambda: calls.append("r"))
+        l.handle_power_event(PBT_APMSUSPEND)
+        self.assertEqual(calls, ["s"])
+
+    def test_resume_automatic_dispatches_on_resume(self):
+        calls = []
+        l = PowerEventListener(on_resume=lambda: calls.append("r"))
+        l.handle_power_event(PBT_APMRESUMEAUTOMATIC)
+        self.assertEqual(calls, ["r"])
+
+    def test_resume_suspend_variant_not_double_dispatched(self):
+        # Windows fires RESUMEAUTOMATIC for every wake and RESUMESUSPEND
+        # additionally for user-present wake; only the former may
+        # dispatch or a user wake would run on_resume twice.
+        calls = []
+        l = PowerEventListener(on_resume=lambda: calls.append("r"))
+        l.handle_power_event(PBT_APMRESUMEAUTOMATIC)
+        l.handle_power_event(PBT_APMRESUMESUSPEND)
+        self.assertEqual(calls, ["r"])
+
+    def test_unknown_event_ignored_and_callback_exceptions_swallowed(self):
+        def _boom():
+            raise RuntimeError("boom")
+        l = PowerEventListener(on_suspend=_boom)
+        l.handle_power_event(0x9999)   # ignored
+        l.handle_power_event(PBT_APMSUSPEND)  # must not raise
+
+    def test_no_callbacks_is_fine(self):
+        PowerEventListener().handle_power_event(PBT_APMSUSPEND)
+
+
+class RegistrationTests(unittest.TestCase):
+    @unittest.skipUnless(os.name == "nt", "Windows-only registration")
+    def test_register_unregister_roundtrip(self):
+        l = PowerEventListener(on_suspend=lambda: None)
+        self.assertTrue(l.start(), "registration must succeed on Windows")
+        self.assertTrue(l.start(), "second start is an idempotent True")
+        l.stop()
+        l.stop()  # idempotent
+
+    def test_non_windows_start_is_noop_false(self):
+        from unittest import mock
+        with mock.patch.object(os, "name", "posix"):
+            self.assertFalse(PowerEventListener().start())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3814,6 +3814,12 @@ class WhisperSync:
         try:
             self.tray.run()
         finally:
+            # Unregister power notifications first: teardown must not
+            # race an OS callback firing into half-shutdown state.
+            try:
+                self._power_listener.stop()
+            except Exception:
+                logger.debug("power listener stop failed", exc_info=True)
             # Flush persistent stats before shutdown
             try:
                 self._stats_flush_stop.set()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3783,6 +3783,34 @@ class WhisperSync:
         from .scheduler import scheduler as _sched
         self._gpu_guard.start(_sched, IO)
 
+        # Suspend/resume awareness (hardware-resilience spec H1): both
+        # transitions land in gpu-guard.jsonl for crash-time correlation,
+        # and resume verifies the CUDA worker survived sleep, restarting
+        # it off-thread if not. Callbacks run on an OS thread: keep them
+        # to a log write + an IO offload.
+        from .power_events import PowerEventListener
+
+        def _on_suspend():
+            self._gpu_guard.log_external_event(
+                "system_suspend",
+                recording=self.recorder.is_recording,
+                transcribing=bool(self.state and self.state.current.meeting_transcribing),
+            )
+
+        def _on_resume():
+            def _check():
+                self._gpu_guard.log_external_event("system_resume")
+                if not self.worker.is_alive():
+                    logger.warning("Worker did not survive suspend/resume; restarting")
+                    self.worker.restart()
+                    notify("WhisperSync recovered",
+                           "Transcription engine restarted after sleep.")
+            submit_or_spawn(IO, "resume-check", _check)
+
+        self._power_listener = PowerEventListener(
+            on_suspend=_on_suspend, on_resume=_on_resume)
+        self._power_listener.start()
+
         try:
             self.tray.run()
         finally:

--- a/whisper_sync/gpu_guard.py
+++ b/whisper_sync/gpu_guard.py
@@ -189,6 +189,16 @@ class GpuGuard:
             return ladder[rung_index]
         return ladder[max(requested_index, rung_index)]
 
+    def log_external_event(self, event: str, **fields) -> None:
+        """Append a non-guard subsystem event to gpu-guard.jsonl.
+
+        Power transitions land here (hardware-resilience spec H1) so one
+        timeline holds everything needed to correlate GPU pressure and
+        sleep/wake against Windows crash times. Logged regardless of the
+        guard toggle - the timeline is diagnostic, not behavioral.
+        """
+        self._event(event, **fields)
+
     def status(self) -> dict:
         with self._lock:
             return {

--- a/whisper_sync/power_events.py
+++ b/whisper_sync/power_events.py
@@ -1,0 +1,129 @@
+"""System suspend/resume detection via RegisterSuspendResumeNotification.
+
+Before this module the app had no power-event handling at all: open
+PortAudio streams, a live CUDA context in the worker, and in-flight
+transcription all ran blindly across laptop suspend/resume - the single
+most plausible trigger moment for a GPU driver fault (2026-07-03
+hardware-resilience spec, H1).
+
+Mechanism: the Win8+ callback registration
+(``user32!RegisterSuspendResumeNotification`` with
+``DEVICE_NOTIFY_CALLBACK``). A message window would NOT work here -
+WM_POWERBROADCAST is a broadcast, and message-only (HWND_MESSAGE)
+windows never receive broadcasts - and a visible top-level window is
+unwanted in a tray app, so the callback registration is both the
+simplest and the correct mechanism.
+
+Dispatch:
+- ``on_suspend`` at PBT_APMSUSPEND (system is about to sleep)
+- ``on_resume`` at PBT_APMRESUMEAUTOMATIC (fires for every wake;
+  PBT_APMRESUMESUSPEND additionally fires only for user-present wake,
+  so dispatching only the AUTOMATIC one avoids double callbacks)
+
+Callbacks run ON AN OS CALLBACK THREAD and must be cheap; wiring
+offloads real work to the IO executor. Non-Windows: start() no-ops.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Callable, Optional
+
+from .logger import logger
+
+PBT_APMSUSPEND = 0x0004
+PBT_APMRESUMEAUTOMATIC = 0x0012
+DEVICE_NOTIFY_CALLBACK = 2
+
+
+class PowerEventListener:
+    """Suspend/resume notifications translated to python callbacks."""
+
+    def __init__(self, on_suspend: Optional[Callable[[], None]] = None,
+                 on_resume: Optional[Callable[[], None]] = None):
+        self._on_suspend = on_suspend
+        self._on_resume = on_resume
+        self._registration = None
+        self._callback_ref = None  # prevent GC of the ctypes callback
+        self._params_ref = None
+        self._lock = threading.Lock()
+
+    def handle_power_event(self, event_type: int) -> None:
+        """Route one power event. Separated from the OS callback so the
+        dispatch logic is unit-testable without registration."""
+        if event_type == PBT_APMSUSPEND:
+            logger.info("power events: system suspending")
+            if self._on_suspend:
+                try:
+                    self._on_suspend()
+                except Exception:
+                    logger.exception("power events: on_suspend raised")
+        elif event_type == PBT_APMRESUMEAUTOMATIC:
+            logger.info("power events: system resumed")
+            if self._on_resume:
+                try:
+                    self._on_resume()
+                except Exception:
+                    logger.exception("power events: on_resume raised")
+
+    def start(self) -> bool:
+        """Register for notifications. True when active. No-op elsewhere."""
+        if os.name != "nt":
+            return False
+        with self._lock:
+            if self._registration is not None:
+                return True
+            import ctypes
+            from ctypes import wintypes as w
+
+            user32 = ctypes.WinDLL("user32", use_last_error=True)
+
+            CBTYPE = ctypes.WINFUNCTYPE(
+                w.DWORD, ctypes.c_void_p, w.ULONG, ctypes.c_void_p
+            )
+
+            def _cb(context, event_type, setting):
+                try:
+                    self.handle_power_event(int(event_type))
+                except Exception:
+                    logger.exception("power events: callback raised")
+                return 0
+
+            class SUBSCRIBE_PARAMS(ctypes.Structure):
+                _fields_ = [("Callback", CBTYPE), ("Context", ctypes.c_void_p)]
+
+            self._callback_ref = CBTYPE(_cb)
+            self._params_ref = SUBSCRIBE_PARAMS(self._callback_ref, None)
+
+            user32.RegisterSuspendResumeNotification.restype = w.HANDLE
+            user32.RegisterSuspendResumeNotification.argtypes = (
+                ctypes.c_void_p, w.DWORD,
+            )
+            handle = user32.RegisterSuspendResumeNotification(
+                ctypes.byref(self._params_ref), DEVICE_NOTIFY_CALLBACK
+            )
+            if not handle:
+                logger.warning(
+                    f"power events: registration failed (err={ctypes.get_last_error()})"
+                )
+                self._callback_ref = None
+                self._params_ref = None
+                return False
+            self._registration = handle
+            logger.info("power events: suspend/resume notifications active")
+            return True
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._registration is None:
+                return
+            import ctypes
+            from ctypes import wintypes as w
+            user32 = ctypes.WinDLL("user32", use_last_error=True)
+            user32.UnregisterSuspendResumeNotification.restype = w.BOOL
+            user32.UnregisterSuspendResumeNotification.argtypes = (w.HANDLE,)
+            user32.UnregisterSuspendResumeNotification(self._registration)
+            self._registration = None
+            self._callback_ref = None
+            self._params_ref = None


### PR DESCRIPTION
## Hardening round item 3 (docs/specs/2026-07-03-hardware-resilience-spec.md H1)

No power-event handling existed: open PortAudio streams and the CUDA worker ran blindly across suspend/resume, the most plausible trigger moment for the driver fault this round hardens against.

- **power_events.py (new)**: RegisterSuspendResumeNotification + DEVICE_NOTIFY_CALLBACK. Architecture note: a message-only window cannot work (WM_POWERBROADCAST is a broadcast; HWND_MESSAGE windows never receive broadcasts), and a hidden top-level window is unwanted in a tray app - the Win8+ callback registration is both simplest and correct. Dispatches SUSPEND and RESUMEAUTOMATIC only (RESUMESUSPEND would double-fire user-present wakes).
- **Wiring**: both transitions append to gpu-guard.jsonl (GpuGuard.log_external_event, new) so ONE timeline correlates GPU pressure + sleep/wake against Windows crash times; resume runs an IO-offloaded worker liveness check and restarts a sleep-killed worker with a toast.
- Callbacks run on an OS thread and stay cheap (log write + IO offload).

## Tests
7 new: dispatch matrix, double-fire guard, exception containment, no-callback safety, real registration roundtrip on Windows, non-Windows no-op. System suite 173 pass.