### PR TITLE
feat: wedged-worker and mic-stall detection

### DIFF
--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -18,7 +18,7 @@
 | 11 | Docs truth and navigation pass | testing-and-docs-cleanup D1-D5 | MERGED (#159) |
 | 10 | docs/testing.md single testing entry point | testing-and-docs-cleanup T2-T4 | MERGED (#159) |
 | 8 | Finish executor migration (remaining stray spawns) | architecture-validation A3 | MERGED (#161) |
-| 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | PENDING |
+| 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | IN PIPELINE |
 | 5 | Overlay dictation disk-first | hardware-resilience H3 | MERGED (#162) |
 | 7 | State machine transition table | architecture-validation A1 | PENDING |
 | 6 | __main__.py decomposition by workflow | architecture-validation A2 | PENDING |
@@ -130,3 +130,16 @@ in one place, not a branching if/then system and not a framework.
   pipeline protocol is in CONTRIBUTING.md; production validation of the
   running app (docs/testing.md, five signals) still awaits the owner
   updating via tray > Settings > Update > Labs/dev.
+
+- **2026-07-03 (item 4)**: H4 - worker emits a liveness ping every 10s
+  during meeting transcriptions (pinger thread in the worker process);
+  the manager's unbounded wait wakes every 15s and, ONLY once a first
+  ping proved this build pings, treats 90s of silence as a wedged
+  process: kill + WorkerCrashedError (feeds the GPU guard ladder).
+  Ping-less workers keep the pure unbounded contract (4f3b307). H2 -
+  callbacks stamp every delivered buffer and surface PortAudio status
+  flags once; a 2s scheduler check notifies the user when the mic goes
+  silent >5s mid-recording and logs a mic_stall event to
+  gpu-guard.jsonl. DEFERRED from H2: automatic mid-recording stream
+  reopen (needs the format-ladder rework; detection ships first) and
+  loopback-stream stall coverage (mic is the critical channel).

--- a/tests/test_worker_protocol.py
+++ b/tests/test_worker_protocol.py
@@ -11,6 +11,7 @@ import queue
 import threading
 import time
 import unittest
+from unittest import mock
 
 from whisper_sync.worker_manager import TranscriptionWorker, WorkerCrashedError
 
@@ -246,6 +247,84 @@ class WorkerProtocolTests(unittest.TestCase):
         self.assertIsNone(pending.response, "failure marker must be set")
         reader.join(timeout=2.0)
         self.assertFalse(reader.is_alive(), "reader must exit on closed queue")
+
+
+class StallDetectionTests(unittest.TestCase):
+    """Wedged-worker detection (H4): ping silence kills; no pings ever
+    preserves the pure unbounded contract (4f3b307)."""
+
+    def setUp(self):
+        import whisper_sync.worker_manager as wm
+        self._wm = wm
+        self._patches = [
+            mock.patch.object(wm, "STALL_AFTER_S", 0.3),
+            mock.patch.object(wm, "_STALL_CHECK_S", 0.05),
+        ]
+        for p_ in self._patches:
+            p_.start()
+            self.addCleanup(p_.stop)
+
+    def tearDown(self):
+        if hasattr(self, "w") and self.w._process is not None:
+            self.w._process.alive = False
+
+    def test_ping_refreshes_slot_without_completing(self):
+        self.w = w = _make_worker()
+        results = {}
+        t = threading.Thread(
+            target=lambda: results.update(
+                ok=w._request({"type": "transcribe"}, timeout=None)),
+            daemon=True,
+        )
+        t.start()
+        rid = w._request_q.get(timeout=2.0)["request_id"]
+        # Keep pinging past several stall windows; request must survive.
+        for _ in range(12):
+            w._response_q.put({"type": "ping", "request_id": rid})
+            time.sleep(0.05)
+        self.assertTrue(t.is_alive(), "pinged request must not be killed")
+        w._response_q.put({"type": "result", "result": {"x": 1}, "request_id": rid})
+        t.join(timeout=2.0)
+        self.assertEqual(results["ok"]["result"], {"x": 1})
+
+    def test_ping_silence_kills_wedged_worker(self):
+        from whisper_sync.worker_manager import WorkerCrashedError
+        self.w = w = _make_worker()
+        errors = []
+
+        def _call():
+            try:
+                w._request({"type": "transcribe"}, timeout=None)
+            except WorkerCrashedError as e:
+                errors.append(e)
+
+        t = threading.Thread(target=_call, daemon=True)
+        t.start()
+        rid = w._request_q.get(timeout=2.0)["request_id"]
+        w._response_q.put({"type": "ping", "request_id": rid})  # arms detection
+        # ...then silence longer than STALL_AFTER_S.
+        t.join(timeout=5.0)
+        self.assertEqual(len(errors), 1, "silent-after-ping worker must be killed")
+        self.assertTrue(w._process.killed)
+
+    def test_no_pings_ever_keeps_unbounded_wait(self):
+        # A worker build without the pinger must never be stall-killed:
+        # the wait stays unbounded until the answer arrives.
+        self.w = w = _make_worker()
+        results = {}
+        t = threading.Thread(
+            target=lambda: results.update(
+                ok=w._request({"type": "transcribe"}, timeout=None)),
+            daemon=True,
+        )
+        t.start()
+        rid = w._request_q.get(timeout=2.0)["request_id"]
+        time.sleep(0.6)  # well past STALL_AFTER_S with zero pings
+        self.assertTrue(t.is_alive(), "ping-less worker must not be stall-killed")
+        self.assertFalse(w._process.killed)
+        w._response_q.put({"type": "result", "result": {}, "request_id": rid})
+        t.join(timeout=2.0)
+        self.assertIn("ok", results)
 
 
 if __name__ == "__main__":

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3854,6 +3854,35 @@ class WhisperSync:
             on_suspend=_on_suspend, on_resume=_on_resume)
         self._power_listener.start()
 
+        # Mic stall monitor (hardware-resilience H2): while recording, a
+        # device that silently stops delivering buffers (USB unplug,
+        # Bluetooth drop) previously produced an empty recording with no
+        # warning until stop. Detection notifies immediately; the stream
+        # keeps running in case the device returns (a mid-recording
+        # reopen is deferred - see the hardening plan).
+        _MIC_STALL_S = 5.0
+
+        def _mic_stall_check():
+            try:
+                age = self.recorder.seconds_since_last_mic_buffer()
+                if age is not None and age > _MIC_STALL_S:
+                    if not getattr(self, "_mic_stall_notified", False):
+                        self._mic_stall_notified = True
+                        logger.warning(
+                            f"Mic delivered no audio for {age:.0f}s while recording "
+                            "(device lost?)"
+                        )
+                        notify("Microphone stopped",
+                               "No audio is arriving from the mic. Check the device; "
+                               "the recording is still open.")
+                        self._gpu_guard.log_external_event("mic_stall", age_s=round(age, 1))
+                elif age is not None and age <= _MIC_STALL_S:
+                    self._mic_stall_notified = False
+            except Exception:
+                logger.debug("mic stall check failed", exc_info=True)
+
+        _sched.call_every(2.0, _mic_stall_check, label="mic-stall-check")
+
         try:
             self.tray.run()
         finally:

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -3876,7 +3876,10 @@ class WhisperSync:
                                "No audio is arriving from the mic. Check the device; "
                                "the recording is still open.")
                         self._gpu_guard.log_external_event("mic_stall", age_s=round(age, 1))
-                elif age is not None and age <= _MIC_STALL_S:
+                else:
+                    # Healthy delivery OR not recording (age None): both
+                    # re-arm the notification for the next stall (review:
+                    # a stall in one recording must not mute the next).
                     self._mic_stall_notified = False
             except Exception:
                 logger.debug("mic stall check failed", exc_info=True)

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     pyaudio = None
 
+from time import monotonic as _monotonic
+
 from .logger import logger
 from .streaming_wav import StreamingWavWriter
 
@@ -211,6 +213,8 @@ class AudioRecorder:
         self._lock = threading.Lock()
         self._disk_only = False
         self._mic_writer: StreamingWavWriter | None = None
+        self._last_mic_buffer: float | None = None   # monotonic; H2 stall stamps
+        self._last_speaker_buffer: float | None = None
         self._speaker_writer: StreamingWavWriter | None = None
         # PyAudioWPatch loopback state
         self._pyaudio = None
@@ -227,6 +231,15 @@ class AudioRecorder:
         try:
             if not self._recording:
                 return
+            # Device-loss visibility (hardware-resilience H2): stamp every
+            # delivered buffer so a stall monitor can detect a device that
+            # silently stopped (USB unplug, Bluetooth drop), and surface
+            # PortAudio status flags (overflow/aborted) once instead of
+            # discarding them.
+            self._last_mic_buffer = _monotonic()
+            if status and not getattr(self, "_mic_status_logged", False):
+                self._mic_status_logged = True
+                logger.warning(f"mic stream status flagged (logged once): {status}")
 
             # Normalize to float32 in [-1, 1] regardless of what dtype the
             # device actually produced. Integer samples must be scaled
@@ -278,6 +291,10 @@ class AudioRecorder:
     def _speaker_callback(self, indata, frames, time_info, status):
         try:
             if self._recording:
+                self._last_speaker_buffer = _monotonic()
+                if status and not getattr(self, "_speaker_status_logged", False):
+                    self._speaker_status_logged = True
+                    logger.warning(f"speaker stream status flagged (logged once): {status}")
                 self._speaker_data.append(indata.copy())
                 if self._speaker_writer is not None:
                     self._speaker_writer.write(indata)
@@ -326,6 +343,13 @@ class AudioRecorder:
             else:
                 self._mic_resample_up = 1
                 self._mic_resample_down = 1
+            # Fresh stall/status baselines per recording (H2): a stale
+            # stamp from a previous session must not read as a stall, and
+            # log-once flags re-arm per session.
+            self._last_mic_buffer = None
+            self._last_speaker_buffer = None
+            self._mic_status_logged = False
+            self._speaker_status_logged = False
             self._recording = True
 
             if speaker_device is not None:
@@ -516,6 +540,17 @@ class AudioRecorder:
     @property
     def is_recording(self) -> bool:
         return self._recording
+
+    def seconds_since_last_mic_buffer(self) -> float | None:
+        """Age of the newest mic buffer, or None before the first one.
+
+        Only meaningful while recording; the stall monitor uses this to
+        detect a device that silently stopped delivering (H2).
+        """
+        last = self._last_mic_buffer
+        if last is None or not self._recording:
+            return None
+        return _monotonic() - last
 
     def start_streaming(self, mic_path, speaker_path=None, disk_only=False):
         """Open streaming WAV writers for crash safety during meeting recording.

--- a/whisper_sync/worker.py
+++ b/whisper_sync/worker.py
@@ -8,6 +8,7 @@ allowing dictation requests to be processed between meeting stages.
 """
 
 import faulthandler
+import threading
 import os
 import queue
 import sys
@@ -15,6 +16,9 @@ import traceback
 from pathlib import Path
 
 import numpy as np
+
+# Liveness ping cadence during meeting transcriptions (see _start_pinger).
+PING_INTERVAL_S = 10.0
 
 
 def _drain_priority(request_queue, response_queue, transcribe_fast_fn, preload_fn):
@@ -163,6 +167,26 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
         """Check for priority requests. Returns True if shutdown requested."""
         return _drain_priority(request_queue, response_queue, transcribe_fast, preload)
 
+    def _start_pinger(req_id):
+        """Liveness pings while a long transcription runs (H4).
+
+        The manager treats prolonged ping silence as a wedged worker.
+        The pinger proves the PROCESS is responsive; a driver-level hang
+        freezes it together with the compute, which is exactly the
+        wanted signal.
+        """
+        stop = threading.Event()
+
+        def _ping():
+            while not stop.wait(PING_INTERVAL_S):
+                try:
+                    response_queue.put({"type": "ping", "request_id": req_id})
+                except Exception:
+                    break
+
+        threading.Thread(target=_ping, daemon=True, name="transcribe-pinger").start()
+        return stop
+
     # Main request loop
     while True:
         try:
@@ -189,6 +213,7 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
                 })
             continue
 
