### PR TITLE
feat: extract dictation flow from __main__ into dictation_flow.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ When a user reports that a meeting "crashed" or "failed" or "didn't finish", do 
 
 | Module | Purpose |
 |--------|---------|
-| `__main__.py` | Entry point. Tray icon, hotkeys, recording flows, GitHub status, incognito, session stats. Uses StateManager for all state transitions. |
+| `__main__.py` | Entry point. Tray icon, hotkey wiring, meeting flow, menu/settings, GitHub status, session stats. Workflows are being extracted into flow modules (hardening item 6). |
+| `dictation_flow.py` | Dictation workflow component: normal/feature-suggest/overlay dictation, auto-stop cap, discard, crash recovery, history. Feature routing state lives in AppState.feature_suggest. |
 | `state_manager.py` | Observable state machine. AppState dataclass, typed StateEvent, event constants, thread-safe emit(), listener subscriptions (on/on_any), event log ringbuffer. All icon/toast updates flow through here. |
 | `transcribe.py` | WhisperX with persistent model cache. Fast path (dictation) and staged pipeline (meeting) |
 | `worker.py` | Multiprocessing transcription worker. CUDA isolation via spawn context |

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -10,7 +10,8 @@ Everything below is for developers modifying this app or for an AI assistant (li
 
 | File | Purpose | Key Classes/Functions |
 |------|---------|----------------------|
-| `__main__.py` | **App entry point.** Tray icon, hotkey listener, recording lifecycle, crash recovery. | `WhisperSync` class --`run()`, `_on_hotkey()`, `_start_dictation()`, `_start_meeting()`, `_do_transcribe()`, `_paste_result()`, `_recover_from_crash()` |
+| `__main__.py` | **App entry point.** Tray icon, hotkey wiring, meeting lifecycle, menu, settings, updates. Workflows are being extracted into flow modules (hardening item 6). | `WhisperSync` class --`run()`, `toggle_meeting()`, `_start_meeting()`, `_stop_meeting()`, `_build_menu()`, `main()` |
+| `dictation_flow.py` | **Dictation workflow.** Normal, feature-suggest, and overlay dictation; auto-stop cap, discard, crash recovery, recent history. Feature routing lives in `AppState.feature_suggest`. | `DictationFlow` class --`toggle()`, `toggle_feature_suggest()`, `discard()`, `recover_dictation()`, `recover_feature()`, `recent_history()` |
 | `capture.py` | **Audio recording.** Multi-stream mic + speaker loopback via WASAPI. | `AudioRecorder` class --`start()`, `stop()`, `_mic_callback()`, `_speaker_callback()`, `start_streaming()`, `stop_streaming()` |
 | `transcribe.py` | **WhisperX engine.** Model loading, transcription, alignment, diarization. Two paths: fast (dictation) and full (meeting). | `transcribe_fast(audio_np, model)` -- in-memory numpy to text; `transcribe(audio_path, diarize, model)` -- file-based full pipeline; `_load_model()`, `_load_align_model()` |
 | `worker.py` | **Subprocess entry point.** Runs transcription in isolated process (crash safety). Receives requests via Queue, returns results. | `worker_main()` -- event loop handling `transcribe_fast`, `transcribe`, `reload_model`, `shutdown` requests |
@@ -50,6 +51,7 @@ Everything below is for developers modifying this app or for an AI assistant (li
 
 ```
 __main__.py (entry point, UI, hotkeys)
+├── dictation_flow.py (dictation workflow component)
 ├── config.py (settings)
 ├── paths.py (directories)
 ├── logger.py (logging)
@@ -77,8 +79,8 @@ benchmark.py (standalone utility)
 
 ```
 User presses Ctrl+Shift+Space
-  -> __main__._on_hotkey("dictation")
-  -> __main__._start_dictation()
+  -> dictation_flow.DictationFlow.toggle()
+  -> dictation_flow.DictationFlow._start()
     -> capture.AudioRecorder.start() [mic only, records to numpy array]
     -> User presses hotkey again
     -> capture.AudioRecorder.stop() -> numpy audio data
@@ -97,7 +99,7 @@ User presses Ctrl+Shift+Space
 
 ```
 User presses Ctrl+Shift+M
-  -> __main__._on_hotkey("meeting")
+  -> __main__.toggle_meeting()
   -> __main__._start_meeting()
     -> Prompts for meeting name (popup dialog)
     -> capture.AudioRecorder.start() [mic + speaker loopback]

--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -179,6 +179,35 @@ in one place, not a branching if/then system and not a framework.
   Production validation (docs/testing.md five signals + gpu-guard.jsonl
   correlation) still awaits the owner updating the running app.
 
+- **2026-07-03 (item 6 opened, fresh session)**: hygiene sub-task first
+  (#168): tests/__init__.py points WS_LOG_DIR + WS_DATA_DIR at a temp
+  dir before any whisper_sync import, so test runs no longer pollute
+  the live app log / worker-pids.json / gpu-guard.jsonl (the tray app
+  runs FROM this checkout). Seam lives in the package init, not
+  conftest, because the venv suite runs under unittest. Soak check on
+  MODE_TRANSITIONS: zero "Unexpected mode transition" warnings in all
+  app logs, BUT the running app predates #164, so the soak clock only
+  starts once the owner restarts onto current dev - warn-to-reject
+  stays deferred past this round.
+
+- **2026-07-03 (item 6, extraction 1)**: dictation flow extracted to
+  dictation_flow.py (~700 lines out of __main__.py: toggles, start/
+  stop, auto-stop cap, overlay dictation, discard, crash recovery,
+  feature formatting, recent history). _feature_suggest_active FOLDED
+  into AppState.feature_suggest: intent passes down as a parameter and
+  enters state atomically with DICTATION_STARTED, clearing on the
+  completion/discard/idle emit - the old set-then-unwind pattern (15+
+  sites) is gone. Duplicated overlay bookkeeping (backup path vs
+  fallback path) collapsed into _deliver_overlay. Heavy deps (capture,
+  backup_worker, paste) import lazily so the flow is testable on the
+  dependency-light system python - 20 unit tests the god-class made
+  impossible, incl. the feature-flag lifecycle and the overlay
+  fallback. DEVIATION from the closing-entry list: _flash_active stays
+  a UI-owned animation gate (moves out with the menu extraction, not
+  into AppState - a cosmetic flash gate in the event log would push
+  out useful history); _updating folds during the lifecycle
+  extraction as planned.
+
 - **2026-07-03 (production bugs, owner-reported)**: two real bugs from
   field use, both fixed. (1) PIPELINE ABORT AFTER TRANSCRIPTION: every
   past-week meeting had transcript.json but no flatten/speakers/minutes.

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -1,0 +1,362 @@
+"""Tests for whisper_sync.dictation_flow.DictationFlow.
+
+The extraction target (hardening item 6): dictation behavior must be
+testable without the tray, hotkeys, or a real worker. Everything the
+flow reaches through the app back-reference is faked; async work runs
+inline via a patched submit_or_spawn.
+
+Also pins the AppState.feature_suggest fold: feature intent enters
+state atomically with DICTATION_STARTED and always clears on the way
+out, including failure and no-audio paths.
+"""
+
+import sys
+import threading
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from whisper_sync import dictation_flow
+from whisper_sync.dictation_flow import DictationFlow, safe_unlink
+from whisper_sync.state_manager import StateManager, MEETING_STARTED
+
+
+class _FakeRecorder:
+    def __init__(self):
+        self.is_recording = False
+        self.streaming_path = None
+        self.audio = {"mic": "AUDIO"}
+        self.stop_streaming_calls = 0
+        self.fail_start = False
+
+    def start(self, mic_device=None):
+        if self.fail_start:
+            raise RuntimeError("no mic")
+        self.is_recording = True
+
+    def start_streaming(self, path):
+        self.streaming_path = path
+
+    def stop(self):
+        self.is_recording = False
+        return self.audio
+
+    def stop_streaming(self):
+        self.stop_streaming_calls += 1
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.ready = True
+        self.calls = []
+
+    def is_ready(self):
+        return self.ready
+
+    def transcribe_fast(self, audio, model_override=None, timeout=None):
+        self.calls.append(model_override)
+        return "hello world"
+
+
+class _FakeBackup:
+    is_loading = False
+
+    def __init__(self):
+        self.calls = 0
+
+    def transcribe(self, audio):
+        self.calls += 1
+        return "overlay text"
+
+
+class _FakeGuard:
+    def effective_model(self, model):
+        return model
+
+    def note_pressure_trigger(self, reason):
+        pass
+
+
+class _FakeStats:
+    def __init__(self):
+        self.dictation_chars = []
+        self.features = 0
+
+    def record_dictation(self, chars, duration):
+        self.dictation_chars.append(chars)
+
+    def record_feature_suggestion(self):
+        self.features += 1
+
+
+class _FakeApp:
+    def __init__(self):
+        self.cfg = {
+            "sample_rate": 16000,
+            "model": "large-v3",
+            "paste_method": "clipboard",
+            "incognito": False,
+            "always_available_dictation": True,
+            "use_system_devices": False,
+            "mic_device": None,
+            "dictation_max_minutes": 30,
+        }
+        self._lock = threading.RLock()
+        self.state = StateManager(None, {})
+        self.recorder = _FakeRecorder()
+        self.worker = _FakeWorker()
+        self._backup = _FakeBackup()
+        self._gpu_guard = _FakeGuard()
+        self._stats = _FakeStats()
+        self.flashes = 0
+        self.refreshes = 0
+
+    def _yellow_flash(self):
+        self.flashes += 1
+
+    def _flash_queued(self):
+        pass
+
+    def _schedule_idle(self, seconds, blink=False):
+        pass
+
+    def _refresh_menu(self):
+        self.refreshes += 1
+
+    def _can_record(self):
+        mode = self.state.current.mode
+        return mode is None or mode in ("transcribing", "done", "error")
+
+
+def _inline(lane, label, fn, native=False):
+    fn()
+
+
+class _FlowHarness(unittest.TestCase):
+    """Fakes everything the flow reaches: app services via _FakeApp, and
+    the numpy/pyperclip-dependent modules (capture, backup_worker, paste)
+    via sys.modules stubs - the flow imports those lazily so the system
+    suite runs without the heavyweight venv."""
+
+    def setUp(self):
+        self.app = _FakeApp()
+        # load_recent reads the (isolated) dictation log dir; start empty.
+        with mock.patch.object(dictation_flow.dictation_log, "load_recent",
+                               return_value=[]):
+            self.flow = DictationFlow(self.app)
+
+        self.paste = mock.Mock()
+        fake_paste = types.ModuleType("whisper_sync.paste")
+        fake_paste.paste = self.paste
+
+        fake_backup_mod = types.ModuleType("whisper_sync.backup_worker")
+
+        class _FakeBackupCls:
+            @staticmethod
+            def is_enabled(cfg=None):
+                return (cfg or {}).get("always_available_dictation", True)
+        fake_backup_mod.BackupTranscriber = _FakeBackupCls
+
+        self.fake_capture = types.ModuleType("whisper_sync.capture")
+        self.fake_capture.get_default_devices = lambda: {"input": None}
+        self.fake_capture.AudioRecorder = _FakeRecorder
+
+        patches = [
+            mock.patch.dict(sys.modules, {
+                "whisper_sync.paste": fake_paste,
+                "whisper_sync.backup_worker": fake_backup_mod,
+                "whisper_sync.capture": self.fake_capture,
+            }),
+            mock.patch.object(dictation_flow, "submit_or_spawn", _inline),
+            mock.patch.object(dictation_flow, "notify"),
+            mock.patch.object(dictation_flow.dictation_log, "append"),
+            mock.patch.object(dictation_flow.weekly_stats, "record_dictation"),
+            mock.patch.object(dictation_flow.weekly_stats, "record_feature_suggestion"),
+            mock.patch.object(DictationFlow, "_format_feature_async"),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+
+class NormalDictationTests(_FlowHarness):
+    def test_toggle_starts_then_stops_and_pastes(self):
+        self.flow.toggle()
+        self.assertEqual(self.app.state.current.mode, "dictation")
+        self.assertTrue(self.app.recorder.is_recording)
+        self.assertIsNotNone(self.flow._wav_path, "disk-first streaming path armed")
+
+        self.flow.toggle()
+        self.paste.assert_called_once()
+        self.assertEqual(self.paste.call_args[0][0], "hello world")
+        self.assertEqual(self.app.state.current.mode, "done")
+        self.assertEqual(self.app._stats.dictation_chars, [len("hello world")])
+        history = self.flow.recent_history()
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0]["text"], "hello world")
+
+    def test_cap_armed_on_start_and_cancelled_on_stop(self):
+        self.flow.toggle()
+        self.assertIsNotNone(self.flow._cap_handle)
+        self.flow.toggle()
+        self.assertIsNone(self.flow._cap_handle)
+
+    def test_worker_not_ready_flashes_and_stays_idle(self):
+        self.app.worker.ready = False
+        self.flow.toggle()
+        self.assertEqual(self.app.flashes, 1)
+        self.assertIsNone(self.app.state.current.mode)
+
+    def test_mic_failure_returns_to_idle_and_clears_feature(self):
+        self.app.recorder.fail_start = True
+        self.flow.toggle_feature_suggest()
+        self.assertIsNone(self.app.state.current.mode)
+        self.assertFalse(self.app.state.current.feature_suggest)
+
+    def test_no_audio_clears_feature_flag(self):
+        self.flow.toggle_feature_suggest()
+        self.assertTrue(self.app.state.current.feature_suggest)
+        self.app.recorder.audio = {}  # mic delivered nothing
+        self.flow.toggle_feature_suggest()
+        self.assertIsNone(self.app.state.current.mode)
+        self.assertFalse(self.app.state.current.feature_suggest)
+
+    def test_concurrent_mode_change_rejects_start(self):
+        # try_transition must reject when mode moved to a non-startable
+        # value between the toggle's check and the start.
+        self.app.state.emit(MEETING_STARTED, mode="saving")
+        self.flow._start(feature=False)
+        self.assertFalse(self.app.recorder.is_recording)
+
+    def test_discard_throws_audio_away(self):
+        self.flow.toggle()
+        self.flow.discard()
+        self.assertIsNone(self.app.state.current.mode)
+        self.assertFalse(self.app.recorder.is_recording)
+        self.paste.assert_not_called()
+
+    def test_incognito_skips_disk_streaming(self):
+        self.app.cfg["incognito"] = True
+        self.flow.toggle()
+        self.assertIsNone(self.flow._wav_path)
+        self.assertIsNone(self.app.recorder.streaming_path)
+
+
+class FeatureSuggestTests(_FlowHarness):
+    def test_feature_routes_to_feature_log_not_paste(self):
+        with mock.patch.object(dictation_flow.feature_log, "append_raw",
+                               return_value="id-1") as append_raw:
+            self.flow.toggle_feature_suggest()
+            self.assertTrue(self.app.state.current.feature_suggest)
+            self.assertEqual(self.app.state.current.mode, "dictation")
+            self.assertTrue(str(self.flow._wav_path.name).startswith("feature_"))
+
+            self.flow.toggle_feature_suggest()
+            append_raw.assert_called_once()
+        self.paste.assert_not_called()
+        self.assertFalse(self.app.state.current.feature_suggest)
+        self.assertEqual(self.app._stats.features, 1)
+
+    def test_normal_toggle_also_stops_a_feature_recording(self):
+        # The dictation hotkey stops whatever dictation is active; the
+        # feature routing must follow the state, not the hotkey used.
+        with mock.patch.object(dictation_flow.feature_log, "append_raw",
+                               return_value="id-1") as append_raw:
+            self.flow.toggle_feature_suggest()
+            self.flow.toggle()  # normal hotkey stops it
+            append_raw.assert_called_once()
+        self.paste.assert_not_called()
+
+    def test_feature_hotkey_ignored_during_normal_dictation(self):
+        self.flow.toggle()
+        self.flow.toggle_feature_suggest()
+        # Still recording the normal dictation; no state change
+        self.assertEqual(self.app.state.current.mode, "dictation")
+        self.assertFalse(self.app.state.current.feature_suggest)
+
+
+class OverlayDictationTests(_FlowHarness):
+    def setUp(self):
+        super().setUp()
+        self.app.state.emit(MEETING_STARTED, mode="meeting")
+        self.overlay_recorder = _FakeRecorder()
+        self.fake_capture.AudioRecorder = (
+            lambda sample_rate=None: self.overlay_recorder)
+
+    def test_toggle_starts_overlay_and_stop_uses_backup(self):
+        self.flow.toggle()
+        self.assertTrue(self.app.state.current.dictation_overlay)
+        self.assertTrue(self.flow.overlay_active)
+        self.assertTrue(self.overlay_recorder.is_recording)
+        self.assertEqual(self.app.state.current.mode, "meeting",
+                         "meeting recording must be untouched")
+
+        self.flow.toggle()
+        self.assertFalse(self.app.state.current.dictation_overlay)
+        self.assertEqual(self.app._backup.calls, 1)
+        self.paste.assert_called_once_with(
+            "overlay text", "clipboard", restore=True)
+        self.assertEqual(self.flow.recent_history()[0]["text"], "overlay text")
+
+    def test_overlay_feature_suggest_routes_to_feature_log(self):
+        with mock.patch.object(dictation_flow.feature_log, "append_raw",
+                               return_value="id-2") as append_raw:
+            self.flow.toggle_feature_suggest()
+            self.assertTrue(self.app.state.current.feature_suggest)
+            self.assertTrue(self.flow._overlay_wav_path.name.startswith("overlay_feature_"))
+            self.flow.toggle_feature_suggest()
+            append_raw.assert_called_once()
+        self.assertFalse(self.app.state.current.feature_suggest)
+        self.paste.assert_not_called()
+
+    def test_backup_loading_flashes_instead_of_starting(self):
+        self.app._backup.is_loading = True
+        self.flow.toggle()
+        self.assertEqual(self.app.flashes, 1)
+        self.assertFalse(self.flow.overlay_active)
+
+    def test_backup_failure_falls_back_to_main_worker(self):
+        self.app._backup.transcribe = mock.Mock(side_effect=RuntimeError("boom"))
+        self.flow.toggle()
+        self.flow.toggle()
+        self.assertEqual(self.app.worker.calls, ["large-v3"],
+                         "fallback must queue on the main worker")
+        self.paste.assert_called_once()
+
+    def test_discard_overlay(self):
+        self.flow.toggle()
+        self.flow.discard()
+        self.assertFalse(self.app.state.current.dictation_overlay)
+        self.assertFalse(self.flow.overlay_active)
+        self.assertFalse(self.app.state.current.feature_suggest)
+        self.paste.assert_not_called()
+
+
+class HistoryTests(_FlowHarness):
+    def test_history_trims_to_limit(self):
+        for i in range(15):
+            self.flow._record_history(f"text {i}")
+        history = self.flow.recent_history()
+        self.assertEqual(len(history), dictation_flow.HISTORY_LIMIT)
+        self.assertEqual(history[-1]["text"], "text 14")
+        self.assertEqual(history[0]["text"], "text 5")
+
+    def test_clear_history_refreshes_menu(self):
+        self.flow._record_history("x")
+        before = self.app.refreshes
+        self.flow.clear_history()
+        self.assertEqual(self.flow.recent_history(), [])
+        self.assertGreater(self.app.refreshes, before)
+
+
+class SafeUnlinkTests(unittest.TestCase):
+    def test_missing_file_is_a_noop(self):
+        safe_unlink(Path("Z:/does/not/exist.wav"))
+
+    def test_none_is_a_noop(self):
+        safe_unlink(None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -324,6 +324,18 @@ class OverlayDictationTests(_FlowHarness):
                          "fallback must queue on the main worker")
         self.paste.assert_called_once()
 
+    def test_feature_hotkey_ignored_during_normal_overlay(self):
+        # Review catch: starting a feature overlay while a NORMAL overlay
+        # dictation records would overwrite _overlay_recorder and
+        # double-open the mic. The hotkey must be a no-op instead.
+        self.flow.toggle()  # normal overlay recording
+        first_recorder = self.flow._overlay_recorder
+        self.flow.toggle_feature_suggest()
+        self.assertIs(self.flow._overlay_recorder, first_recorder,
+                      "overlay recorder must not be replaced")
+        self.assertTrue(first_recorder.is_recording)
+        self.assertFalse(self.app.state.current.feature_suggest)
+
     def test_discard_overlay(self):
         self.flow.toggle()
         self.flow.discard()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -26,7 +26,6 @@ warnings.filterwarnings("ignore", message="std\\(\\): degrees of freedom is <= 0
 logging.getLogger("lightning.pytorch.utilities.migration.utils").setLevel(logging.ERROR)
 logging.getLogger("whisperx.vads.pyannote").setLevel(logging.WARNING)
 logging.getLogger("whisperx.diarize").setLevel(logging.WARNING)
-import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -40,19 +39,16 @@ from .idle_reset import schedule_idle_reset
 from .capture import AudioRecorder, get_default_devices, get_host_apis, list_devices, save_wav, save_stereo_wav
 from .icons import (idle_icon, build_icon, resolve_icon_key, ICON_REGISTRY,
                      IconAnimator)
-from .logger import logger, get_log_path, set_console_level, log_dictation_result, log_meeting_result, log_transcript_preview
+from .logger import logger, get_log_path, set_console_level
 from .model_status import get_model_status, download_model, bootstrap_models
-from .paste import paste
-from .paths import (get_install_root, get_default_output_dir,
+from .paths import (get_install_root,
                      get_data_dir, get_dictation_log_dir,
                      get_legacy_config_path, get_legacy_speaker_config_path,
                      get_legacy_dictation_log_dir, get_config_path as get_data_config_path,
                      get_speaker_config_path)
-from .worker_manager import TranscriptionWorker, WorkerCrashedError
+from .worker_manager import TranscriptionWorker
 from .gpu_guard import GpuGuard
 from .backup_worker import BackupTranscriber
-from . import dictation_log
-from . import feature_log
 from . import weekly_stats
 from .streaming_wav import fix_orphan
 from .crash_diagnostics import install_excepthook, check_previous_crash, install_faulthandler
@@ -63,12 +59,12 @@ from .notifications import notify, ToastListener
 from .state_manager import (
     StateManager, AppState,
     MEETING_STARTED, MEETING_STOPPED, MEETING_COMPLETED,
-    DICTATION_STARTED, DICTATION_COMPLETED, DICTATION_DISCARDED,
     TRANSCRIPTION_STARTED, TRANSCRIPTION_PROGRESS, TRANSCRIPTION_COMPLETED,
     ERROR, MODEL_LOADING, MODEL_READY, MODEL_DOWNLOADING,
     PR_STATUS_CHANGED, SPEAKER_HEALTH_CHANGED, QUEUED, IDLE,
 )
 from .meeting_job import MeetingJob
+from .dictation_flow import DictationFlow
 from .rebuild_index import rebuild_root_index
 from .speakers import identify_speakers, write_speaker_map, update_config, get_config_path
 from .dialog_dispatcher import DialogDispatcher
@@ -146,18 +142,14 @@ class WhisperSync:
         self._lock = threading.RLock()
         self._tray_lock = threading.Lock()  # Serialize all tray icon/title updates (pystray not thread-safe)
         self._api_filter = "Windows WASAPI"  # None = show all
-        self._dictation_wav_path: Path | None = None
         self._meeting_start_time: datetime | None = None
         self._gpu_guard = GpuGuard(self.cfg, notify=notify)
         dictation_model = self._gpu_guard.effective_model(
             self.cfg.get("dictation_model", self.cfg["model"]))
         self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
         self._backup = BackupTranscriber(self.cfg)
-        self._overlay_recorder = None    # Separate AudioRecorder for dictation during meetings
         self._github_poller = None
         self._github_prs = []
-        self._dictation_history = dictation_log.load_recent(10)  # persist across restarts
-        self._feature_suggest_active = False  # routes dictation output to feature log
         self._post_queue = queue.Queue()  # Post-processing queue for completed meetings
         self._post_worker_thread = None  # Started in run()
         # Single long-lived thread for ALL tkinter dialogs. tk.Tk() must not
@@ -171,13 +163,14 @@ class WhisperSync:
         # worker threads concurrently (see session_stats.py).
         from .session_stats import SessionStats
         self._stats = SessionStats()
-        # _dictation_history is appended from dictation AND overlay worker
-        # threads and read by menu builds; guard every access.
-        self._dictation_history_lock = threading.Lock()
         # Flash gate: lock-guarded check-and-set (Event.is_set()+set() alone
         # is not atomic; two hotkey threads could both observe False).
         self._flash_lock = threading.Lock()
         self._flash_active = threading.Event()
+        # Dictation workflow component (dictation_flow.py): dictation,
+        # overlay, feature-suggest, discard, recovery, history. The app
+        # remains the wiring surface (hardening item 6).
+        self.dictation = DictationFlow(self)
 
     @staticmethod
     def _migrate_data():
@@ -261,7 +254,7 @@ class WhisperSync:
         if action == "meeting":
             self.toggle_meeting()
         elif action == "dictation":
-            self.toggle_dictation()
+            self.dictation.toggle()
 
     def _on_left_click(self):
         # Left-click while dictating = discard (stop recording, throw away audio)
@@ -269,7 +262,7 @@ class WhisperSync:
         mode = current.mode if current else None
         overlay = current.dictation_overlay if current else False
         if mode == "dictation" or overlay:
-            self._discard_dictation()
+            self.dictation.discard()
             return
         self._dispatch_action(self.cfg.get("left_click", "meeting"))
 
@@ -286,21 +279,6 @@ class WhisperSync:
         """
         schedule_idle_reset(self.state, seconds, blink)
 
-    @staticmethod
-    def _safe_unlink(path: Path, retries: int = 2, delay: float = 0.5):
-        """Delete a file, retrying on PermissionError (Windows file locking)."""
-        import time
-        for attempt in range(retries + 1):
-            try:
-                if path and path.exists():
-                    path.unlink(missing_ok=True)
-                return
-            except PermissionError:
-                if attempt < retries:
-                    time.sleep(delay)
-                else:
-                    logger.debug(f"Could not delete {path} — will clean up on next restart")
-
     def _flash_queued(self):
         """Rapid amber flash to indicate dictation is queued behind a meeting stage."""
         animator = IconAnimator(self.tray, lock=self._tray_lock)
@@ -310,607 +288,6 @@ class WhisperSync:
         """Can we start a new recording? Allowed if idle or just transcribing in background."""
         mode = self.state.current.mode if self.state else None
         return mode is None or mode in ("transcribing", "done", "error")
-
-    def toggle_dictation(self):
-        with self._lock:
-            current = self.state.current if self.state else None
-            mode = current.mode if current else None
-            overlay = current.dictation_overlay if current else False
-            meeting_tx = current.meeting_transcribing if current else False
-
-            # Handle overlay dictation during meetings
-            if overlay:
-                self._stop_overlay_dictation()
-                return
-
-            if mode == "dictation":
-                self._stop_dictation()
-            elif mode == "meeting" or (mode is None and meeting_tx):
-                # Dictation during meeting recording or meeting transcription
-                if self.cfg.get("always_available_dictation", True):
-                    if self._backup.is_loading:
-                        logger.debug("Backup model still loading, triggering yellow flash", extra={"secondary": True})
-                        self._yellow_flash()
-                        return
-                    self._start_overlay_dictation()
-                else:
-                    logger.info("Dictation unavailable during meeting (always_available_dictation disabled)", extra={"secondary": True})
-                    notify("Dictation unavailable", "Enable always-available dictation in settings")
-            elif mode == "saving":
-                logger.debug("Dictation ignored - meeting is saving")
-            elif self._can_record():
-                self._start_dictation()
-
-    def toggle_feature_suggest(self):
-        """Toggle feature suggestion recording (same as dictation but saves to feature log)."""
-        with self._lock:
-            current = self.state.current if self.state else None
-            mode = current.mode if current else None
-            overlay = current.dictation_overlay if current else False
-            meeting_tx = current.meeting_transcribing if current else False
-
-            # If already recording a feature suggestion, stop it
-            if overlay and self._feature_suggest_active:
-                self._stop_overlay_dictation()
-                return
-            if mode == "dictation" and self._feature_suggest_active:
-                self._stop_dictation()
-                return
-
-            # Start feature suggestion (reuses dictation pipeline)
-            if mode == "dictation" and not self._feature_suggest_active:
-                # Already recording a normal dictation - ignore
-                logger.debug("Feature suggest ignored - dictation in progress")
-                return
-
-            self._feature_suggest_active = True
-            if mode == "meeting" or (mode is None and meeting_tx):
-                if self.cfg.get("always_available_dictation", True):
-                    if self._backup.is_loading:
-                        self._feature_suggest_active = False
-                        logger.debug("Backup model still loading, triggering yellow flash", extra={"secondary": True})
-                        self._yellow_flash()
-                        return
-                    self._start_overlay_dictation()
-                else:
-                    self._feature_suggest_active = False
-                    logger.info("Feature suggest unavailable during meeting (always_available_dictation disabled)", extra={"secondary": True})
-                    notify("Feature suggest unavailable", "Enable always-available dictation in settings")
-            elif mode == "saving":
-                self._feature_suggest_active = False
-                logger.debug("Feature suggest ignored - meeting is saving")
-            elif self._can_record():
-                self._start_dictation()
-            else:
-                self._feature_suggest_active = False
-
-    def _dictation_log_dir(self) -> Path:
-        return get_dictation_log_dir()
-
-    def _start_dictation(self):
-        _meeting_tx = self.state.current.meeting_transcribing if self.state else False
-        if not self.worker.is_ready() and not (_meeting_tx and BackupTranscriber.is_enabled(self.cfg)):
-            logger.warning("Worker not ready yet - ignoring dictation request")
-            self._feature_suggest_active = False
-            self._yellow_flash()
-            return
-        # Atomic claim: only start if mode is still startable. A worker
-        # completion (or a double-fired hotkey on another thread) changing
-        # mode between the toggle's check and this start is rejected here
-        # instead of producing two concurrent recording sessions.
-        if not self.state.try_transition(
-            (None, "transcribing", "done", "error"),
-            DICTATION_STARTED, mode="dictation",
-        ):
-            logger.debug("dictation start rejected: mode changed concurrently")
-            self._feature_suggest_active = False
-            return
-        mic = self.cfg.get("mic_device")
-        if self.cfg.get("use_system_devices", True):
-            # Explicitly use the WASAPI default instead of falling through
-            # to sd.default.device[0], which on Windows resolves to an MME
-            # device and often rejects float32 @ 16 kHz with MME error 32.
-            mic = get_default_devices().get("input")
-        try:
-            self.recorder.start(mic_device=mic)
-        except Exception as e:
-            logger.error("Failed to start mic for dictation: %s", e, exc_info=True)
-            notify("Dictation unavailable", f"Mic could not be opened: {e}")
-            self._feature_suggest_active = False
-            self.state.emit(IDLE, mode=None)
-            return
-        # Stream to disk for crash recovery -- skip when incognito (RAM only)
-        if self.cfg.get("incognito", False):
-            self._dictation_wav_path = None
-        else:
-            log_dir = self._dictation_log_dir()
-            log_dir.mkdir(parents=True, exist_ok=True)
-            ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            prefix = "feature_" if self._feature_suggest_active else ""
-            self._dictation_wav_path = log_dir / f"{prefix}{ts}.wav"
-            try:
-                self.recorder.start_streaming(self._dictation_wav_path)
-            except Exception as e:
-                logger.warning("Dictation disk streaming disabled: %s", e)
-                self._dictation_wav_path = None
-
-        # Memory protection: dictation mic audio accumulates in RAM
-        # (~230 MB/hour @16k float32). A forgotten hotkey used to grow
-        # unbounded. Auto-stop at the configured cap; the audio captured
-        # so far is transcribed normally, nothing is lost.
-        self._arm_dictation_cap()
-
-    def _arm_dictation_cap(self):
-        """Schedule the dictation auto-stop cap for this session."""
-        cap_min = float(self.cfg.get("dictation_max_minutes", 30) or 0)
-        if cap_min <= 0:
-            return
-        from .scheduler import scheduler
-
-        def _cap_hit():
-            mode = self.state.current.mode if self.state else None
-            if mode != "dictation":
-                return  # session already ended normally
-
-            def _do_stop():
-                logger.warning(
-                    "Dictation auto-stopped at %.0f min cap "
-                    "(dictation_max_minutes; audio so far is transcribed)",
-                    cap_min,
-                )
-                try:
-                    notify(
-                        "Dictation auto-stopped",
-                        f"Hit the {cap_min:.0f} min cap; transcribing what was recorded",
-                    )
-                except Exception:
-                    pass
-                # toggle takes the app lock and routes by current mode, so
-                # a user stop racing this is benign (mode check repeats
-                # under the lock inside toggle_dictation).
-                self.toggle_dictation()
-
-            # Scheduler jobs must stay short (scheduler.py contract):
-            # toggle acquires the app lock and stops the recorder, so
-            # offload it instead of blocking other timer jobs (menu
-            # refresh, idle GC).
-            submit_or_spawn(DICTATION, "dictation-cap-stop", _do_stop)
-
-        self._cancel_dictation_cap()
-        self._dictation_cap_handle = scheduler.call_later(
-            cap_min * 60.0, _cap_hit, label="dictation-cap"
-        )
-
-    def _cancel_dictation_cap(self):
-        handle = getattr(self, "_dictation_cap_handle", None)
-        if handle is not None:
-            handle.cancel()
-            self._dictation_cap_handle = None
-
-    def _stop_dictation(self):
-        self._cancel_dictation_cap()
-        audio = self.recorder.stop()
-        self.recorder.stop_streaming()
-
-        if "mic" not in audio:
-            self._feature_suggest_active = False
-            self.state.emit(IDLE, mode=None)
-            return
-
-        self.state.emit(TRANSCRIPTION_STARTED, mode="transcribing")
-
-        dictation_model = self._gpu_guard.effective_model(
-            self.cfg.get("dictation_model", self.cfg["model"]))
-        use_backup = self.state.current.meeting_transcribing and BackupTranscriber.is_enabled(self.cfg)
-        # Capture feature flag under lock before spawning background thread
-        with self._lock:
-            is_feature = self._feature_suggest_active
-            self._feature_suggest_active = False
-
-        def _process():
-            import time as _time
-
-            t0 = _time.perf_counter()
-            try:
-                text = None
-                used_backup = False
-                if use_backup:
-                    # Meeting is transcribing - use lightweight backup model
-                    # instead of queuing on the busy worker
-                    try:
-                        text = self._backup.transcribe(audio["mic"])
-                        used_backup = True
-                        t1 = _time.perf_counter()
-                        backup_model = self.cfg.get("backup_model", "base")
-                        backup_device = self.cfg.get("backup_device", "cpu")
-                        logger.info(
-                            f"Dictation (backup, {backup_device} {backup_model}): "
-                            f"{t1 - t0:.2f}s",
-                            extra={"secondary": True},
-                        )
-                    except Exception as backup_err:
-                        # Backup failed - fall back to queuing on the main worker
-                        logger.warning(f"Backup transcriber failed: {backup_err}", extra={"secondary": True})
-                        logger.info("Falling back to main worker (queued)", extra={"secondary": True})
-                        self._flash_queued()
-                        timeout = 180
-                        text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
-                        t1 = _time.perf_counter()
-                        logger.debug(f"transcribe_fast (fallback): {t1 - t0:.2f}s")
-                else:
-                    # Normal path or backup disabled
-                    if self.state.current.meeting_transcribing:
-                        self._flash_queued()
-                    timeout = 180 if self.state.current.meeting_transcribing else 60
-                    text = self.worker.transcribe_fast(audio["mic"], model_override=dictation_model, timeout=timeout)
-                    t1 = _time.perf_counter()
-                    logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
-                t2 = _time.perf_counter()
-                char_count = len(text) if text else 0
-
-                if is_feature:
-                    # Feature suggestion mode
-                    if not text:
-                        logger.info("Feature suggestion discarded (no speech detected)")
-                    elif self.cfg.get("incognito", False):
-                        logger.info("Feature suggestion skipped: whisper mode enabled")
-                        notify("Feature not saved", "Whisper mode is on; suggestions are not stored on disk")
-                    else:
-                        entry_id = feature_log.append_raw(text, t2 - t0)
-                        logger.info(f"Feature suggestion saved: {char_count} chars in {t2 - t0:.2f}s")
-                        notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
-                        self._stats.record_feature_suggestion()
-                        weekly_stats.record_feature_suggestion()
-                        # Format asynchronously via Claude CLI
-                        submit_or_spawn(
-                            IO, "feature-format",
-                            lambda t=text, e=entry_id: self._format_feature_async(t, e),
-                            native=True,
-                        )
-                else:
-                    # Normal dictation mode: paste + log
-                    if text:
-                        paste(text, self.cfg["paste_method"], restore=not self.cfg.get("incognito", False))
-                    delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
-                    if self.cfg.get("incognito"):
-                        logger.info(f"Dictation: {t2 - t0:.2f}s -- {delivery} ({char_count} chars)")
-                    else:
-                        log_dictation_result(text or "", t2 - t0, delivery, char_count, secondary=used_backup)
-                    effective_model = self.cfg.get("backup_model", "base") if used_backup else dictation_model
-                    logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, model={effective_model}{' (backup)' if used_backup else ''}")
-                    # Update session stats
-                    self._stats.record_dictation(char_count, t2 - t0)
-                    weekly_stats.record_dictation(char_count, t2 - t0)
-                    incognito = self.cfg.get("incognito", False)
-                    if text and not incognito:
-                        dictation_log.append(text, t2 - t0, model=effective_model)
-                        with self._dictation_history_lock:
-                            self._dictation_history.append({
-                                "text": text,
-                                "timestamp": datetime.now().strftime("%H:%M"),
-                                "chars": len(text),
-                            })
-                            if len(self._dictation_history) > 10:
-                                self._dictation_history = self._dictation_history[-10:]
-                        self._refresh_menu()
-                # Success -- remove crash-safety WAV (text is in the log)
-                self.recorder.stop_streaming()  # defensive: ensure writer closed
-                if self._dictation_wav_path:
-                    self._safe_unlink(self._dictation_wav_path)
-                self.state.emit(DICTATION_COMPLETED, mode="done")
-            except WorkerCrashedError:
-                self._gpu_guard.note_pressure_trigger("worker_crash_dictation")
-                logger.error("Worker crashed during dictation -- respawning...")
-                if self._dictation_wav_path:
-                    logger.info(f"Dictation audio preserved at: {self._dictation_wav_path}")
-                self.worker.restart()
-                self.state.emit(ERROR, mode="error", data={"message": "Worker crashed during dictation", "recoverable": True})
-            except Exception as e:
-                logger.error(f"Dictation error: {e}")
-                import traceback
-                logger.debug(traceback.format_exc())
-                self.state.emit(ERROR, mode="error", data={"message": str(e), "recoverable": False})
-            finally:
-                self._schedule_idle(2)
-
-        submit_or_spawn(DICTATION, "dictation-process", _process)
-
-    # --- Overlay dictation (dictation during meeting recording/transcription) ---
-
-    def _start_overlay_dictation(self):
-        """Start dictation using a separate audio stream while meeting continues.
-
-        Uses an independent AudioRecorder so the meeting recording is never
-        interrupted. Transcription uses the backup model (CPU or secondary GPU).
-        """
-        # Note: always_available_dictation config flag already gates the call to
-        # this method in toggle_dictation(), so no need to re-check is_enabled() here.
-
-        meeting_state = "recording" if (self.state.current.mode if self.state else None) == "meeting" else "transcribing"
-        backup_model = self.cfg.get("backup_model", "base")
-        backup_device = self.cfg.get("backup_device", "cpu")
-        logger.info(f"Dictation requested during meeting {meeting_state} (using backup model)", extra={"secondary": True})
-        logger.info(f"Backup model: {backup_model} on {backup_device}", extra={"secondary": True})
-
-        # Create a separate recorder for dictation audio (mic only)
-        self._overlay_recorder = AudioRecorder(sample_rate=self.cfg["sample_rate"])
-        mic = self.cfg.get("mic_device")
-        if self.cfg.get("use_system_devices", True):
-            mic = get_default_devices().get("input")
-        try:
-            self._overlay_recorder.start(mic_device=mic)
-        except Exception as e:
-            logger.error("Failed to start overlay dictation mic: %s", e, exc_info=True)
-            notify("Dictation unavailable", f"Mic could not be opened: {e}")
-            self._overlay_recorder = None
-            self._feature_suggest_active = False
-            return
-        # Disk-first like normal dictation (hardware-resilience H3):
-        # overlay audio was the last RAM-only capture path, so a crash
-        # mid-overlay lost it. Incognito intentionally stays RAM-only.
-        self._overlay_wav_path = None
-        if not self.cfg.get("incognito", False):
-            log_dir = self._dictation_log_dir()
-            log_dir.mkdir(parents=True, exist_ok=True)
-            ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            prefix = "feature_" if self._feature_suggest_active else ""
-            self._overlay_wav_path = log_dir / f"overlay_{prefix}{ts}.wav"
-            try:
-                self._overlay_recorder.start_streaming(self._overlay_wav_path)
-            except Exception as e:
-                logger.warning("Overlay disk streaming disabled: %s", e)
-                self._overlay_wav_path = None
-        logger.info("Dictation during meeting: recording started", extra={"secondary": True})
-        self.state.emit(DICTATION_STARTED, dictation_overlay=True)
-
-    def _stop_overlay_dictation(self):
-        """Stop overlay dictation, transcribe with backup model, paste result."""
-        if not self._overlay_recorder:
-            self.state.emit(IDLE, dictation_overlay=False)
-            return
-
-        audio = self._overlay_recorder.stop()
-        # Finalize the streaming WAV (header + handle) so the file can be
-        # deleted on success or preserved intact on failure - stop() does
-        # not close the mic writer (same discipline as normal dictation).
-        self._overlay_recorder.stop_streaming()
-        self.state.emit(DICTATION_COMPLETED, dictation_overlay=False)
-
-        if "mic" not in audio:
-            logger.debug("Overlay dictation stopped - no audio captured", extra={"secondary": True})
-            self._overlay_recorder = None
-            self._feature_suggest_active = False
-            return
-
-        overlay_audio = audio["mic"]
-        self._overlay_recorder = None
-        overlay_wav = getattr(self, "_overlay_wav_path", None)
-        self._overlay_wav_path = None
-
-        # Capture feature flag before spawning background thread
-        with self._lock:
-            is_feature = self._feature_suggest_active
-            self._feature_suggest_active = False
-
-        logger.info("Dictation during meeting: transcribing...", extra={"secondary": True})
-
-        def _process_overlay():
-            import time as _time
-
-            transcribed = False
-            t0 = _time.perf_counter()
-            try:
-                text = self._backup.transcribe(overlay_audio)
-                transcribed = True
-                t1 = _time.perf_counter()
-                duration = t1 - t0
-                char_count = len(text) if text else 0
-                backup_model = self.cfg.get("backup_model", "base")
-                backup_device = self.cfg.get("backup_device", "cpu")
-                logger.info(
-                    f"Dictation during meeting: {duration:.1f}s, {char_count} chars "
-                    f"(backup {backup_device} {backup_model})",
-                    extra={"secondary": True},
-                )
-                if is_feature:
-                    if not text:
-                        logger.info("Feature suggestion (overlay) discarded (no speech detected)", extra={"secondary": True})
-                    elif self.cfg.get("incognito", False):
-                        logger.info("Feature suggestion skipped: whisper mode enabled", extra={"secondary": True})
-                        notify("Feature not saved", "Whisper mode is on; suggestions are not stored on disk")
-                    else:
-                        entry_id = feature_log.append_raw(text, duration)
-                        logger.info(f"Feature suggestion (overlay) saved: {char_count} chars in {duration:.2f}s", extra={"secondary": True})
-                        notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
-                        self._stats.record_feature_suggestion()
-                        weekly_stats.record_feature_suggestion()
-                        submit_or_spawn(
-                            IO, "feature-format",
-                            lambda t=text, e=entry_id: self._format_feature_async(t, e),
-                            native=True,
-                        )
-                else:
-                    if text:
-                        paste(text, self.cfg["paste_method"], restore=not self.cfg.get("incognito", False))
-
-                    # Update session stats
-                    self._stats.record_dictation(char_count, duration)
-                    weekly_stats.record_dictation(char_count, duration)
-
-                    incognito = self.cfg.get("incognito", False)
-                    if text and not incognito:
-                        dictation_log.append(text, duration, model=backup_model)
-                        with self._dictation_history_lock:
-                            self._dictation_history.append({
-                                "text": text,
-                                "timestamp": datetime.now().strftime("%H:%M"),
-                                "chars": len(text),
-                            })
-                            if len(self._dictation_history) > 10:
-                                self._dictation_history = self._dictation_history[-10:]
-                        self._refresh_menu()
-
-                    delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
-                    if incognito:
-                        logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
-                    else:
-                        log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
-
-            except Exception as e:
-                logger.error(f"Overlay dictation error: {e}", extra={"secondary": True})
-                import traceback
-                logger.debug(traceback.format_exc())
-                # Fall back to queuing on main worker if backup fails
-                try:
-                    logger.info("Falling back to main worker for overlay dictation", extra={"secondary": True})
-                    dictation_model = self._gpu_guard.effective_model(
-                        self.cfg.get("dictation_model", self.cfg["model"]))
-                    timeout = 180
-                    text = self.worker.transcribe_fast(overlay_audio, model_override=dictation_model, timeout=timeout)
-                    transcribed = True
-                    if text:
-                        paste(text, self.cfg["paste_method"], restore=not self.cfg.get("incognito", False))
-                    t1 = _time.perf_counter()
-                    duration = t1 - t0
-                    char_count = len(text or "")
-                    logger.info(f"Overlay dictation fallback: {duration:.2f}s, {char_count} chars", extra={"secondary": True})
-
-                    # Post-dictation bookkeeping (same as the normal overlay path)
-                    self._stats.record_dictation(char_count, duration)
-                    weekly_stats.record_dictation(char_count, duration)
-
-                    incognito = self.cfg.get("incognito", False)
-                    if text and not incognito:
-                        dictation_log.append(text, duration, model=dictation_model)
-                        with self._dictation_history_lock:
-                            self._dictation_history.append({
-                                "text": text,
-                                "timestamp": datetime.now().strftime("%H:%M"),
-                                "chars": len(text),
-                            })
-                            if len(self._dictation_history) > 10:
-                                self._dictation_history = self._dictation_history[-10:]
-                        self._refresh_menu()
-
-                    delivery = "pasted" if self.cfg["paste_method"] == "keystrokes" else "clipboard"
-                    if incognito:
-                        logger.info(f"Overlay dictation fallback: {duration:.2f}s - {delivery} ({char_count} chars)", extra={"secondary": True})
-                    else:
-                        log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
-                except Exception as fallback_err:
-                    logger.error(f"Overlay dictation fallback also failed: {fallback_err}", extra={"secondary": True})
-
-            if overlay_wav:
-                if transcribed:
-                    self._safe_unlink(overlay_wav)
-                else:
-                    logger.info(f"Overlay dictation audio preserved at: {overlay_wav}", extra={"secondary": True})
-
-        submit_or_spawn(DICTATION, "overlay-process", _process_overlay)
-
-    def _recover_dictation(self, wav_path: str):
-        """Transcribe a recovered dictation WAV from a previous crash.
-
-        Puts the text on the clipboard (not auto-paste — wrong window may be focused
-        after a restart). The user can Ctrl+V when ready.
-        """
-        import pyperclip
-        logger.info(f"Recovering crashed dictation from: {wav_path}")
-        try:
-            import numpy as np
-            import wave
-            with wave.open(wav_path, "r") as wf:
-                frames = wf.readframes(wf.getnframes())
-                audio_np = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32767.0
-
-            dictation_model = self._gpu_guard.effective_model(
-                self.cfg.get("dictation_model", self.cfg["model"]))
-            text = self.worker.transcribe_fast(audio_np, model_override=dictation_model)
-            if text:
-                pyperclip.copy(text)
-                dictation_log.append(text, 0, model=dictation_model)
-                logger.info(f"Crash-recovered dictation copied to clipboard: {text[:80]}...")
-                # #38: Toast with recovered text info and Copy button
-                try:
-                    _recovered_text = text
-                    def _copy_recovered(t=_recovered_text):
-                        import pyperclip as _pc
-                        _pc.copy(t)
-                    notify(
-                        "Dictation recovered",
-                        f"{len(text)} chars recovered from crash",
-                        buttons=[{"label": "Copy to Clipboard", "action": _copy_recovered}],
-                    )
-                except Exception:
-                    logger.debug("Recovery toast failed", exc_info=True)
-            else:
-                logger.info("Crash-recovered dictation produced no text")
-            # Clean up the WAV now that text is on clipboard + in the .md log
-            Path(wav_path).unlink(missing_ok=True)
-        except Exception as e:
-            logger.error(f"Failed to recover dictation: {e}")
-            logger.info(f"Audio preserved at: {wav_path}")
-
-    def _recover_feature(self, wav_path: str):
-        """Recover a crashed feature suggestion with interactive notification.
-
-        Unlike dictation recovery (clipboard only), feature recovery routes
-        the transcription to the feature log and applies Claude formatting.
-        Shows a toast with Recover / Cancel options.
-        """
-        logger.info(f"Recovering crashed feature suggestion from: {wav_path}")
-        try:
-            import numpy as np
-            import wave
-            with wave.open(wav_path, "r") as wf:
-                frames = wf.readframes(wf.getnframes())
-                audio_np = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32767.0
-
-            dictation_model = self._gpu_guard.effective_model(
-                self.cfg.get("dictation_model", self.cfg["model"]))
-            text = self.worker.transcribe_fast(audio_np, model_override=dictation_model)
-            if not text:
-                logger.info("Crashed feature suggestion produced no text, cleaning up")
-                Path(wav_path).unlink(missing_ok=True)
-                return
-
-            logger.info(f"Recovered feature text ({len(text)} chars): {text[:80]}...")
-
-            # Show interactive notification with Recover / Cancel options
-            def _do_recover():
-                entry_id = feature_log.append_raw(text, 0)
-                logger.info(f"Feature suggestion recovered to feature log: {entry_id}")
-                # Format via Claude CLI in background
-                submit_or_spawn(
-                    IO, "feature-format",
-                    lambda t=text, e=entry_id: self._format_feature_async(t, e),
-                    native=True,
-                )
-                notify("Feature recovered", f"{len(text)} chars saved to feature log")
-
-            def _do_cancel():
-                logger.info("Feature recovery cancelled by user")
-
-            try:
-                preview = f'"{text[:120]}..."' if len(text) > 120 else f'"{text}"'
-                notify(
-                    "Recover feature suggestion?",
-                    preview,
-                    buttons=[
-                        {"label": "Recover", "action": _do_recover},
-                        {"label": "Cancel", "action": _do_cancel},
-                    ],
-                )
-            except Exception:
-                # If notification fails, auto-recover silently
-                logger.debug("Feature recovery notification failed, auto-recovering", exc_info=True)
-                _do_recover()
-
-            # Clean up WAV after showing notification (actions handle the rest)
-            Path(wav_path).unlink(missing_ok=True)
-        except Exception as e:
-            logger.error(f"Failed to recover feature suggestion: {e}")
-            logger.info(f"Audio preserved at: {wav_path}")
 
     def _recover_meetings(self):
         """Show a dialog for each recovered meeting WAV, let user name and place it."""
@@ -1138,32 +515,6 @@ class WhisperSync:
 
         name = result[0] or ""
         return "".join(c if c.isalnum() or c in " -_" else "" for c in name).strip().replace(" ", "-")
-
-    def _discard_dictation(self):
-        """Discard current dictation - stop recording, throw away audio, return to idle."""
-        with self._lock:
-            # Handle overlay dictation discard
-            _overlay = self.state.current.dictation_overlay if self.state else False
-            if _overlay and self._overlay_recorder:
-                self._overlay_recorder.stop()
-                self._overlay_recorder.stop_streaming()
-                self._overlay_recorder = None
-                discarded_wav = getattr(self, "_overlay_wav_path", None)
-                self._overlay_wav_path = None
-                if discarded_wav:
-                    self._safe_unlink(discarded_wav)
-                logger.info("Overlay dictation discarded (left-click)", extra={"secondary": True})
-                self.state.emit(DICTATION_DISCARDED, dictation_overlay=False)
-                return
-
-            if (self.state.current.mode if self.state else None) != "dictation":
-                return
-            self.recorder.stop()  # stop recording, discard the audio
-            self.recorder.stop_streaming()
-            if self._dictation_wav_path and self._dictation_wav_path.exists():
-                self._dictation_wav_path.unlink(missing_ok=True)
-            logger.info("Dictation discarded (left-click)")
-            self.state.emit(DICTATION_DISCARDED, mode=None)
 
     def toggle_meeting(self):
         with self._lock:
@@ -2315,42 +1666,6 @@ class WhisperSync:
         except _sp.TimeoutExpired:
             logger.warning("Claude CLI timed out generating minutes (5 min limit)")
 
-    def _format_feature_async(self, raw_text: str, entry_id: str):
-        """Format a feature suggestion via Claude CLI (background thread)."""
-        import subprocess as _sp
-
-        prompt_file = Path(__file__).parent / "feature_prompt.md"
-        if not prompt_file.exists():
-            logger.warning(f"Feature prompt template not found: {prompt_file}")
-            return
-
-        prompt_text = prompt_file.read_text(encoding="utf-8")
-        prompt_text = prompt_text.replace("{TRANSCRIPTION}", raw_text)
-
-        logger.info("Formatting feature suggestion via Claude CLI...")
-        try:
-            from .executors import native_call
-            with native_call("claude-feature-format"):
-                result = _sp.run(
-                    ["claude", "-p", "--model", "haiku"],
-                    input=prompt_text,
-                    capture_output=True,
-                    text=True,
-                    timeout=60,
-                )
-            if result.returncode == 0 and result.stdout.strip():
-                feature_log.update_consolidated(entry_id, result.stdout.strip())
-                logger.info("Feature suggestion formatted successfully")
-                notify("Feature formatted", "Claude formatted your feature suggestion")
-            else:
-                logger.warning(f"Claude CLI returned code {result.returncode}")
-                if result.stderr:
-                    logger.debug(f"stderr: {result.stderr[:500]}")
-        except FileNotFoundError:
-            logger.warning("Claude CLI not found - raw feature saved without formatting")
-        except _sp.TimeoutExpired:
-            logger.warning("Claude CLI timed out formatting feature (60s limit)")
-
     def _meeting_temp_dir(self) -> Path:
         return Path(__file__).parent / "logs" / "data" / "meeting"
 
@@ -2385,16 +1700,9 @@ class WhisperSync:
         else:
             logger.info("No dictation logs folder found")
 
-    def _clear_dictation_history(self):
-        """Clear the in-memory dictation history (menu only, logs on disk are preserved)."""
-        with self._dictation_history_lock:
-            self._dictation_history.clear()
-        self._refresh_menu()
-
     def _build_recent_dictations_menu(self):
         """Build the Recent Dictations submenu items."""
-        with self._dictation_history_lock:
-            history = list(self._dictation_history)
+        history = self.dictation.recent_history()
         if not history:
             return pystray.Menu(
                 pystray.MenuItem("No dictations yet", None, enabled=False),
@@ -2414,7 +1722,7 @@ class WhisperSync:
             pystray.MenuItem("Open Logs", self._cb(self._open_dictation_logs))
         )
         items.append(
-            pystray.MenuItem("Clear History", self._cb(self._clear_dictation_history))
+            pystray.MenuItem("Clear History", self._cb(self.dictation.clear_history))
         )
         return pystray.Menu(*items)
 
@@ -2706,7 +2014,7 @@ class WhisperSync:
             pystray.MenuItem("Meetings", self._build_meetings_menu()),
             pystray.MenuItem("Recent Dictations", self._build_recent_dictations_menu()),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(f"Dictation\t{dict_hk}", lambda: self._on_left_click() if left_action == "dictation" else self.toggle_dictation(),
+            pystray.MenuItem(f"Dictation\t{dict_hk}", lambda: self._on_left_click() if left_action == "dictation" else self.dictation.toggle(),
                              default=left_action == "dictation"),
             pystray.MenuItem(f"Meeting\t{meet_hk}", lambda: self._on_left_click() if left_action == "meeting" else self.toggle_meeting(),
                              default=left_action == "meeting"),
@@ -3640,7 +2948,7 @@ class WhisperSync:
         # Check for orphaned dictation WAVs from a previous crash
         # (successful dictations delete the WAV, so any .wav here = crash)
         self._recovered_dictation_paths = []
-        dict_log_dir = self._dictation_log_dir()
+        dict_log_dir = get_dictation_log_dir()
         if dict_log_dir.exists():
             for wav in sorted(dict_log_dir.glob("*.wav")):
                 dur = fix_orphan(wav)
@@ -3672,7 +2980,7 @@ class WhisperSync:
 
         keyboard.add_hotkey(
             self.cfg["hotkeys"]["dictation_toggle"],
-            _guarded(self.toggle_dictation, "dictation"),
+            _guarded(self.dictation.toggle, "dictation"),
             suppress=False,
         )
         keyboard.add_hotkey(
@@ -3684,7 +2992,7 @@ class WhisperSync:
         if feature_hk:
             keyboard.add_hotkey(
                 feature_hk,
-                _guarded(self.toggle_feature_suggest, "feature-suggest"),
+                _guarded(self.dictation.toggle_feature_suggest, "feature-suggest"),
                 suppress=False,
             )
 
@@ -3770,9 +3078,9 @@ class WhisperSync:
                 # Recover any crashed dictations/features found at startup
                 for wav_path in self._recovered_dictation_paths:
                     if Path(wav_path).name.startswith("feature_"):
-                        self._recover_feature(wav_path)
+                        self.dictation.recover_feature(wav_path)
                     else:
-                        self._recover_dictation(wav_path)
+                        self.dictation.recover_dictation(wav_path)
                 self._recovered_dictation_paths = []
                 # Recover any crashed meetings — show dialog for naming
                 if self._recovered_meeting_paths:
@@ -3811,7 +3119,7 @@ class WhisperSync:
         self._idle_collector = IdleCollector(
             is_pipeline_idle=lambda: self._post_queue.unfinished_tasks == 0,
             is_recording=lambda: (
-                self.recorder.is_recording or self._overlay_recorder is not None
+                self.recorder.is_recording or self.dictation.overlay_active
             ),
             is_mode_terminal=lambda: (
                 self.state is not None

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -42,7 +42,7 @@ from .worker_manager import WorkerCrashedError
 HISTORY_LIMIT = 10
 
 
-def safe_unlink(path: Path, retries: int = 2, delay: float = 0.5):
+def safe_unlink(path: Path | None, retries: int = 2, delay: float = 0.5):
     """Delete a file, retrying on PermissionError (Windows file locking)."""
     import time
     for attempt in range(retries + 1):
@@ -117,6 +117,14 @@ class DictationFlow:
             # If already recording a feature suggestion, stop it
             if overlay and feature_active:
                 self._stop_overlay()
+                return
+            if overlay:
+                # A NORMAL overlay dictation is recording - ignore, exactly
+                # like the feature hotkey during a normal dictation below.
+                # Starting a second overlay here would overwrite
+                # _overlay_recorder and double-open the mic (review catch on
+                # the extraction; the bug predates it).
+                logger.debug("Feature suggest ignored - overlay dictation in progress")
                 return
             if mode == "dictation" and feature_active:
                 self._stop()

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -1,0 +1,765 @@
+"""Dictation workflow - normal, feature-suggest, and overlay dictation.
+
+Extracted from __main__.py (hardening round item 6, architecture spec
+A2). DictationFlow owns the dictation lifecycle end to end: hotkey
+toggles, start/stop, the auto-stop memory cap, overlay dictation during
+meetings, left-click discard, crash recovery, feature-suggestion
+formatting, and the recent-dictation history.
+
+The flow keeps a back-reference to the application object for shared
+services (cfg, state manager, recorder, worker, backup transcriber,
+GPU guard, session stats, tray helpers) - the same composition pattern
+as meeting_job.MeetingJob. The app stays the wiring surface; behavior
+lives here.
+
+Feature-suggest routing state: the old ``_feature_suggest_active`` flag
+on the app (toggled at 15+ call sites) is folded into
+``AppState.feature_suggest``. Feature intent is passed DOWN as a
+parameter and enters state atomically with DICTATION_STARTED; it clears
+with the completion/discard/idle emit. Start attempts that fail before
+DICTATION_STARTED never touch state, which eliminates the old
+set-then-unwind pattern entirely.
+"""
+
+import threading
+from datetime import datetime
+from pathlib import Path
+
+from . import dictation_log
+from . import feature_log
+from . import weekly_stats
+from .executors import DICTATION, IO, submit_or_spawn
+from .logger import logger, log_dictation_result
+from .notifications import notify
+from .paths import get_dictation_log_dir
+from .state_manager import (
+    DICTATION_STARTED, DICTATION_COMPLETED, DICTATION_DISCARDED,
+    TRANSCRIPTION_STARTED, ERROR, IDLE,
+)
+from .worker_manager import WorkerCrashedError
+
+# In-memory history shown in the Recent Dictations menu.
+HISTORY_LIMIT = 10
+
+
+def safe_unlink(path: Path, retries: int = 2, delay: float = 0.5):
+    """Delete a file, retrying on PermissionError (Windows file locking)."""
+    import time
+    for attempt in range(retries + 1):
+        try:
+            if path and path.exists():
+                path.unlink(missing_ok=True)
+            return
+        except PermissionError:
+            if attempt < retries:
+                time.sleep(delay)
+            else:
+                logger.debug(f"Could not delete {path} - will clean up on next restart")
+
+
+class DictationFlow:
+    """Owns dictation behavior; reads shared services through ``app``.
+
+    Thread model: toggles and discard run under ``app._lock`` (shared
+    with the meeting flow so mode checks and starts are atomic across
+    workflows). Transcription work is offloaded to the DICTATION
+    executor lane. History is guarded by its own lock because dictation
+    and overlay worker threads append while menu builds read.
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self._wav_path: Path | None = None
+        self._overlay_recorder = None  # separate AudioRecorder during meetings
+        self._overlay_wav_path: Path | None = None
+        self._cap_handle = None
+        self._history = dictation_log.load_recent(HISTORY_LIMIT)
+        self._history_lock = threading.Lock()
+
+    # -- Public API (hotkeys, clicks, menu, startup recovery) ---------------
+
+    @property
+    def overlay_active(self) -> bool:
+        """True while an overlay dictation recorder exists."""
+        return self._overlay_recorder is not None
+
+    def toggle(self):
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            mode = current.mode if current else None
+            overlay = current.dictation_overlay if current else False
+            meeting_tx = current.meeting_transcribing if current else False
+
+            # Handle overlay dictation during meetings
+            if overlay:
+                self._stop_overlay()
+                return
+
+            if mode == "dictation":
+                self._stop()
+            elif mode == "meeting" or (mode is None and meeting_tx):
+                # Dictation during meeting recording or meeting transcription
+                self._toggle_during_meeting(feature=False)
+            elif mode == "saving":
+                logger.debug("Dictation ignored - meeting is saving")
+            elif self.app._can_record():
+                self._start(feature=False)
+
+    def toggle_feature_suggest(self):
+        """Toggle feature suggestion recording (dictation routed to the feature log)."""
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            mode = current.mode if current else None
+            overlay = current.dictation_overlay if current else False
+            meeting_tx = current.meeting_transcribing if current else False
+            feature_active = current.feature_suggest if current else False
+
+            # If already recording a feature suggestion, stop it
+            if overlay and feature_active:
+                self._stop_overlay()
+                return
+            if mode == "dictation" and feature_active:
+                self._stop()
+                return
+            if mode == "dictation":
+                # Already recording a normal dictation - ignore
+                logger.debug("Feature suggest ignored - dictation in progress")
+                return
+
+            if mode == "meeting" or (mode is None and meeting_tx):
+                self._toggle_during_meeting(feature=True)
+            elif mode == "saving":
+                logger.debug("Feature suggest ignored - meeting is saving")
+            elif self.app._can_record():
+                self._start(feature=True)
+
+    def discard(self):
+        """Discard current dictation - stop recording, throw away audio, return to idle."""
+        with self.app._lock:
+            _overlay = self.app.state.current.dictation_overlay if self.app.state else False
+            if _overlay and self._overlay_recorder:
+                self._overlay_recorder.stop()
+                self._overlay_recorder.stop_streaming()
+                self._overlay_recorder = None
+                discarded_wav = self._overlay_wav_path
+                self._overlay_wav_path = None
+                if discarded_wav:
+                    safe_unlink(discarded_wav)
+                logger.info("Overlay dictation discarded (left-click)", extra={"secondary": True})
+                self.app.state.emit(DICTATION_DISCARDED, dictation_overlay=False,
+                                    feature_suggest=False)
+                return
+
+            if (self.app.state.current.mode if self.app.state else None) != "dictation":
+                return
+            self.app.recorder.stop()  # stop recording, discard the audio
+            self.app.recorder.stop_streaming()
+            if self._wav_path and self._wav_path.exists():
+                self._wav_path.unlink(missing_ok=True)
+            logger.info("Dictation discarded (left-click)")
+            self.app.state.emit(DICTATION_DISCARDED, mode=None, feature_suggest=False)
+
+    def recent_history(self) -> list[dict]:
+        """Snapshot of the recent-dictation history (newest last)."""
+        with self._history_lock:
+            return list(self._history)
+
+    def clear_history(self):
+        """Clear the in-memory dictation history (menu only, logs on disk are preserved)."""
+        with self._history_lock:
+            self._history.clear()
+        self.app._refresh_menu()
+
+    # -- Start/stop ----------------------------------------------------------
+
+    def _toggle_during_meeting(self, feature: bool):
+        """Route a mid-meeting dictation request to the overlay path if allowed."""
+        label = "Feature suggest" if feature else "Dictation"
+        if self.app.cfg.get("always_available_dictation", True):
+            if self.app._backup.is_loading:
+                logger.debug("Backup model still loading, triggering yellow flash",
+                             extra={"secondary": True})
+                self.app._yellow_flash()
+                return
+            self._start_overlay(feature=feature)
+        else:
+            logger.info(f"{label} unavailable during meeting "
+                        "(always_available_dictation disabled)", extra={"secondary": True})
+            notify(f"{label} unavailable", "Enable always-available dictation in settings")
+
+    def _start(self, feature: bool):
+        # Lazy: capture/backup_worker import numpy; keep this module
+        # importable on the dependency-light system python (CI suite).
+        from .backup_worker import BackupTranscriber
+        from .capture import get_default_devices
+
+        app = self.app
+        _meeting_tx = app.state.current.meeting_transcribing if app.state else False
+        if not app.worker.is_ready() and not (_meeting_tx and BackupTranscriber.is_enabled(app.cfg)):
+            logger.warning("Worker not ready yet - ignoring dictation request")
+            app._yellow_flash()
+            return
+        # Atomic claim: only start if mode is still startable. A worker
+        # completion (or a double-fired hotkey on another thread) changing
+        # mode between the toggle's check and this start is rejected here
+        # instead of producing two concurrent recording sessions. Feature
+        # intent enters state WITH the started event.
+        if not app.state.try_transition(
+            (None, "transcribing", "done", "error"),
+            DICTATION_STARTED, mode="dictation", feature_suggest=feature,
+        ):
+            logger.debug("dictation start rejected: mode changed concurrently")
+            return
+        mic = app.cfg.get("mic_device")
+        if app.cfg.get("use_system_devices", True):
+            # Explicitly use the WASAPI default instead of falling through
+            # to sd.default.device[0], which on Windows resolves to an MME
+            # device and often rejects float32 @ 16 kHz with MME error 32.
+            mic = get_default_devices().get("input")
+        try:
+            app.recorder.start(mic_device=mic)
+        except Exception as e:
+            logger.error("Failed to start mic for dictation: %s", e, exc_info=True)
+            notify("Dictation unavailable", f"Mic could not be opened: {e}")
+            app.state.emit(IDLE, mode=None, feature_suggest=False)
+            return
+        # Stream to disk for crash recovery -- skip when incognito (RAM only)
+        if app.cfg.get("incognito", False):
+            self._wav_path = None
+        else:
+            log_dir = get_dictation_log_dir()
+            log_dir.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            prefix = "feature_" if feature else ""
+            self._wav_path = log_dir / f"{prefix}{ts}.wav"
+            try:
+                app.recorder.start_streaming(self._wav_path)
+            except Exception as e:
+                logger.warning("Dictation disk streaming disabled: %s", e)
+                self._wav_path = None
+
+        # Memory protection: dictation mic audio accumulates in RAM
+        # (~230 MB/hour @16k float32). A forgotten hotkey used to grow
+        # unbounded. Auto-stop at the configured cap; the audio captured
+        # so far is transcribed normally, nothing is lost.
+        self._arm_cap()
+
+    def _arm_cap(self):
+        """Schedule the dictation auto-stop cap for this session."""
+        cap_min = float(self.app.cfg.get("dictation_max_minutes", 30) or 0)
+        if cap_min <= 0:
+            return
+        from .scheduler import scheduler
+
+        def _cap_hit():
+            mode = self.app.state.current.mode if self.app.state else None
+            if mode != "dictation":
+                return  # session already ended normally
+
+            def _do_stop():
+                logger.warning(
+                    "Dictation auto-stopped at %.0f min cap "
+                    "(dictation_max_minutes; audio so far is transcribed)",
+                    cap_min,
+                )
+                try:
+                    notify(
+                        "Dictation auto-stopped",
+                        f"Hit the {cap_min:.0f} min cap; transcribing what was recorded",
+                    )
+                except Exception:
+                    pass
+                # toggle takes the app lock and routes by current mode, so
+                # a user stop racing this is benign (mode check repeats
+                # under the lock inside toggle).
+                self.toggle()
+
+            # Scheduler jobs must stay short (scheduler.py contract):
+            # toggle acquires the app lock and stops the recorder, so
+            # offload it instead of blocking other timer jobs (menu
+            # refresh, idle GC).
+            submit_or_spawn(DICTATION, "dictation-cap-stop", _do_stop)
+
+        self._cancel_cap()
+        self._cap_handle = scheduler.call_later(
+            cap_min * 60.0, _cap_hit, label="dictation-cap"
+        )
+
+    def _cancel_cap(self):
+        if self._cap_handle is not None:
+            self._cap_handle.cancel()
+            self._cap_handle = None
+
+    def _stop(self):
+        from .backup_worker import BackupTranscriber
+        from .paste import paste
+
+        app = self.app
+        self._cancel_cap()
+        audio = app.recorder.stop()
+        app.recorder.stop_streaming()
+
+        if "mic" not in audio:
+            app.state.emit(IDLE, mode=None, feature_suggest=False)
+            return
+
+        # Capture-and-clear: read feature intent, then clear it in the same
+        # transition that leaves dictation mode. All mutators of
+        # feature_suggest run under app._lock (which every caller of _stop
+        # holds), so the read-then-emit pair is atomic exactly like the old
+        # locked flag capture.
+        is_feature = app.state.current.feature_suggest
+        app.state.emit(TRANSCRIPTION_STARTED, mode="transcribing", feature_suggest=False)
+
+        dictation_model = app._gpu_guard.effective_model(
+            app.cfg.get("dictation_model", app.cfg["model"]))
+        use_backup = (app.state.current.meeting_transcribing
+                      and BackupTranscriber.is_enabled(app.cfg))
+
+        def _process():
+            import time as _time
+
+            t0 = _time.perf_counter()
+            try:
+                text = None
+                used_backup = False
+                if use_backup:
+                    # Meeting is transcribing - use lightweight backup model
+                    # instead of queuing on the busy worker
+                    try:
+                        text = app._backup.transcribe(audio["mic"])
+                        used_backup = True
+                        t1 = _time.perf_counter()
+                        backup_model = app.cfg.get("backup_model", "base")
+                        backup_device = app.cfg.get("backup_device", "cpu")
+                        logger.info(
+                            f"Dictation (backup, {backup_device} {backup_model}): "
+                            f"{t1 - t0:.2f}s",
+                            extra={"secondary": True},
+                        )
+                    except Exception as backup_err:
+                        # Backup failed - fall back to queuing on the main worker
+                        logger.warning(f"Backup transcriber failed: {backup_err}",
+                                       extra={"secondary": True})
+                        logger.info("Falling back to main worker (queued)",
+                                    extra={"secondary": True})
+                        app._flash_queued()
+                        timeout = 180
+                        text = app.worker.transcribe_fast(
+                            audio["mic"], model_override=dictation_model, timeout=timeout)
+                        t1 = _time.perf_counter()
+                        logger.debug(f"transcribe_fast (fallback): {t1 - t0:.2f}s")
+                else:
+                    # Normal path or backup disabled
+                    if app.state.current.meeting_transcribing:
+                        app._flash_queued()
+                    timeout = 180 if app.state.current.meeting_transcribing else 60
+                    text = app.worker.transcribe_fast(
+                        audio["mic"], model_override=dictation_model, timeout=timeout)
+                    t1 = _time.perf_counter()
+                    logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
+                t2 = _time.perf_counter()
+                char_count = len(text) if text else 0
+
+                if is_feature:
+                    self._save_feature(text, t2 - t0, overlay=False)
+                else:
+                    # Normal dictation mode: paste + log
+                    if text:
+                        paste(text, app.cfg["paste_method"],
+                              restore=not app.cfg.get("incognito", False))
+                    delivery = "pasted" if app.cfg["paste_method"] == "keystrokes" else "clipboard"
+                    if app.cfg.get("incognito"):
+                        logger.info(f"Dictation: {t2 - t0:.2f}s -- {delivery} ({char_count} chars)")
+                    else:
+                        log_dictation_result(text or "", t2 - t0, delivery, char_count,
+                                             secondary=used_backup)
+                    effective_model = (app.cfg.get("backup_model", "base")
+                                       if used_backup else dictation_model)
+                    logger.debug(f"total (stop -> paste): {t2 - t0:.2f}s, "
+                                 f"model={effective_model}{' (backup)' if used_backup else ''}")
+                    # Update session stats
+                    app._stats.record_dictation(char_count, t2 - t0)
+                    weekly_stats.record_dictation(char_count, t2 - t0)
+                    if text and not app.cfg.get("incognito", False):
+                        dictation_log.append(text, t2 - t0, model=effective_model)
+                        self._record_history(text)
+                # Success -- remove crash-safety WAV (text is in the log)
+                app.recorder.stop_streaming()  # defensive: ensure writer closed
+                if self._wav_path:
+                    safe_unlink(self._wav_path)
+                app.state.emit(DICTATION_COMPLETED, mode="done")
+            except WorkerCrashedError:
+                app._gpu_guard.note_pressure_trigger("worker_crash_dictation")
+                logger.error("Worker crashed during dictation -- respawning...")
+                if self._wav_path:
+                    logger.info(f"Dictation audio preserved at: {self._wav_path}")
+                app.worker.restart()
+                app.state.emit(ERROR, mode="error",
+                               data={"message": "Worker crashed during dictation",
+                                     "recoverable": True})
+            except Exception as e:
+                logger.error(f"Dictation error: {e}")
+                import traceback
+                logger.debug(traceback.format_exc())
+                app.state.emit(ERROR, mode="error",
+                               data={"message": str(e), "recoverable": False})
+            finally:
+                app._schedule_idle(2)
+
+        submit_or_spawn(DICTATION, "dictation-process", _process)
+
+    # -- Overlay dictation (dictation during meeting recording/transcription) --
+
+    def _start_overlay(self, feature: bool):
+        """Start dictation using a separate audio stream while meeting continues.
+
+        Uses an independent AudioRecorder so the meeting recording is never
+        interrupted. Transcription uses the backup model (CPU or secondary GPU).
+        """
+        # Note: always_available_dictation config flag already gates the call
+        # to this method in _toggle_during_meeting, so no need to re-check
+        # is_enabled() here.
+        from .capture import AudioRecorder, get_default_devices
+
+        app = self.app
+        meeting_state = ("recording"
+                         if (app.state.current.mode if app.state else None) == "meeting"
+                         else "transcribing")
+        backup_model = app.cfg.get("backup_model", "base")
+        backup_device = app.cfg.get("backup_device", "cpu")
+        logger.info(f"Dictation requested during meeting {meeting_state} "
+                    "(using backup model)", extra={"secondary": True})
+        logger.info(f"Backup model: {backup_model} on {backup_device}",
+                    extra={"secondary": True})
+
+        # Create a separate recorder for dictation audio (mic only)
+        self._overlay_recorder = AudioRecorder(sample_rate=app.cfg["sample_rate"])
+        mic = app.cfg.get("mic_device")
+        if app.cfg.get("use_system_devices", True):
+            mic = get_default_devices().get("input")
+        try:
+            self._overlay_recorder.start(mic_device=mic)
+        except Exception as e:
+            logger.error("Failed to start overlay dictation mic: %s", e, exc_info=True)
+            notify("Dictation unavailable", f"Mic could not be opened: {e}")
+            self._overlay_recorder = None
+            return
+        # Disk-first like normal dictation (hardware-resilience H3):
+        # overlay audio was the last RAM-only capture path, so a crash
+        # mid-overlay lost it. Incognito intentionally stays RAM-only.
+        self._overlay_wav_path = None
+        if not app.cfg.get("incognito", False):
+            log_dir = get_dictation_log_dir()
+            log_dir.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            prefix = "feature_" if feature else ""
+            self._overlay_wav_path = log_dir / f"overlay_{prefix}{ts}.wav"
+            try:
+                self._overlay_recorder.start_streaming(self._overlay_wav_path)
+            except Exception as e:
+                logger.warning("Overlay disk streaming disabled: %s", e)
+                self._overlay_wav_path = None
+        logger.info("Dictation during meeting: recording started", extra={"secondary": True})
+        app.state.emit(DICTATION_STARTED, dictation_overlay=True, feature_suggest=feature)
+
+    def _stop_overlay(self):
+        """Stop overlay dictation, transcribe with backup model, paste result."""
+        app = self.app
+        if not self._overlay_recorder:
+            app.state.emit(IDLE, dictation_overlay=False, feature_suggest=False)
+            return
+
+        audio = self._overlay_recorder.stop()
+        # Finalize the streaming WAV (header + handle) so the file can be
+        # deleted on success or preserved intact on failure - stop() does
+        # not close the mic writer (same discipline as normal dictation).
+        self._overlay_recorder.stop_streaming()
+        # Capture-and-clear under app._lock, same rationale as _stop.
+        is_feature = app.state.current.feature_suggest
+        app.state.emit(DICTATION_COMPLETED, dictation_overlay=False, feature_suggest=False)
+
+        if "mic" not in audio:
+            logger.debug("Overlay dictation stopped - no audio captured",
+                         extra={"secondary": True})
+            self._overlay_recorder = None
+            return
+
+        overlay_audio = audio["mic"]
+        self._overlay_recorder = None
+        overlay_wav = self._overlay_wav_path
+        self._overlay_wav_path = None
+
+        logger.info("Dictation during meeting: transcribing...", extra={"secondary": True})
+
+        def _process_overlay():
+            import time as _time
+
+            transcribed = False
+            t0 = _time.perf_counter()
+            try:
+                text = app._backup.transcribe(overlay_audio)
+                transcribed = True
+                t1 = _time.perf_counter()
+                duration = t1 - t0
+                char_count = len(text) if text else 0
+                backup_model = app.cfg.get("backup_model", "base")
+                backup_device = app.cfg.get("backup_device", "cpu")
+                logger.info(
+                    f"Dictation during meeting: {duration:.1f}s, {char_count} chars "
+                    f"(backup {backup_device} {backup_model})",
+                    extra={"secondary": True},
+                )
+                if is_feature:
+                    self._save_feature(text, duration, overlay=True)
+                else:
+                    self._deliver_overlay(text, duration, model=backup_model)
+            except Exception as e:
+                logger.error(f"Overlay dictation error: {e}", extra={"secondary": True})
+                import traceback
+                logger.debug(traceback.format_exc())
+                # Fall back to queuing on main worker if backup fails
+                try:
+                    logger.info("Falling back to main worker for overlay dictation",
+                                extra={"secondary": True})
+                    dictation_model = app._gpu_guard.effective_model(
+                        app.cfg.get("dictation_model", app.cfg["model"]))
+                    timeout = 180
+                    text = app.worker.transcribe_fast(
+                        overlay_audio, model_override=dictation_model, timeout=timeout)
+                    transcribed = True
+                    duration = _time.perf_counter() - t0
+                    char_count = len(text or "")
+                    logger.info(f"Overlay dictation fallback: {duration:.2f}s, "
+                                f"{char_count} chars", extra={"secondary": True})
+                    self._deliver_overlay(text, duration, model=dictation_model)
+                except Exception as fallback_err:
+                    logger.error(f"Overlay dictation fallback also failed: {fallback_err}",
+                                 extra={"secondary": True})
+
+            if overlay_wav:
+                if transcribed:
+                    safe_unlink(overlay_wav)
+                else:
+                    logger.info(f"Overlay dictation audio preserved at: {overlay_wav}",
+                                extra={"secondary": True})
+
+        submit_or_spawn(DICTATION, "overlay-process", _process_overlay)
+
+    def _deliver_overlay(self, text: str | None, duration: float, *, model: str):
+        """Paste + log + stats for an overlay dictation result.
+
+        Shared by the backup path and the main-worker fallback (their
+        bookkeeping was duplicated before the extraction).
+        """
+        from .paste import paste
+
+        app = self.app
+        char_count = len(text) if text else 0
+        if text:
+            paste(text, app.cfg["paste_method"],
+                  restore=not app.cfg.get("incognito", False))
+
+        # Update session stats
+        app._stats.record_dictation(char_count, duration)
+        weekly_stats.record_dictation(char_count, duration)
+
+        incognito = app.cfg.get("incognito", False)
+        if text and not incognito:
+            dictation_log.append(text, duration, model=model)
+            self._record_history(text)
+
+        delivery = "pasted" if app.cfg["paste_method"] == "keystrokes" else "clipboard"
+        if incognito:
+            logger.info(f"Overlay dictation: {duration:.2f}s - {delivery} "
+                        f"({char_count} chars)", extra={"secondary": True})
+        else:
+            log_dictation_result(text or "", duration, delivery, char_count, secondary=True)
+
+    # -- Feature suggestions -------------------------------------------------
+
+    def _save_feature(self, text: str | None, duration: float, *, overlay: bool):
+        """Route a feature-suggest transcription to the feature log."""
+        app = self.app
+        tag = " (overlay)" if overlay else ""
+        secondary = {"extra": {"secondary": True}} if overlay else {}
+        if not text:
+            logger.info(f"Feature suggestion{tag} discarded (no speech detected)",
+                        **secondary)
+        elif app.cfg.get("incognito", False):
+            logger.info("Feature suggestion skipped: whisper mode enabled", **secondary)
+            notify("Feature not saved",
+                   "Whisper mode is on; suggestions are not stored on disk")
+        else:
+            char_count = len(text)
+            entry_id = feature_log.append_raw(text, duration)
+            logger.info(f"Feature suggestion{tag} saved: {char_count} chars "
+                        f"in {duration:.2f}s", **secondary)
+            notify("Feature saved", f"Suggestion recorded ({char_count} chars)")
+            app._stats.record_feature_suggestion()
+            weekly_stats.record_feature_suggestion()
+            # Format asynchronously via Claude CLI
+            submit_or_spawn(
+                IO, "feature-format",
+                lambda t=text, e=entry_id: self._format_feature_async(t, e),
+                native=True,
+            )
+
+    def _format_feature_async(self, raw_text: str, entry_id: str):
+        """Format a feature suggestion via Claude CLI (background thread)."""
+        import subprocess as _sp
+
+        prompt_file = Path(__file__).parent / "feature_prompt.md"
+        if not prompt_file.exists():
+            logger.warning(f"Feature prompt template not found: {prompt_file}")
+            return
+
+        prompt_text = prompt_file.read_text(encoding="utf-8")
+        prompt_text = prompt_text.replace("{TRANSCRIPTION}", raw_text)
+
+        logger.info("Formatting feature suggestion via Claude CLI...")
+        try:
+            from .executors import native_call
+            with native_call("claude-feature-format"):
+                result = _sp.run(
+                    ["claude", "-p", "--model", "haiku"],
+                    input=prompt_text,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+            if result.returncode == 0 and result.stdout.strip():
+                feature_log.update_consolidated(entry_id, result.stdout.strip())
+                logger.info("Feature suggestion formatted successfully")
+                notify("Feature formatted", "Claude formatted your feature suggestion")
+            else:
+                logger.warning(f"Claude CLI returned code {result.returncode}")
+                if result.stderr:
+                    logger.debug(f"stderr: {result.stderr[:500]}")
+        except FileNotFoundError:
+            logger.warning("Claude CLI not found - raw feature saved without formatting")
+        except _sp.TimeoutExpired:
+            logger.warning("Claude CLI timed out formatting feature (60s limit)")
+
+    # -- Crash recovery ------------------------------------------------------
+
+    def recover_dictation(self, wav_path: str):
+        """Transcribe a recovered dictation WAV from a previous crash.
+
+        Puts the text on the clipboard (not auto-paste - wrong window may be
+        focused after a restart). The user can Ctrl+V when ready.
+        """
+        import pyperclip
+        app = self.app
+        logger.info(f"Recovering crashed dictation from: {wav_path}")
+        try:
+            audio_np = self._load_wav(wav_path)
+            dictation_model = app._gpu_guard.effective_model(
+                app.cfg.get("dictation_model", app.cfg["model"]))
+            text = app.worker.transcribe_fast(audio_np, model_override=dictation_model)
+            if text:
+                pyperclip.copy(text)
+                dictation_log.append(text, 0, model=dictation_model)
+                logger.info(f"Crash-recovered dictation copied to clipboard: {text[:80]}...")
+                # #38: Toast with recovered text info and Copy button
+                try:
+                    _recovered_text = text
+
+                    def _copy_recovered(t=_recovered_text):
+                        import pyperclip as _pc
+                        _pc.copy(t)
+                    notify(
+                        "Dictation recovered",
+                        f"{len(text)} chars recovered from crash",
+                        buttons=[{"label": "Copy to Clipboard", "action": _copy_recovered}],
+                    )
+                except Exception:
+                    logger.debug("Recovery toast failed", exc_info=True)
+            else:
+                logger.info("Crash-recovered dictation produced no text")
+            # Clean up the WAV now that text is on clipboard + in the .md log
+            Path(wav_path).unlink(missing_ok=True)
+        except Exception as e:
+            logger.error(f"Failed to recover dictation: {e}")
+            logger.info(f"Audio preserved at: {wav_path}")
+
+    def recover_feature(self, wav_path: str):
+        """Recover a crashed feature suggestion with interactive notification.
+
+        Unlike dictation recovery (clipboard only), feature recovery routes
+        the transcription to the feature log and applies Claude formatting.
+        Shows a toast with Recover / Cancel options.
+        """
+        app = self.app
+        logger.info(f"Recovering crashed feature suggestion from: {wav_path}")
+        try:
+            audio_np = self._load_wav(wav_path)
+            dictation_model = app._gpu_guard.effective_model(
+                app.cfg.get("dictation_model", app.cfg["model"]))
+            text = app.worker.transcribe_fast(audio_np, model_override=dictation_model)
+            if not text:
+                logger.info("Crashed feature suggestion produced no text, cleaning up")
+                Path(wav_path).unlink(missing_ok=True)
+                return
+
+            logger.info(f"Recovered feature text ({len(text)} chars): {text[:80]}...")
+
+            # Show interactive notification with Recover / Cancel options
+            def _do_recover():
+                entry_id = feature_log.append_raw(text, 0)
+                logger.info(f"Feature suggestion recovered to feature log: {entry_id}")
+                # Format via Claude CLI in background
+                submit_or_spawn(
+                    IO, "feature-format",
+                    lambda t=text, e=entry_id: self._format_feature_async(t, e),
+                    native=True,
+                )
+                notify("Feature recovered", f"{len(text)} chars saved to feature log")
+
+            def _do_cancel():
+                logger.info("Feature recovery cancelled by user")
+
+            try:
+                preview = f'"{text[:120]}..."' if len(text) > 120 else f'"{text}"'
+                notify(
+                    "Recover feature suggestion?",
+                    preview,
+                    buttons=[
+                        {"label": "Recover", "action": _do_recover},
+                        {"label": "Cancel", "action": _do_cancel},
+                    ],
+                )
+            except Exception:
+                # If notification fails, auto-recover silently
+                logger.debug("Feature recovery notification failed, auto-recovering",
+                             exc_info=True)
+                _do_recover()
+
+            # Clean up WAV after showing notification (actions handle the rest)
+            Path(wav_path).unlink(missing_ok=True)
+        except Exception as e:
+            logger.error(f"Failed to recover feature suggestion: {e}")
+            logger.info(f"Audio preserved at: {wav_path}")
+
+    # -- Helpers ---------------------------------------------------------------
+
+    @staticmethod
+    def _load_wav(wav_path: str):
+        """Read a 16-bit WAV into the float32 array transcribe_fast expects."""
+        import numpy as np
+        import wave
+        with wave.open(wav_path, "r") as wf:
+            frames = wf.readframes(wf.getnframes())
+            return np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32767.0
+
+    def _record_history(self, text: str):
+        """Append to the recent-dictation history (menu source) and refresh."""
+        with self._history_lock:
+            self._history.append({
+                "text": text,
+                "timestamp": datetime.now().strftime("%H:%M"),
+                "chars": len(text),
+            })
+            if len(self._history) > HISTORY_LIMIT:
+                self._history = self._history[-HISTORY_LIMIT:]
+        self.app._refresh_menu()

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -62,6 +62,15 @@ class AppState:
     dictation_overlay: bool = False
     """True while dictation is active during a meeting."""
 
+    feature_suggest: bool = False
+    """True while the active dictation records a feature suggestion.
+
+    Folded in from __main__'s old _feature_suggest_active flag (hardening
+    item 6): set atomically with DICTATION_STARTED, cleared by the
+    completion/discard/idle emit, so routing intent is inspectable in the
+    same snapshot as the mode.
+    """
+
     speaker_ok: bool = True
     """Speaker loopback health (outer ring indicator)."""
 


### PR DESCRIPTION
## Summary

Hardening item 6, extraction 1 of 4 (architecture spec A2: decompose the 3,990-line god-class by workflow). This PR moves the dictation workflow - normal, feature-suggest, and overlay dictation, the auto-stop memory cap, left-click discard, crash recovery, feature formatting, and the recent-dictation history - into a new dictation_flow.py component. __main__.py shrinks ~700 lines and keeps only wiring (hotkeys, clicks, menu items point at the flow).

Composition follows the existing meeting_job.MeetingJob pattern: the flow holds an app back-reference for shared services; toggles run under the shared app lock so mode checks stay atomic across workflows.

### AppState fold (deferred from item 7 for exactly this moment)

`_feature_suggest_active` - previously toggled at 15+ sites with a set-then-unwind pattern - is folded into `AppState.feature_suggest`. Feature intent passes down as a parameter and enters state atomically with DICTATION_STARTED (inside the same try_transition that claims the mode); it clears on the completion/discard/idle emit. Start attempts that fail before DICTATION_STARTED never touch state, so there is nothing to unwind.

Deviation, recorded in the plan log: `_flash_active` stays a UI-owned animation gate and will move out with the menu extraction rather than into AppState - a cosmetic flash bit toggling in the event log would push useful history out of the 100-event ringbuffer. `_updating` folds during the lifecycle extraction as planned.

### Testability

capture/backup_worker/paste import lazily (numpy/pyperclip), so the flow is fully testable on the dependency-light system python. 20 new unit tests cover what the god-class made impossible: the feature-flag lifecycle including failure and no-audio paths, overlay start/stop with backup fallback to the main worker, concurrent-start rejection, discard for both paths, incognito disk-skip, cap arm/cancel, and history trim/clear.

Duplicated overlay bookkeeping (backup path vs main-worker fallback had copy-pasted paste/stats/history/logging blocks) collapsed into one _deliver_overlay helper.

### Docs (same PR)

TECHNICAL.md module table + dependency map + dictation flow diagram, CLAUDE.md module map, plan doc progress entries (incl. the MODE_TRANSITIONS soak note: the running app predates #164, so the soak clock starts at the owner's restart; warn-to-reject stays deferred).

## Testing

- System suite: 213 passed (193 + 20 new in tests/test_dictation_flow.py).
- Behavior preserved by direct code move; the only intentional behavior change is the state-field fold described above.