### PR TITLE
test: isolate test artifacts from the live app log and data dir

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,6 +13,15 @@ page disagree, fix the other doc.
 | End-to-end | Production worker subprocess on the smallest real recording (~1 min) | Local, opt-in (`WS_E2E=1`); run after worker-protocol or pipeline changes | see development.md |
 | Manual checklist | Hardware-in-the-loop checks no automated test covers (real mic, hotkeys, tray, GPU) | Local, before releases and after audio/tray changes | [.claude/rules/testing.md](../.claude/rules/testing.md) |
 
+## Test-run isolation
+
+The tray app runs from the repo checkout, so test runs used to write
+into the live app log and live data dir. `tests/__init__.py` now points
+`WS_LOG_DIR` and `WS_DATA_DIR` at a disposable temp dir before any
+whisper_sync import; both the pytest system suite and the unittest venv
+suite get this automatically, and the env vars propagate to the E2E
+worker subprocess. Set either variable explicitly to retarget a run.
+
 ## Where results and decisions are recorded
 
 Test results and the decisions made on them live in the active plan

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,36 @@
+"""Test-run isolation, applied on package import.
+
+The tray app runs FROM this repo checkout, so before this seam existed
+test runs wrote into the live app log (whisper_sync/logs/app/) and the
+live data dir (worker-pids.json picked up test pids, gpu-guard.jsonl got
+test events). Pointing WS_LOG_DIR and WS_DATA_DIR at a disposable temp
+dir keeps production diagnostics clean.
+
+It lives here, not only in conftest.py, because the venv suite runs via
+``python -m unittest tests.<module>`` where pytest conftest never loads;
+both runners import this package before any test module, and
+whisper_sync.logger resolves its log dir at import time. The env vars
+propagate to subprocesses, so the opt-in E2E test (WS_E2E=1) spawns its
+production worker with the same isolation.
+
+An explicitly set WS_LOG_DIR / WS_DATA_DIR is respected, so a developer
+can still point a test run at a specific location.
+"""
+
+import os
+import tempfile
+
+_root = None
+
+
+def _default_env(name: str, subdir: str) -> None:
+    global _root
+    if os.environ.get(name):
+        return
+    if _root is None:
+        _root = tempfile.mkdtemp(prefix="whispersync-tests-")
+    os.environ[name] = os.path.join(_root, subdir)
+
+
+_default_env("WS_LOG_DIR", "logs")
+_default_env("WS_DATA_DIR", "data")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,7 +17,9 @@ An explicitly set WS_LOG_DIR / WS_DATA_DIR is respected, so a developer
 can still point a test run at a specific location.
 """
 
+import atexit
 import os
+import shutil
 import tempfile
 
 _root = None
@@ -29,6 +31,11 @@ def _default_env(name: str, subdir: str) -> None:
         return
     if _root is None:
         _root = tempfile.mkdtemp(prefix="whispersync-tests-")
+        # Auto-created root only - an explicitly set WS_* path is the
+        # user's to manage. ignore_errors: the log FileHandler may still
+        # hold its file open at exit; leftover files are in the system
+        # temp dir and get reaped by the OS eventually.
+        atexit.register(shutil.rmtree, _root, ignore_errors=True)
     os.environ[name] = os.path.join(_root, subdir)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest hook point: apply the isolation seam before collection.
+
+The actual logic lives in tests/__init__.py so the unittest-run venv
+suite gets it too; importing the package here guarantees it runs at
+pytest startup regardless of import mode.
+"""
+
+import tests  # noqa: F401  (import applies WS_LOG_DIR / WS_DATA_DIR)

--- a/tests/test_path_isolation.py
+++ b/tests/test_path_isolation.py
@@ -13,12 +13,14 @@ from whisper_sync import logger, paths
 
 
 class PathIsolationTests(unittest.TestCase):
-    def test_conftest_set_both_overrides(self):
+    def test_isolation_seam_set_both_overrides(self):
         self.assertTrue(os.environ.get("WS_LOG_DIR"))
         self.assertTrue(os.environ.get("WS_DATA_DIR"))
 
     def test_app_log_dir_is_redirected(self):
-        # logger resolves its dir at import time; conftest ran first.
+        # logger resolves its dir at import time; tests/__init__.py ran
+        # first (both runners import the tests package before any test
+        # module).
         self.assertEqual(logger._LOG_DIR, Path(os.environ["WS_LOG_DIR"]))
         repo_log_dir = Path(logger.__file__).parent / "logs" / "app"
         self.assertNotEqual(logger._LOG_DIR, repo_log_dir)