+        _stop_ping = _start_pinger(req_id) if req_type == "transcribe" else None
         try:
             if req_type == "transcribe_fast":
                 audio_np = np.load(request["audio_path"], allow_pickle=False)
@@ -285,3 +310,6 @@ def worker_main(request_queue, response_queue, cfg_snapshot: dict,
                 "traceback": traceback.format_exc(),
                 "request_id": req_id,
             })
+        finally:
+            if _stop_ping is not None:
+                _stop_ping.set()

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -53,11 +53,12 @@ def _reconstruct_error(response: dict) -> Exception:
 class _PendingRequest:
     """A response slot one caller waits on; completed by the reader thread."""
 
-    __slots__ = ("done", "response")
+    __slots__ = ("done", "response", "last_ping")
 
     def __init__(self):
         self.done = threading.Event()
         self.response: dict | None = None  # None after done => worker died
+        self.last_ping: float | None = None  # monotonic time of latest ping
 
 
 class _WorkerGeneration:
@@ -76,6 +77,18 @@ class _WorkerGeneration:
         self.pending_lock = threading.Lock()
         self.ready_event = threading.Event()
         self.ready_ok = False
+
+
+# Wedged-worker detection (hardware-resilience H4): during an unbounded
+# meeting transcription the worker emits a liveness ping every 10s
+# (worker.PING_INTERVAL_S). Once at least one ping has arrived (proving
+# this worker build pings at all - anything older keeps the pure
+# unbounded contract of 4f3b307), silence longer than STALL_AFTER_S
+# means the whole process is wedged (the classic hung-driver symptom):
+# kill it and raise WorkerCrashedError instead of hanging the meeting
+# pipeline forever. Audio is disk-first, so nothing is lost.
+STALL_AFTER_S = 90.0
+_STALL_CHECK_S = 15.0
 
 
 class TranscriptionWorker:
