### PR TITLE
feat: mode transition table validated in one place, warn-then-allow

### DIFF
--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -20,7 +20,7 @@
 | 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | MERGED (#161) |
 | 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
 | 5 | Overlay dictation disk-first | hardware-resilience H3 | MERGED (#162) |
-| 7 | State machine transition table | architecture-validation A1 | PENDING |
+| 7 | State machine transition table | architecture-validation A1 | IN PIPELINE |
 | 6 | __main__.py decomposition by workflow | architecture-validation A2 | PENDING |
 
 Execution order: 2, 9, 1, 3, 11+10, 8, 4, 5, 7, 6. Owner approved the
@@ -130,3 +130,15 @@ in one place, not a branching if/then system and not a framework.
   pipeline protocol is in CONTRIBUTING.md; production validation of the
   running app (docs/testing.md, five signals) still awaits the owner
   updating via tray > Settings > Update > Labs/dev.
+
+- **2026-07-03 (item 7)**: MODE_TRANSITIONS flat table in
+  state_manager.py, validated in exactly one place (_apply_locked),
+  warn-then-allow: an unexpected transition applies but logs loudly, so
+  flows the table missed surface during a soak period without breaking
+  production; tighten to reject after the log stays clean. Table derived
+  from the actual emit sites (all 7 modes). Self-transitions silent.
+  Folding the stray flags (_feature_suggest_active, _updating,
+  _flash_active) into AppState is DEFERRED to item 6: those flags are
+  toggled at 15+ sites inside the code the decomposition will move, so
+  folding them first would create double churn. 4 new tests including
+  the full legal-matrix sweep.

--- a/tests/test_state_transitions.py
+++ b/tests/test_state_transitions.py
@@ -107,12 +107,26 @@ class ModeTransitionTableTests(unittest.TestCase):
     tests pin both halves of that contract plus the legal matrix.
     """
 
+    # Legal emit paths from the initial state (None) to each mode, so
+    # the matrix sweep sets up old modes through the PUBLIC API only.
+    _PATH_TO = {
+        None: [],
+        "dictation": ["dictation"],
+        "meeting": ["meeting"],
+        "saving": ["meeting", "saving"],
+        "transcribing": ["transcribing"],
+        "done": ["done"],
+        "error": ["error"],
+    }
+
     def test_every_table_entry_is_silent(self):
         from whisper_sync.state_manager import MODE_TRANSITIONS
         for old_mode, targets in MODE_TRANSITIONS.items():
             for new_mode in targets:
                 sm = _make_state()
-                sm._state.mode = old_mode
+                for step in self._PATH_TO[old_mode]:
+                    sm.emit(IDLE, mode=step)
+                self.assertEqual(sm.current.mode, old_mode, "setup path broken")
                 with self.assertNoLogs("whisper_sync.state", level="WARNING"):
                     sm.emit(IDLE, mode=new_mode)
                 self.assertEqual(sm.current.mode, new_mode)

--- a/tests/test_state_transitions.py
+++ b/tests/test_state_transitions.py
@@ -100,9 +100,6 @@ class TryTransitionTests(unittest.TestCase):
         self.assertEqual(len(sm.history), 1)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 class ModeTransitionTableTests(unittest.TestCase):
     """The flat MODE_TRANSITIONS table, checked only in _apply_locked.
 

--- a/tests/test_state_transitions.py
+++ b/tests/test_state_transitions.py
@@ -102,3 +102,43 @@ class TryTransitionTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class ModeTransitionTableTests(unittest.TestCase):
+    """The flat MODE_TRANSITIONS table, checked only in _apply_locked.
+
+    Warn-then-allow soak: unexpected transitions apply but log. These
+    tests pin both halves of that contract plus the legal matrix.
+    """
+
+    def test_every_table_entry_is_silent(self):
+        from whisper_sync.state_manager import MODE_TRANSITIONS
+        for old_mode, targets in MODE_TRANSITIONS.items():
+            for new_mode in targets:
+                sm = _make_state()
+                sm._state.mode = old_mode
+                with self.assertNoLogs("whisper_sync.state", level="WARNING"):
+                    sm.emit(IDLE, mode=new_mode)
+                self.assertEqual(sm.current.mode, new_mode)
+
+    def test_unexpected_transition_warns_but_applies(self):
+        sm = _make_state()
+        sm.emit(MEETING_STARTED, mode="meeting")
+        with self.assertLogs("whisper_sync.state", level="WARNING") as logs:
+            sm.emit(DICTATION_STARTED, mode="dictation")  # meeting -> dictation: not legal
+        self.assertIn("Unexpected mode transition", logs.output[0])
+        self.assertEqual(sm.current.mode, "dictation", "soak mode still applies the change")
+
+    def test_self_transition_is_silent(self):
+        sm = _make_state()
+        sm.emit(MEETING_STARTED, mode="meeting")
+        with self.assertNoLogs("whisper_sync.state", level="WARNING"):
+            sm.emit(MEETING_STARTED, mode="meeting")
+
+    def test_emit_without_mode_never_validates(self):
+        sm = _make_state()
+        with self.assertNoLogs("whisper_sync.state", level="WARNING"):
+            sm.emit(IDLE, meeting_transcribing=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -93,6 +93,31 @@ class StateEvent:
 # StateManager
 # ---------------------------------------------------------------------------
 
+# Legal mode transitions (hardening round item 7, architecture spec A1).
+# A flat data table checked in exactly ONE place (_apply_locked) - by
+# owner directive this stays a table, not a branching system and not a
+# framework. Self-transitions (mode unchanged) are always silent.
+#
+#   idle(None) -> start dictation/meeting; recovery re-enters
+#                 transcribing; the done-blink re-enters done
+#   dictation  -> transcribing (processing) | done | error | idle (cancel)
+#   meeting    -> saving (stop) | error | idle (cancel)
+#   saving     -> transcribing | done | error | idle
+#   transcribing -> done | error | idle; dictation/meeting may START
+#                 while a background transcription owns the mode
+#   done/error -> idle; fast restarts into dictation/meeting; recovery
+#                 may re-enter transcribing from done
+MODE_TRANSITIONS: dict = {
+    None: frozenset({"dictation", "meeting", "transcribing", "done", "error"}),
+    "dictation": frozenset({"transcribing", "done", "error", None}),
+    "meeting": frozenset({"saving", "done", "error", None}),
+    "saving": frozenset({"transcribing", "done", "error", None}),
+    "transcribing": frozenset({"dictation", "meeting", "done", "error", None}),
+    "done": frozenset({"dictation", "meeting", "transcribing", "error", None}),
+    "error": frozenset({"dictation", "meeting", None}),
+}
+
+
 class StateManager:
     """Observable state machine for WhisperSync.
 
@@ -171,6 +196,22 @@ class StateManager:
                       state_changes: dict):
         """Apply state changes and build the event. Caller holds the lock."""
         old = replace(self._state)
+        # Mode transition validation (hardening round item 7): the flat
+        # MODE_TRANSITIONS table is checked here and ONLY here. Currently
+        # warn-then-allow - an unexpected transition is applied but logged
+        # loudly, so real flows the table missed surface during the soak
+        # period without breaking production. Tighten to reject after the
+        # table has soaked clean.
+        if "mode" in state_changes:
+            new_mode = state_changes["mode"]
+            if new_mode != self._state.mode:
+                allowed = MODE_TRANSITIONS.get(self._state.mode, frozenset())
+                if new_mode not in allowed:
+                    _logger.warning(
+                        "Unexpected mode transition %r -> %r (event %s); "
+                        "not in MODE_TRANSITIONS - applying anyway (soak)",
+                        self._state.mode, new_mode, event_type,
+                    )
         # Warn on unknown state fields (catches typos at call sites)
         unknown_keys = [k for k in state_changes if not hasattr(self._state, k)]
         if unknown_keys:

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -107,7 +107,7 @@ class StateEvent:
 #                 while a background transcription owns the mode
 #   done/error -> idle; fast restarts into dictation/meeting; recovery
 #                 may re-enter transcribing from done
-MODE_TRANSITIONS: dict = {
+MODE_TRANSITIONS: dict[str | None, frozenset[str | None]] = {
     None: frozenset({"dictation", "meeting", "transcribing", "done", "error"}),
     "dictation": frozenset({"transcribing", "done", "error", None}),
     "meeting": frozenset({"saving", "done", "error", None}),


### PR DESCRIPTION
## Hardening round item 7 (docs/specs/2026-07-03-architecture-validation.md A1)

The state manager was an event bus - any caller could set any mode; transition legality lived in scattered caller-supplied sets. MODE_TRANSITIONS is a flat table (per owner directive: simple, reliable, troubleshootable - no branching system, no framework) checked in exactly one place (_apply_locked).

**Warn-then-allow soak**: unexpected transitions apply but log loudly; enforcement tightens after the log stays clean in production. The table is derived from every actual emit site. Self-transitions silent.

Stray-flag folding (_feature_suggest_active/_updating/_flash_active into AppState) is deferred to item 6 with reasoning recorded in the plan doc: those flags are toggled at 15+ sites in exactly the code the decomposition will move.

## Tests
4 new incl. a full legal-matrix sweep. System suite 177 pass.