### PR TITLE
feat: migrate remaining stray thread spawns onto executors and scheduler

### DIFF
--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -13,19 +13,11 @@
 |---|------|------|--------|
 | 2 | In-app single-instance lock + orphan worker reaping | gpu-guard-spec B4 | MERGED (#156) |
 | 9 | CI runs the system test suite on every PR | testing-and-docs-cleanup T1 | MERGED (#157) |
-<<<<<<< HEAD
-| 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | IN PIPELINE |
-| 3 | Sleep/resume power event handling | hardware-resilience H1 | PENDING |
-| 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | PENDING |
-| 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | PENDING |
-| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | IN PIPELINE |
-=======
 | 1 | GPU Guard: VRAM watchdog, model downgrade ladder, event log | gpu-guard-spec B1-B3 | MERGED (#158) |
-| 3 | Sleep/resume power event handling | hardware-resilience H1 | IN PIPELINE |
+| 3 | Sleep/resume power event handling | hardware-resilience H1 | MERGED (#160) |
 | 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | MERGED (#159) |
 | 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | MERGED (#159) |
-| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | PENDING |
->>>>>>> origin/dev
+| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | IN PIPELINE |
 | 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
 | 5 | Overlay dictation disk-first | hardware-resilience H3 | PENDING |
 | 7 | State machine transition table | architecture-validation A1 | PENDING |
@@ -76,18 +68,6 @@ in one place, not a branching if/then system and not a framework.
   dictation_model computations and meeting_job step_transcribe
   (model_override). 17 tests. System suite 164; venv 36.
 
-<<<<<<< HEAD
-- **2026-07-03 (item 8)**: remaining stray spawns migrated: feature
-  recovery format + deep speaker-ID (IO, native-gauged), meeting WAV
-  save+enqueue (IO), github first-poll waiter (scheduler step chain
-  replaces a sleeping thread), dictation model reload (DICTATION lane -
-  reloads and dictations cannot overlap anyway), paste clipboard restore
-  (scheduler delayed job). NOT migrated, deliberate: the error-popup
-  dialog spawn (a modal dialog can block for minutes and would starve
-  the serial IO lane; the dialog dispatcher already single-owns Tk),
-  startup recovery transcription, and the documented once-per-session
-  threads (download/update/restart/quit) plus long-lived loops.
-=======
 - **2026-07-03 (item 1 merged, #158)**: review hardening: providerless
   machines fully inert (crash triggers included), invalid ladder config
   falls back to default instead of IndexError. 16 tests.
@@ -105,4 +85,14 @@ in one place, not a branching if/then system and not a framework.
   gpu-guard.jsonl via GpuGuard.log_external_event (one correlation
   timeline); resume verifies the worker survived sleep and restarts it
   off-thread with a toast if not. Callbacks stay cheap on the OS thread.
->>>>>>> origin/dev
+
+- **2026-07-03 (item 8)**: remaining stray spawns migrated: feature
+  recovery format + deep speaker-ID (IO, native-gauged), meeting WAV
+  save+enqueue (IO), github first-poll waiter (scheduler step chain
+  replaces a sleeping thread), dictation model reload (DICTATION lane -
+  reloads and dictations cannot overlap anyway), paste clipboard restore
+  (scheduler delayed job). NOT migrated, deliberate: the error-popup
+  dialog spawn (a modal dialog can block for minutes and would starve
+  the serial IO lane; the dialog dispatcher already single-owns Tk),
+  startup recovery transcription, and the documented once-per-session
+  threads (download/update/restart/quit) plus long-lived loops.

--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -17,7 +17,7 @@
 | 3 | Sleep/resume power event handling | hardware-resilience H1 | PENDING |
 | 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | PENDING |
 | 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | PENDING |
-| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | PENDING |
+| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | IN PIPELINE |
 | 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
 | 5 | Overlay dictation disk-first | hardware-resilience H3 | PENDING |
 | 7 | State machine transition table | architecture-validation A1 | PENDING |
@@ -67,3 +67,14 @@ in one place, not a branching if/then system and not a framework.
   meeting pipeline worker crash. Model seam: effective_model() at the 6
   dictation_model computations and meeting_job step_transcribe
   (model_override). 17 tests. System suite 164; venv 36.
+
+- **2026-07-03 (item 8)**: remaining stray spawns migrated: feature
+  recovery format + deep speaker-ID (IO, native-gauged), meeting WAV
+  save+enqueue (IO), github first-poll waiter (scheduler step chain
+  replaces a sleeping thread), dictation model reload (DICTATION lane -
+  reloads and dictations cannot overlap anyway), paste clipboard restore
+  (scheduler delayed job). NOT migrated, deliberate: the error-popup
+  dialog spawn (a modal dialog can block for minutes and would starve
+  the serial IO lane; the dialog dispatcher already single-owns Tk),
+  startup recovery transcription, and the documented once-per-session
+  threads (download/update/restart/quit) plus long-lived loops.

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -851,11 +851,11 @@ class WhisperSync:
                 entry_id = feature_log.append_raw(text, 0)
                 logger.info(f"Feature suggestion recovered to feature log: {entry_id}")
                 # Format via Claude CLI in background
-                threading.Thread(
-                    target=self._format_feature_async,
-                    args=(text, entry_id),
-                    daemon=True,
-                ).start()
+                submit_or_spawn(
+                    IO, "feature-format",
+                    lambda t=text, e=entry_id: self._format_feature_async(t, e),
+                    native=True,
+                )
                 notify("Feature recovered", f"{len(text)} chars saved to feature log")
 
             def _do_cancel():
@@ -1891,7 +1891,7 @@ class WhisperSync:
                             _deep_running[0] = False
                         root.after(0, _err)
 
-                threading.Thread(target=_run_deep, daemon=True).start()
+                submit_or_spawn(IO, "speaker-id-deep", _run_deep, native=True)
 
             def _confirm():
                 if _closing[0]:
@@ -2060,7 +2060,7 @@ class WhisperSync:
                 self.state.emit(ERROR, meeting_transcribing=False, mode="error", data={"message": str(e), "recoverable": False})
                 self._schedule_idle(3)
 
-        threading.Thread(target=_save_and_enqueue, daemon=True).start()
+        submit_or_spawn(IO, "meeting-save-enqueue", _save_and_enqueue)
 
     def _post_process_worker(self):
         """Process meeting job steps sequentially.
@@ -2875,16 +2875,21 @@ class WhisperSync:
         )
         self._github_poller.start()
         if self._github_poller.state.available:
-            # Refresh menu after first poll completes
-            def _wait_first_poll():
-                import time
-                for _ in range(30):  # Wait up to 30s for first poll
-                    time.sleep(1)
-                    if self._github_poller.state.last_poll > 0:
-                        self._github_prs = self._github_poller.state.prs
-                        self._refresh_menu()
-                        break
-            threading.Thread(target=_wait_first_poll, daemon=True).start()
+            # Refresh menu after the first poll completes: a scheduler
+            # step chain (1s cadence, 30 tries) instead of a sleeping
+            # thread. Each step is a cheap flag check.
+            from .scheduler import scheduler as _sched
+
+            def _first_poll_step(remaining: int):
+                if self._github_poller.state.last_poll > 0:
+                    self._github_prs = self._github_poller.state.prs
+                    self._refresh_menu()
+                    return
+                if remaining > 0:
+                    _sched.call_later(1.0, lambda: _first_poll_step(remaining - 1),
+                                      label="github-first-poll")
+
+            _first_poll_step(30)
 
     def _notify(self, title: str, body: str = "", *, buttons=None, on_click=None):
         """Show a Windows toast notification via windows-toasts."""
@@ -3297,10 +3302,13 @@ class WhisperSync:
         self._save_and_refresh()
         # Reload model in the appropriate worker subprocess
         if key == "dictation_model":
-            threading.Thread(
-                target=lambda: self.worker.reload_model(model_name),
-                daemon=True,
-            ).start()
+            # DICTATION lane: a reload and a dictation cannot run
+            # concurrently anyway, so serializing them is the semantics.
+            submit_or_spawn(
+                DICTATION, "dictation-model-reload",
+                lambda m=model_name: self.worker.reload_model(m),
+                native=True,
+            )
 
     def _model_menu_items(self) -> list:
         """Build model status menu items."""

--- a/whisper_sync/paste.py
+++ b/whisper_sync/paste.py
@@ -107,7 +107,6 @@ def _schedule_clipboard_restore(previous: dict | str | None) -> None:
         return
 
     def _restore():
-        time.sleep(_RESTORE_DELAY)
         try:
             if isinstance(previous, dict):
                 ct = _get_clipboard_thread()
@@ -121,7 +120,10 @@ def _schedule_clipboard_restore(previous: dict | str | None) -> None:
         except Exception:
             logger.debug("Clipboard restore failed", exc_info=True)
 
-    threading.Thread(target=_restore, daemon=True).start()
+    # Deferred via the scheduler instead of a sleeping thread; the
+    # restore itself is a quick clipboard-thread handoff.
+    from .scheduler import scheduler
+    scheduler.call_later(_RESTORE_DELAY, _restore, label="clipboard-restore")
 
 
 def paste_clipboard(text: str, *, restore: bool = True) -> None:

--- a/whisper_sync/paste.py
+++ b/whisper_sync/paste.py
@@ -120,10 +120,17 @@ def _schedule_clipboard_restore(previous: dict | str | None) -> None:
         except Exception:
             logger.debug("Clipboard restore failed", exc_info=True)
 
-    # Deferred via the scheduler instead of a sleeping thread; the
-    # restore itself is a quick clipboard-thread handoff.
+    # Deferred via the scheduler instead of a sleeping thread. The
+    # restore itself can block up to the clipboard-thread handoff
+    # timeout, so the timer only enqueues it onto IO - scheduler jobs
+    # must stay short.
+    from .executors import IO, submit_or_spawn
     from .scheduler import scheduler
-    scheduler.call_later(_RESTORE_DELAY, _restore, label="clipboard-restore")
+    scheduler.call_later(
+        _RESTORE_DELAY,
+        lambda: submit_or_spawn(IO, "clipboard-restore", _restore),
+        label="clipboard-restore",
+    )
 
 
 def paste_clipboard(text: str, *, restore: bool = True) -> None:


### PR DESCRIPTION
## Hardening round item 8 (docs/specs/2026-07-03-architecture-validation.md A3)

Closes the executor migration the stability rebuild's Phase 1b started. Six sites move onto the single-owner primitives (two of them native-gauged subprocess work that idle-GC previously could not see); two sleeping threads become scheduler jobs. The deliberate exclusions (modal error dialog, startup recovery, once-per-session ops, long-lived loops) are recorded in the hardening plan with reasons.

## Tests
Existing suites cover the executors/scheduler contracts (submit_or_spawn fallback, scheduler chains); system suite 166 pass on this branch.