@@ -185,6 +198,14 @@ class TranscriptionWorker:
                 continue
 
             rid = msg.get("request_id")
+            if mtype == "ping":
+                # Liveness ping during a long transcription (H4): refresh
+                # the slot's timestamp, never complete it.
+                with gen.pending_lock:
+                    slot = gen.pending.get(rid)
+                if slot is not None:
+                    slot.last_ping = time.monotonic()
+                continue
             with gen.pending_lock:
                 pending = gen.pending.pop(rid, None)
             if pending is not None:
@@ -232,7 +253,26 @@ class TranscriptionWorker:
                 gen.pending.pop(request_id, None)
             raise
 
-        if not pending.done.wait(timeout):
+        if timeout is None:
+            # Unbounded wait with wedge detection: wake periodically and
+            # check ping staleness. Armed only after the first ping.
+            while not pending.done.wait(_STALL_CHECK_S):
+                last = pending.last_ping
+                if last is not None and (time.monotonic() - last) > STALL_AFTER_S:
+                    with self._gen.pending_lock:
+                        self._gen.pending.pop(request_id, None)
+                    logger.error(
+                        f"Worker wedged: no liveness ping for {STALL_AFTER_S:.0f}s "
+                        f"(request {request_id}); killing worker"
+                    )
+                    if self._process is not None and self._process.is_alive():
+                        self._process.kill()
+                        self._process.join(timeout=3)
+                    raise WorkerCrashedError(
+                        "Worker stopped responding during transcription and was "
+                        "terminated (no liveness ping). Audio is preserved on disk."
+                    )
+        elif not pending.done.wait(timeout):
             with gen.pending_lock:
                 gen.pending.pop(request_id, None)
             logger.error(

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -240,6 +240,7 @@ class TranscriptionWorker:
         caller's existing crash handling respawns it.
         """
         gen = self._gen
+        process = self._process  # bind: a restart mid-wait must not be targeted
         request_id = self._next_id()
         pending = _PendingRequest()
         with gen.pending_lock:
@@ -259,15 +260,18 @@ class TranscriptionWorker:
             while not pending.done.wait(_STALL_CHECK_S):
                 last = pending.last_ping
                 if last is not None and (time.monotonic() - last) > STALL_AFTER_S:
-                    with self._gen.pending_lock:
-                        self._gen.pending.pop(request_id, None)
+                    # Use the gen/process bound at registration: a worker
+                    # restarted mid-wait must never have its NEW healthy
+                    # process killed or its pending map touched (review).
+                    with gen.pending_lock:
+                        gen.pending.pop(request_id, None)
                     logger.error(
                         f"Worker wedged: no liveness ping for {STALL_AFTER_S:.0f}s "
                         f"(request {request_id}); killing worker"
                     )
-                    if self._process is not None and self._process.is_alive():
-                        self._process.kill()
-                        self._process.join(timeout=3)
+                    if process is not None and process.is_alive():
+                        process.kill()
+                        process.join(timeout=3)
                     raise WorkerCrashedError(
                         "Worker stopped responding during transcription and was "
                         "terminated (no liveness ping). Audio is preserved on disk."


### PR DESCRIPTION
## Hardening round item 4 (docs/specs/2026-07-03-hardware-resilience-spec.md H2+H4)

**H4 (architecture note, protected worker paths)**: a worker that wedges while staying alive previously hung meeting transcription forever - only process death was detected. The worker now pings every 10s during transcriptions (pinger thread; a driver-level hang freezes it with the compute, which is the wanted signal); the manager's unbounded wait treats 90s of silence AFTER a first ping as a wedge: kill + WorkerCrashedError (feeds the GPU guard ladder). Ping-less builds keep the pure unbounded contract (4f3b307); pings never complete a pending slot, so routing is untouched.

**H2**: callbacks stamp delivered buffers and surface PortAudio status flags (once per session); a 2s scheduler check toasts the user when the mic goes silent 5s mid-recording and logs mic_stall to gpu-guard.jsonl. Mid-recording reopen + loopback coverage deferred with reasons in the plan doc.

## Tests
3 new protocol tests: pings keep an unbounded request alive past the stall window, silence-after-ping kills and raises, zero-ping workers are never stall-killed. System 176 pass; venv 36 pass locally.