### PR TITLE
fix: pipeline abort after transcription; split name collision

### DIFF
--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -178,3 +178,26 @@ in one place, not a branching if/then system and not a framework.
   (or a flow needs fixing) BEFORE tightening warn-to-reject.
   Production validation (docs/testing.md five signals + gpu-guard.jsonl
   correlation) still awaits the owner updating the running app.
+
+- **2026-07-03 (production bugs, owner-reported)**: two real bugs from
+  field use, both fixed. (1) PIPELINE ABORT AFTER TRANSCRIPTION: every
+  past-week meeting had transcript.json but no flatten/speakers/minutes.
+  Root cause found in the 07-03 app log: #141 aliased speaker_segments
+  to the raw segments LIST; log_transcript_preview expects
+  {speaker: [utterances]}, raised AttributeError at the END of
+  step_transcribe, and the job aborted with the transcript already
+  saved. Fix: meeting_job groups previews itself
+  (group_speaker_previews, garbage-tolerant), the alias is removed from
+  stage_finalize, and log_transcript_preview can no longer raise at
+  all. Verified with WS_E2E on real audio. (2) SPLIT NAME COLLISION:
+  portion [1] starts at t=0 so its MMDD_HHMM prefix equals the
+  source's; reusing the source's name made dest == source (copy2
+  SameFileError; exist_ok would also silently clobber unrelated
+  folders). Fix: pre-flight destination checks (duplicates and existing
+  folders rejected BEFORE any write) + the source renames to
+  <name>.splitting during the split, so a portion may legitimately
+  reuse the original name. 8 new tests (5 split on synthetic wavs, 3
+  preview/logger). NOTE: the running tray app executes from this repo
+  checkout - it must be RESTARTED after this merges to load the fix,
+  and pytest runs pollute the live app log (logs/app), a hygiene item
+  for item 6's session.

--- a/tests/test_meeting_job.py
+++ b/tests/test_meeting_job.py
@@ -321,5 +321,37 @@ class StepFlattenAndCompleteTests(unittest.TestCase):
         )
 
 
+class SpeakerPreviewTests(unittest.TestCase):
+    """Regression for the 2026-07-03 pipeline-abort bug: preview material
+    must be grouped correctly and must never be able to kill a job."""
+
+    def test_group_speaker_previews_shapes_dict(self):
+        from whisper_sync.meeting_job import group_speaker_previews
+        segments = [
+            {"speaker": "Alice", "text": " Hello. ", "start": 0, "end": 1},
+            {"speaker": "Bob", "text": "Hi.", "start": 1, "end": 2},
+            {"speaker": "Alice", "text": "Bye.", "start": 2, "end": 3},
+        ]
+        self.assertEqual(
+            group_speaker_previews(segments),
+            {"Alice": ["Hello.", "Bye."], "Bob": ["Hi."]},
+        )
+
+    def test_group_speaker_previews_tolerates_garbage(self):
+        from whisper_sync.meeting_job import group_speaker_previews
+        self.assertEqual(group_speaker_previews(None), {})
+        self.assertEqual(group_speaker_previews("not a list"), {})
+        self.assertEqual(group_speaker_previews(
+            [None, {}, {"text": "   "}, {"text": "x"}]), {"UNKNOWN": ["x"]})
+
+    def test_log_transcript_preview_never_raises_on_wrong_shape(self):
+        # The exact production failure: a segments LIST passed where a
+        # dict was expected aborted the job after transcription.
+        from whisper_sync.logger import log_transcript_preview
+        log_transcript_preview("", speakers=[{"speaker": "A", "text": "hi"}])
+        log_transcript_preview("", speakers={"A": object()})  # non-iterable utterances
+        log_transcript_preview("some text", speakers=None)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_split_meeting.py
+++ b/tests/test_split_meeting.py
@@ -128,6 +128,23 @@ class PreflightTests(_SplitHarness):
                         "existing folder must never be clobbered")
         self.assertTrue(source.exists(), "source untouched on pre-flight failure")
 