--- a/tests/test_path_isolation.py
+++ b/tests/test_path_isolation.py
@@ -1,0 +1,44 @@
+"""The WS_LOG_DIR / WS_DATA_DIR isolation seam (tests/__init__.py).
+
+Pins that pytest runs are redirected away from the live app log and
+live data dir - the tray app executes from this repo checkout, so a
+regression here silently pollutes production diagnostics again.
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+from whisper_sync import logger, paths
+
+
+class PathIsolationTests(unittest.TestCase):
+    def test_conftest_set_both_overrides(self):
+        self.assertTrue(os.environ.get("WS_LOG_DIR"))
+        self.assertTrue(os.environ.get("WS_DATA_DIR"))
+
+    def test_app_log_dir_is_redirected(self):
+        # logger resolves its dir at import time; conftest ran first.
+        self.assertEqual(logger._LOG_DIR, Path(os.environ["WS_LOG_DIR"]))
+        repo_log_dir = Path(logger.__file__).parent / "logs" / "app"
+        self.assertNotEqual(logger._LOG_DIR, repo_log_dir)
+
+    def test_data_dir_is_redirected(self):
+        data_dir = paths.get_data_dir()
+        self.assertEqual(data_dir, Path(os.environ["WS_DATA_DIR"]))
+        self.assertTrue(data_dir.is_dir())
+
+    def test_data_dir_override_is_read_per_call(self):
+        # get_data_dir honors the env var at call time, not import time,
+        # so a test may retarget it with mock.patch.dict if needed.
+        original = os.environ["WS_DATA_DIR"]
+        try:
+            alt = str(Path(original) / "alt")
+            os.environ["WS_DATA_DIR"] = alt
+            self.assertEqual(paths.get_data_dir(), Path(alt))
+        finally:
+            os.environ["WS_DATA_DIR"] = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/logger.py
+++ b/whisper_sync/logger.py
@@ -6,7 +6,9 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-_LOG_DIR = Path(__file__).parent / "logs" / "app"
+# WS_LOG_DIR redirects app logs (set by tests/__init__.py so test runs
+# never write into the live app log - the tray app runs from this checkout).
+_LOG_DIR = Path(os.environ.get("WS_LOG_DIR") or Path(__file__).parent / "logs" / "app")
 _LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 _log_file = _LOG_DIR / f"whisper-sync-{datetime.now():%Y-%m-%d}.log"

--- a/whisper_sync/paths.py
+++ b/whisper_sync/paths.py
@@ -87,12 +87,12 @@ def _resolve_output_dir() -> Path:
 
 
 def get_data_dir() -> Path:
-    """Return output_dir/.whispersync/, creating it if needed.
+    """Return the user data directory, creating it if needed.
 
-    This is the single source of truth for where user data lives.
-    WS_DATA_DIR overrides the resolved location (set by tests/__init__.py
-    so test runs never write worker-pids.json / gpu-guard.jsonl into
-    the live data dir).
+    This is the single source of truth for where user data lives:
+    output_dir/.whispersync/ normally, or the WS_DATA_DIR override when
+    set (tests/__init__.py sets it so test runs never write
+    worker-pids.json / gpu-guard.jsonl into the live data dir).
     """
     override = os.environ.get("WS_DATA_DIR")
     if override:

--- a/whisper_sync/paths.py
+++ b/whisper_sync/paths.py
@@ -1,6 +1,7 @@
 """Central path resolution for repo mode."""
 
 import json
+import os
 from pathlib import Path
 
 _PKG_DIR = Path(__file__).parent
@@ -89,8 +90,15 @@ def get_data_dir() -> Path:
     """Return output_dir/.whispersync/, creating it if needed.
 
     This is the single source of truth for where user data lives.
+    WS_DATA_DIR overrides the resolved location (set by tests/__init__.py
+    so test runs never write worker-pids.json / gpu-guard.jsonl into
+    the live data dir).
     """
-    p = _resolve_output_dir() / ".whispersync"
+    override = os.environ.get("WS_DATA_DIR")
+    if override:
+        p = Path(override)
+    else:
+        p = _resolve_output_dir() / ".whispersync"
     p.mkdir(parents=True, exist_ok=True)
     return p
 


### PR DESCRIPTION
## Summary

The tray app executes FROM this repo checkout, so every pytest run polluted production diagnostics: test log lines landed in the live app log (whisper_sync/logs/app), worker-pids.json picked up test pids (111/444 on 2026-07-03), and gpu-guard.jsonl got test events, muddying the BSOD-correlation timeline.

- tests/__init__.py sets WS_LOG_DIR and WS_DATA_DIR to a disposable temp dir before any whisper_sync import. It lives in the package init, not only conftest.py, because the venv suite runs via python -m unittest where conftest never loads; both runners import the package first.
- whisper_sync/logger.py honors WS_LOG_DIR (resolved at import time, which is why the seam must run first).
- whisper_sync/paths.get_data_dir() honors WS_DATA_DIR (read per call).
- Explicitly set env vars are respected; both propagate to the E2E worker subprocess.
- docs/testing.md documents the seam (same-PR docs rule).

Hygiene sub-task of hardening item 6 (docs/plans/2026-07-03-hardening-round.md closing entry).

## Testing

- System suite: 193 passed (189 + 4 new in tests/test_path_isolation.py pinning redirection of both paths).
- Verified live-file hygiene during the run: the live app log received only the running app's own heartbeat lines; the test log file and data writes landed in the temp dir.