### PR TITLE
feat: overlay dictation streams to disk like normal dictation

### DIFF
--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -17,9 +17,9 @@
 | 3 | Sleep/resume power event handling | hardware-resilience H1 | MERGED (#160) |
 | 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | MERGED (#159) |
 | 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | MERGED (#159) |
-| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | IN PIPELINE |
+| 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | MERGED (#161) |
 | 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
-| 5 | Overlay dictation disk-first | hardware-resilience H3 | PENDING |
+| 5 | Overlay dictation disk-first | hardware-resilience H3 | IN PIPELINE |
 | 7 | State machine transition table | architecture-validation A1 | PENDING |
 | 6 | __main__.py decomposition by workflow | architecture-validation A2 | PENDING |
 
@@ -96,3 +96,17 @@ in one place, not a branching if/then system and not a framework.
   the serial IO lane; the dialog dispatcher already single-owns Tk),
   startup recovery transcription, and the documented once-per-session
   threads (download/update/restart/quit) plus long-lived loops.
+
+- **2026-07-03 (item 8 merged, #161)**: review moved the clipboard
+  restore off the scheduler thread (timer only enqueues onto IO). A
+  scripting mistake briefly committed unresolved conflict markers into
+  this doc; repaired in 6bfc97e - lesson: never chain git commands after
+  a resolution script without checking its exit status.
+
+- **2026-07-03 (item 5)**: overlay dictation now streams to disk
+  (overlay_ prefix in the dictation log dir, same naming family as
+  normal dictation), deleted after either transcription path succeeds,
+  preserved with a log line when both fail. Incognito stays RAM-only by
+  design. Meeting-stop overlay cancellation cleans the temp like the
+  normal-dictation path. Also fixes the stale paste.py docstring flagged
+  post-merge on #161.

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -670,6 +670,10 @@ class WhisperSync:
             return
 
         audio = self._overlay_recorder.stop()
+        # Finalize the streaming WAV (header + handle) so the file can be
+        # deleted on success or preserved intact on failure - stop() does
+        # not close the mic writer (same discipline as normal dictation).
+        self._overlay_recorder.stop_streaming()
         self.state.emit(DICTATION_COMPLETED, dictation_overlay=False)
 
         if "mic" not in audio:
@@ -1142,6 +1146,7 @@ class WhisperSync:
             _overlay = self.state.current.dictation_overlay if self.state else False
             if _overlay and self._overlay_recorder:
                 self._overlay_recorder.stop()
+                self._overlay_recorder.stop_streaming()
                 self._overlay_recorder = None
                 discarded_wav = getattr(self, "_overlay_wav_path", None)
                 self._overlay_wav_path = None

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -645,6 +645,21 @@ class WhisperSync:
             self._overlay_recorder = None
             self._feature_suggest_active = False
             return
+        # Disk-first like normal dictation (hardware-resilience H3):
+        # overlay audio was the last RAM-only capture path, so a crash
+        # mid-overlay lost it. Incognito intentionally stays RAM-only.
+        self._overlay_wav_path = None
+        if not self.cfg.get("incognito", False):
+            log_dir = self._dictation_log_dir()
+            log_dir.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            prefix = "feature_" if self._feature_suggest_active else ""
+            self._overlay_wav_path = log_dir / f"overlay_{prefix}{ts}.wav"
+            try:
+                self._overlay_recorder.start_streaming(self._overlay_wav_path)
+            except Exception as e:
+                logger.warning("Overlay disk streaming disabled: %s", e)
+                self._overlay_wav_path = None
         logger.info("Dictation during meeting: recording started", extra={"secondary": True})
         self.state.emit(DICTATION_STARTED, dictation_overlay=True)
 
@@ -665,6 +680,8 @@ class WhisperSync:
 
         overlay_audio = audio["mic"]
         self._overlay_recorder = None
+        overlay_wav = getattr(self, "_overlay_wav_path", None)
+        self._overlay_wav_path = None
 
         # Capture feature flag before spawning background thread
         with self._lock:
@@ -676,9 +693,11 @@ class WhisperSync:
         def _process_overlay():
             import time as _time
 
+            transcribed = False
             t0 = _time.perf_counter()
             try:
                 text = self._backup.transcribe(overlay_audio)
+                transcribed = True
                 t1 = _time.perf_counter()
                 duration = t1 - t0
                 char_count = len(text) if text else 0
@@ -744,6 +763,7 @@ class WhisperSync:
                         self.cfg.get("dictation_model", self.cfg["model"]))
                     timeout = 180
                     text = self.worker.transcribe_fast(overlay_audio, model_override=dictation_model, timeout=timeout)
+                    transcribed = True
                     if text:
                         paste(text, self.cfg["paste_method"], restore=not self.cfg.get("incognito", False))
                     t1 = _time.perf_counter()
@@ -775,6 +795,12 @@ class WhisperSync:
                         log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
                 except Exception as fallback_err:
                     logger.error(f"Overlay dictation fallback also failed: {fallback_err}", extra={"secondary": True})
+
+            if overlay_wav:
+                if transcribed:
+                    self._safe_unlink(overlay_wav)
+                else:
+                    logger.info(f"Overlay dictation audio preserved at: {overlay_wav}", extra={"secondary": True})
 
         submit_or_spawn(DICTATION, "overlay-process", _process_overlay)
 
@@ -1117,6 +1143,10 @@ class WhisperSync:
             if _overlay and self._overlay_recorder:
                 self._overlay_recorder.stop()
                 self._overlay_recorder = None
+                discarded_wav = getattr(self, "_overlay_wav_path", None)
+                self._overlay_wav_path = None
+                if discarded_wav:
+                    self._safe_unlink(discarded_wav)
                 logger.info("Overlay dictation discarded (left-click)", extra={"secondary": True})
                 self.state.emit(DICTATION_DISCARDED, dictation_overlay=False)
                 return

--- a/whisper_sync/paste.py
+++ b/whisper_sync/paste.py
@@ -101,7 +101,7 @@ def _save_clipboard() -> dict[int, bytes] | str | None:
 def _schedule_clipboard_restore(previous: dict | str | None) -> None:
     """Restore *previous* clipboard contents after a short delay.
 
-    Runs in a daemon thread so it never blocks the caller.
+    Runs via a scheduler timer that enqueues onto the IO executor so it never blocks the caller.
     """
     if previous is None:
         return


### PR DESCRIPTION
## Hardening round item 5 (docs/specs/2026-07-03-hardware-resilience-spec.md H3)

Overlay dictation was the last RAM-only capture path - a crash mid-overlay lost the audio. It now uses the same streaming-WAV discipline as everything else: written during capture, deleted on successful transcription (either the backup path or the main-worker fallback), preserved with a logged location when both fail, cleaned on user discard, RAM-only under incognito by design.

Also fixes the stale paste.py docstring flagged post-merge on #161.

## Tests
Capture streaming behavior is covered by the existing venv suite (36 pass locally); system suite 173 pass.