+    def test_mid_split_failure_rolls_staging_back(self):
+        # Regression for PR review: an unexpected error inside the split
+        # loop must rename the staged source back to its original name.
+        from unittest import mock
+        import whisper_sync.split_meeting as sm
+        source = self._make_source("Original")
+        with mock.patch.object(sm, "trim_wav_inplace",
+                               side_effect=RuntimeError("disk full")):
+            with self.assertRaises(RuntimeError):
+                split_meeting(source, [2.0], ["PartA", "PartB"])
+        self.assertTrue(source.exists(), "source must be restored on failure")
+        self.assertTrue((source / "transcript.json").exists())
+        self.assertFalse(
+            source.with_name(source.name + ".splitting").exists(),
+            "staging must not linger after rollback",
+        )
+
     def test_leftover_staging_folder_rejected(self):
         source = self._make_source("Original")
         staging = source.with_name(source.name + ".splitting")

--- a/tests/test_split_meeting.py
+++ b/tests/test_split_meeting.py
@@ -1,0 +1,141 @@
+"""Tests for whisper_sync.split_meeting - the split pipeline on synthetic audio.
+
+Regression focus (2026-07-03 production bug): portion [1] starts at t=0,
+so its MMDD_HHMM prefix equals the source folder's; reusing the source's
+name made dest == source and the copy crashed. The staging rename must
+make that case work, and pre-flight checks must refuse duplicate or
+already-existing destinations before any file is touched.
+"""
+
+import json
+import os
+import struct
+import unittest
+import tempfile
+import wave
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from whisper_sync.split_meeting import split_meeting
+
+
+def _write_wav(path: Path, seconds: float, rate: int = 16000):
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(struct.pack(f"<{int(rate * seconds)}h",
+                                  *([0] * int(rate * seconds))))
+
+
+def _transcript(duration: float) -> dict:
+    return {
+        "speaker_map": {"SPEAKER_00": "Alice"},
+        "segments": [
+            {"speaker": "SPEAKER_00", "text": "First half.",
+             "start": 0.5, "end": min(1.5, duration)},
+            {"speaker": "SPEAKER_00", "text": "Second half.",
+             "start": min(duration - 1.0, 2.5), "end": duration - 0.1},
+        ],
+    }
+
+
+class _SplitHarness(unittest.TestCase):
+    DURATION = 4.0
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _make_source(self, name_suffix: str):
+        """Create a source meeting folder placed exactly where portion [1]
+        with the same suffix would land, so name reuse == full collision."""
+        scratch = self.root / "scratch"
+        scratch.mkdir()
+        wav = scratch / "recording.wav"
+        _write_wav(wav, self.DURATION)
+        # Recreate split_meeting's own math: portion 1 start time derives
+        # from the wav mtime minus total duration.
+        mtime = datetime.fromtimestamp(os.path.getmtime(str(wav)))
+        start = mtime - timedelta(seconds=self.DURATION)
+        week = f"{start.strftime('%m')}-w{(start.day - 1) // 7 + 1}"
+        folder_name = f"{start.strftime('%m%d_%H%M')}_{name_suffix}"
+        source = self.root / week / folder_name
+        source.parent.mkdir(parents=True, exist_ok=True)
+        os.rename(str(scratch), str(source))
+        (source / "transcript.json").write_text(json.dumps(_transcript(self.DURATION)))
+        return source
+
+    def _portions(self):
+        """All meeting folders under the temp root (post-split state)."""
+        return sorted(
+            p for p in self.root.glob("*/*")
+            if p.is_dir() and not p.name.endswith(".splitting")
+        )
+
+
+class NameReuseTests(_SplitHarness):
+    def test_portion_one_may_reuse_the_source_name(self):
+        source = self._make_source("Patrick")
+        split_meeting(source, [2.0], ["Patrick", "SecondPart"])
+
+        portions = self._portions()
+        self.assertEqual(len(portions), 2, f"expected 2 portions, got {portions}")
+        for p in portions:
+            for f in ("recording.wav", "transcript.json", "transcript-readable.txt"):
+                self.assertTrue((p / f).exists(), f"{p.name} missing {f}")
+        # The reused name is one of the portions and holds TRIMMED audio.
+        reused = [p for p in portions if p.name.endswith("_Patrick")]
+        self.assertEqual(len(reused), 1)
+        with wave.open(str(reused[0] / "recording.wav"), "rb") as w:
+            dur = w.getnframes() / w.getframerate()
+        self.assertLess(dur, 3.0, "portion audio must be trimmed, not the full source")
+        self.assertFalse(
+            any(p.name.endswith(".splitting") for p in self.root.glob("*/*")),
+            "staging folder must be removed after a successful split",
+        )
+
+    def test_distinct_names_still_work(self):
+        source = self._make_source("Original")
+        split_meeting(source, [2.0], ["PartA", "PartB"])
+        self.assertEqual(len(self._portions()), 2)
+        self.assertFalse(source.exists(), "source must be removed after success")
+
+
+class PreflightTests(_SplitHarness):
+    def test_duplicate_portion_names_rejected_before_any_write(self):
+        source = self._make_source("Original")
+        with self.assertRaises(ValueError):
+            split_meeting(source, [2.0], ["Same", "Same"])
+        self.assertTrue(source.exists(), "source untouched on pre-flight failure")
+        self.assertTrue((source / "recording.wav").exists())
+
+    def test_existing_unrelated_destination_rejected(self):
+        source = self._make_source("Original")
+        # Fabricate a folder exactly where portion 1 named "Occupied" lands.
+        mtime = datetime.fromtimestamp(
+            os.path.getmtime(str(source / "recording.wav")))
+        start = mtime - timedelta(seconds=self.DURATION)
+        week = f"{start.strftime('%m')}-w{(start.day - 1) // 7 + 1}"
+        occupied = self.root / week / f"{start.strftime('%m%d_%H%M')}_Occupied"
+        occupied.mkdir(parents=True)
+        (occupied / "keep.txt").write_text("existing meeting")
+
+        with self.assertRaises(FileExistsError):
+            split_meeting(source, [2.0], ["Occupied", "Other"])
+        self.assertTrue((occupied / "keep.txt").exists(),
+                        "existing folder must never be clobbered")
+        self.assertTrue(source.exists(), "source untouched on pre-flight failure")
+
+    def test_leftover_staging_folder_rejected(self):
+        source = self._make_source("Original")
+        staging = source.with_name(source.name + ".splitting")
+        staging.mkdir()
+        with self.assertRaises(FileExistsError):
+            split_meeting(source, [2.0], ["A", "B"])
+        self.assertTrue(source.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/logger.py
+++ b/whisper_sync/logger.py
@@ -215,14 +215,24 @@ def log_transcript_preview(text: str, speakers: dict = None) -> None:
     speakers: dict mapping speaker labels to list of sample utterances
               e.g. {"Colby": ["So the next improvement..."], "Dinesh": ["Yeah, the OAuth..."]}
     """
-    if speakers:
-        for speaker, utterances in speakers.items():
-            for utt in utterances[:1]:  # First utterance per speaker
-                preview = utt[:80] + ("..." if len(utt) > 80 else "")
-                logger.log(TRANSCRIPT, f"        [{speaker}] {preview}")
-    elif text:
-        preview = text[:200] + ("..." if len(text) > 200 else "")
-        logger.log(TRANSCRIPT, f"        {preview}")
+    # Preview logging must NEVER raise: a malformed speakers value once
+    # aborted the whole meeting pipeline (2026-07-03). Wrong shapes are
+    # logged at debug and otherwise ignored.
+    try:
+        if speakers and hasattr(speakers, "items"):
+            for speaker, utterances in speakers.items():
+                for utt in list(utterances)[:1]:  # First utterance per speaker
+                    preview = utt[:80] + ("..." if len(utt) > 80 else "")
+                    logger.log(TRANSCRIPT, f"        [{speaker}] {preview}")
+        elif speakers:
+            logger.debug(
+                f"transcript preview skipped: speakers is {type(speakers).__name__}, expected dict"
+            )
+        elif text:
+            preview = text[:200] + ("..." if len(text) > 200 else "")
+            logger.log(TRANSCRIPT, f"        {preview}")
+    except Exception:
+        logger.debug("transcript preview failed", exc_info=True)
 
 
 def get_log_path() -> Path:

--- a/whisper_sync/logger.py
+++ b/whisper_sync/logger.py
@@ -221,6 +221,8 @@ def log_transcript_preview(text: str, speakers: dict = None) -> None:
     try:
         if speakers and hasattr(speakers, "items"):
             for speaker, utterances in speakers.items():
+                if isinstance(utterances, str):
+                    utterances = [utterances]  # one utterance, not characters
                 for utt in list(utterances)[:1]:  # First utterance per speaker
                     preview = utt[:80] + ("..." if len(utt) > 80 else "")
                     logger.log(TRANSCRIPT, f"        [{speaker}] {preview}")

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -22,6 +22,26 @@ from pathlib import Path
 logger = logging.getLogger("whisper_sync.meeting_job")
 
 
+def group_speaker_previews(segments) -> dict:
+    """{speaker: [utterance texts]} from a transcript segments list.
+
+    Tolerant of malformed input (None, non-list, segments without
+    speaker/text) - preview material must never abort the pipeline.
+    """
+    grouped: dict = {}
+    if not isinstance(segments, list):
+        return grouped
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        speaker = seg.get("speaker") or "UNKNOWN"
+        grouped.setdefault(str(speaker), []).append(text)
+    return grouped
+
+
 class MeetingJob:
     """A meeting recording with its own state and processing steps."""
 
@@ -172,10 +192,15 @@ class MeetingJob:
         self.app._stats.record_meeting(int(duration), words)
         weekly_stats.record_meeting(int(duration), words)
 
-        # Speaker segment previews
-        segments = self.transcript_result.get("speaker_segments")
-        if segments:
-            log_transcript_preview("", speakers=segments)
+        # Speaker segment previews. Grouped here from the raw segments:
+        # passing the segments LIST straight to log_transcript_preview
+        # (which expects {speaker: [utterances]}) raised AttributeError
+        # and aborted the whole job after transcription - transcript.json
+        # existed but flatten/speakers/minutes never ran (2026-07-03
+        # production bug; regression from #141's speaker_segments alias).
+        previews = group_speaker_previews(self.transcript_result.get("segments"))
+        if previews:
+            log_transcript_preview("", speakers=previews)
 
         # Cache LLM availability for later steps
         self.llm_ok = self.app._is_claude_cli_available()

--- a/whisper_sync/split_meeting.py
+++ b/whisper_sync/split_meeting.py
@@ -189,6 +189,38 @@ def split_meeting(source_folder: Path, split_points: list[float], names: list[st
     # Determine output parent (same month folder as source)
     parent = source_folder.parent
 
+    # Pre-flight destination checks (2026-07-03 production bug): portion
+    # [1] starts at t=0, so its MMDD_HHMM prefix equals the source's -
+    # reusing the source's name made dest == source and copy2 crashed on
+    # a same-file copy (and exist_ok would have clobbered any unrelated
+    # existing folder silently). Compute every destination first, reject
+    # duplicates and collisions with EXISTING folders, then rename the
+    # source aside so a portion may legitimately reuse its name.
+    dests = []
+    for (start_sec, _end_sec), name in zip(ranges, names):
+        p_start = original_start + timedelta(seconds=start_sec)
+        wk = f"{p_start.strftime('%m')}-w{(p_start.day - 1) // 7 + 1}"
+        fname = f"{p_start.strftime('%m%d_%H%M')}_{name}"
+        dests.append(parent.parent / wk / fname)
+    if len({str(d).lower() for d in dests}) != len(dests):
+        raise ValueError(f"Duplicate destination folders in split: {[d.name for d in dests]}")
+    for d in dests:
+        if d.exists() and d.resolve() != source_folder.resolve():
+            raise FileExistsError(
+                f"Destination already exists: {d} - refusing to overwrite an "
+                "existing meeting; pick a different name"
+            )
+
+    staging = source_folder.with_name(source_folder.name + ".splitting")
+    if staging.exists():
+        raise FileExistsError(
+            f"Leftover staging folder from a previous run: {staging} - "
+            "inspect/remove it first"
+        )
+    os.rename(str(source_folder), str(staging))
+    wav_path = staging / "recording.wav"
+    json_path = staging / "transcript.json"
+
     print(f"Source: {source_folder.name} ({total_duration / 60:.1f} min)")
     print(f"Original recorded: {original_start.strftime('%Y-%m-%d %H:%M')} - {original_mtime.strftime('%H:%M')}")
     print(f"Splitting into {len(ranges)} meetings:")
@@ -279,14 +311,14 @@ def split_meeting(source_folder: Path, split_points: list[float], names: list[st
                 all_ok = False
 
     if not all_ok:
-        print("\nVerification FAILED — original folder preserved for recovery.")
-        print(f"Original: {source_folder}")
+        print("\nVerification FAILED - original folder preserved for recovery.")
+        print(f"Original (staged): {staging}")
         return
 
-    # --- Remove original folder ---
+    # --- Remove original folder (staged copy) ---
     import shutil as _shutil
-    _shutil.rmtree(str(source_folder))
-    print(f"\nOriginal folder removed: {source_folder}")
+    _shutil.rmtree(str(staging))
+    print(f"\nOriginal folder removed: {staging}")
 
     # Rebuild INDEX.md files
     try:

--- a/whisper_sync/split_meeting.py
+++ b/whisper_sync/split_meeting.py
@@ -221,6 +221,19 @@ def split_meeting(source_folder: Path, split_points: list[float], names: list[st
     wav_path = staging / "recording.wav"
     json_path = staging / "transcript.json"
 
+    def _rollback_staging(exc):
+        """Best-effort undo of the staging rename after a mid-split error."""
+        try:
+            if not source_folder.exists():
+                os.rename(str(staging), str(source_folder))
+                print(f"Split failed ({exc}); original restored: {source_folder}")
+            else:
+                print(f"Split failed ({exc}); original preserved at: {staging} "
+                      f"(could not rename back - {source_folder.name} exists)")
+        except OSError as rb:
+            print(f"Split failed ({exc}); rollback also failed ({rb}); "
+                  f"original data is intact at: {staging}")
+
     print(f"Source: {source_folder.name} ({total_duration / 60:.1f} min)")
     print(f"Original recorded: {original_start.strftime('%Y-%m-%d %H:%M')} - {original_mtime.strftime('%H:%M')}")
     print(f"Splitting into {len(ranges)} meetings:")
@@ -236,49 +249,56 @@ def split_meeting(source_folder: Path, split_points: list[float], names: list[st
         _spec.loader.exec_module(_mod)
         flatten_transcript = _mod.flatten
 
-    for i, ((start_sec, end_sec), name) in enumerate(zip(ranges, names)):
-        portion_start = original_start + timedelta(seconds=start_sec)
-        portion_end = original_start + timedelta(seconds=end_sec)
-        duration = end_sec - start_sec
+    # Any unexpected failure inside the split loop rolls the staging
+    # rename back (review: the original must never be stranded under
+    # a .splitting name the pipeline does not know).
+    try:
+        for i, ((start_sec, end_sec), name) in enumerate(zip(ranges, names)):
+            portion_start = original_start + timedelta(seconds=start_sec)
+            portion_end = original_start + timedelta(seconds=end_sec)
+            duration = end_sec - start_sec
 
-        # Build folder name: MMDD_HHMM_name inside MM-wN week folder
-        week_dir = f"{portion_start.strftime('%m')}-w{(portion_start.day - 1) // 7 + 1}"
-        folder_name = f"{portion_start.strftime('%m%d_%H%M')}_{name}"
-        dest_folder = parent.parent / week_dir / folder_name
+            # Build folder name: MMDD_HHMM_name inside MM-wN week folder
+            week_dir = f"{portion_start.strftime('%m')}-w{(portion_start.day - 1) // 7 + 1}"
+            folder_name = f"{portion_start.strftime('%m%d_%H%M')}_{name}"
+            dest_folder = parent.parent / week_dir / folder_name
 
-        print(f"\n  [{i + 1}] {folder_name}")
-        print(f"      {portion_start.strftime('%H:%M')} - {portion_end.strftime('%H:%M')} ({duration / 60:.1f} min)")
+            print(f"\n  [{i + 1}] {folder_name}")
+            print(f"      {portion_start.strftime('%H:%M')} - {portion_end.strftime('%H:%M')} ({duration / 60:.1f} min)")
 
-        # Create folder
-        dest_folder.mkdir(parents=True, exist_ok=True)
+            # Create folder
+            dest_folder.mkdir(parents=True, exist_ok=True)
 
-        # Copy original WAV (preserves some OS metadata as baseline)
-        dest_wav = dest_folder / "recording.wav"
-        shutil.copy2(str(wav_path), str(dest_wav))
+            # Copy original WAV (preserves some OS metadata as baseline)
+            dest_wav = dest_folder / "recording.wav"
+            shutil.copy2(str(wav_path), str(dest_wav))
 
-        # Trim to this portion
-        trim_wav_inplace(str(dest_wav), start_sec, end_sec)
+            # Trim to this portion
+            trim_wav_inplace(str(dest_wav), start_sec, end_sec)
 
-        # Set correct Windows file times:
-        #   creation time = original file creation time (when recording started)
-        #   modification time = portion end time (so mtime - wav_duration = portion start)
-        set_file_times(str(dest_wav), original_ctime, portion_end)
-        print(f"      WAV: {os.path.getsize(str(dest_wav)) / 1024 / 1024:.1f} MB, "
-              f"ctime preserved, mtime={portion_end.strftime('%H:%M')}")
+            # Set correct Windows file times:
+            #   creation time = original file creation time (when recording started)
+            #   modification time = portion end time (so mtime - wav_duration = portion start)
+            set_file_times(str(dest_wav), original_ctime, portion_end)
+            print(f"      WAV: {os.path.getsize(str(dest_wav)) / 1024 / 1024:.1f} MB, "
+                  f"ctime preserved, mtime={portion_end.strftime('%H:%M')}")
 
-        # Split transcript
-        portion_transcript = split_transcript(transcript, start_sec, end_sec)
-        dest_json = dest_folder / "transcript.json"
-        with open(dest_json, "w") as f:
-            json.dump(portion_transcript, f, indent=2)
-        print(f"      Transcript: {len(portion_transcript['segments'])} segments")
+            # Split transcript
+            portion_transcript = split_transcript(transcript, start_sec, end_sec)
+            dest_json = dest_folder / "transcript.json"
+            with open(dest_json, "w") as f:
+                json.dump(portion_transcript, f, indent=2)
+            print(f"      Transcript: {len(portion_transcript['segments'])} segments")
 
-        # Flatten
-        try:
-            readable = flatten_transcript(str(dest_json))
-            print(f"      Flattened: {readable}")
-        except Exception as e:
-            print(f"      Flatten failed (non-fatal): {e}")
+            # Flatten
+            try:
+                readable = flatten_transcript(str(dest_json))
+                print(f"      Flattened: {readable}")
+            except Exception as e:
+                print(f"      Flatten failed (non-fatal): {e}")
+    except Exception as exc:
+        _rollback_staging(exc)
+        raise
 
     # --- Verify all splits ---
     print("\nVerifying splits...")

--- a/whisper_sync/transcribe.py
+++ b/whisper_sync/transcribe.py
@@ -641,10 +641,11 @@ def stage_finalize(ctx: dict, result: dict, diarize_segments=None) -> dict:
             }
             for seg in result.get("segments", [])
         ]
-        # meeting_job.step_transcribe reads "speaker_segments" for the
-        # transcript preview log; same mismatched-key family as the stats
-        # above (it always read None before).
-        output["speaker_segments"] = output["segments"]
+        # NOTE: no "speaker_segments" alias. #141 aliased the raw
+        # segments list here for the preview log, but the preview expects
+        # {speaker: [utterances]} and the shape mismatch aborted meeting
+        # jobs right after transcription. meeting_job now groups previews
+        # from "segments" itself (group_speaker_previews).
         # Pass the full parsed transcript dict back to the calling process so
         # downstream steps (notably write_speaker_map) can mutate it in memory
         # rather than re-reading transcript.json on a background thread, which


### PR DESCRIPTION
## Two owner-reported production bugs

**Bug 1 - meetings stopped after transcription** (every past-week recording: transcript.json present, no flatten/speakers/minutes). Today's log shows the exact failure: step_transcribe raises AttributeError at its END because #141 aliased `speaker_segments` to the raw segments LIST while `log_transcript_preview` expects `{speaker: [utterances]}`. The step failed after saving the transcript, aborting the whole job.

Architecture note (transcribe.py, protected path): alias removed; meeting_job groups previews itself (`group_speaker_previews`, garbage-tolerant); `log_transcript_preview` hardened so preview logging can never raise into the pipeline. **WS_E2E verified on real audio.**

**Bug 2 - split_meeting crash on name reuse**: portion [1]'s MMDD_HHMM prefix equals the source's (t=0), so reusing the source name made dest == source (SameFileError; exist_ok could also clobber unrelated folders). Now: all destinations validated before any write (duplicates + occupied destinations rejected cleanly), and the source renames to `<name>.splitting` during the split so name reuse is legitimate. Verification failure preserves the staged source.

## Tests
8 new (5 split on synthetic wavs incl. the exact Patrick scenario, 3 preview/logger incl. the exact production shape). System 188 pass; venv 36; WS_E2E PASS.

Post-merge: the running tray app executes from this checkout and must be restarted to load the fix.