### PR TITLE
feat: extract update/restart/quit lifecycle; fold _updating into AppState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ When a user reports that a meeting "crashed" or "failed" or "didn't finish", do 
 | `meeting_flow.py` | Meeting workflow component: record/save/post-process pipeline (MeetingJob steps), crash recovery, re-run speaker ID, rename suggestions, minutes via Claude CLI. |
 | `tray_menu.py` | Tray menu construction + all settings setters + option constants. menu_callback() binds pystray item callbacks. |
 | `github_tray.py` | GitHub PR status tray glue: poller lifecycle, PR toasts, menu section, gh merge. |
+| `app_control.py` | Update/restart/quit lifecycle: git self-update, shared shutdown, deferred exits. Update guard folded into AppState.updating. |
 | `state_manager.py` | Observable state machine. AppState dataclass, typed StateEvent, event constants, thread-safe emit(), listener subscriptions (on/on_any), event log ringbuffer. All icon/toast updates flow through here. |
 | `transcribe.py` | WhisperX with persistent model cache. Fast path (dictation) and staged pipeline (meeting) |
 | `worker.py` | Multiprocessing transcription worker. CUDA isolation via spawn context |

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -16,6 +16,7 @@ Everything below is for developers modifying this app or for an AI assistant (li
 | `meeting_flow.py` | **Meeting workflow.** Toggle/start/stop, save-and-enqueue, sequential post-processing worker driving MeetingJob steps, crash recovery, rename suggestions, minutes generation. | `MeetingFlow` class --`toggle()`, `recover_meetings()`, `recover_meeting_speakers()`, `generate_minutes()`, `start_post_worker()`, `pipeline_idle()` |
 | `tray_menu.py` | **Tray menu + settings.** Full right-click menu build, every settings setter, output-folder dialogs, error popup. Menus swap via MenuRefresher under the tray lock. | `TrayMenu` class --`build()`, `_set_*()`, `_change_output_folder()`; module `menu_callback()` + option constants |
 | `github_tray.py` | **GitHub PR tray glue.** Poller lifecycle, PR change toasts with action buttons, GitHub menu section, gh-CLI merge. | `GitHubTray` class --`start()`, `stop()`, `menu_items()`, `_merge_pr()` |
+| `app_control.py` | **Update/restart/quit lifecycle.** Self-update via git against the running checkout, shared shutdown sequence, deferred restart/quit (menu callbacks run inside the Win32 pump). Update guard lives in `AppState.updating`. | `AppControl` class --`update()`, `restart()`, `quit()`, `_cleanup()` |
 | `capture.py` | **Audio recording.** Multi-stream mic + speaker loopback via WASAPI. | `AudioRecorder` class --`start()`, `stop()`, `_mic_callback()`, `_speaker_callback()`, `start_streaming()`, `stop_streaming()` |
 | `transcribe.py` | **WhisperX engine.** Model loading, transcription, alignment, diarization. Two paths: fast (dictation) and full (meeting). | `transcribe_fast(audio_np, model)` -- in-memory numpy to text; `transcribe(audio_path, diarize, model)` -- file-based full pipeline; `_load_model()`, `_load_align_model()` |
 | `worker.py` | **Subprocess entry point.** Runs transcription in isolated process (crash safety). Receives requests via Queue, returns results. | `worker_main()` -- event loop handling `transcribe_fast`, `transcribe`, `reload_model`, `shutdown` requests |
@@ -60,6 +61,7 @@ __main__.py (entry point, UI, hotkeys)
 ├── meeting_flow.py (meeting workflow component)
 ├── tray_menu.py (menu + settings component)
 ├── github_tray.py (GitHub PR status glue)
+├── app_control.py (update/restart/quit lifecycle)
 ├── config.py (settings)
 ├── paths.py (directories)
 ├── logger.py (logging)

--- a/docs/plans/2026-07-03-hardening-round.md
+++ b/docs/plans/2026-07-03-hardening-round.md
@@ -21,7 +21,7 @@
 | 4 | Device-loss and wedged-worker stall detection | hardware-resilience H2+H4 | MERGED (#165) |
 | 5 | Overlay dictation disk-first | hardware-resilience H3 | MERGED (#162) |
 | 7 | State machine transition table | architecture-validation A1 | MERGED (#164) |
-| 6 | __main__.py decomposition by workflow | architecture-validation A2 | PENDING |
+| 6 | __main__.py decomposition by workflow | architecture-validation A2 | MERGED (#168-#173) |
 
 Execution order: 2, 9, 1, 3, 11+10, 8, 4, 5, 7, 6. Owner approved the
 full list 2026-07-03 with standing authorization to proceed item to item
@@ -274,6 +274,37 @@ in one place, not a branching if/then system and not a framework.
   (bare self.worker refs, self._update bound callbacks) and the
   _updating class attribute stranded away from its users before any
   code shipped.
+
+- **2026-07-03 (item 6, extraction 4 + ROUND CLOSE)**: update/restart/
+  quit lifecycle extracted to app_control.py (AppControl: git
+  self-update against the running checkout, shared shutdown sequence,
+  deferred restart/quit for the Win32 pump). _updating FOLDED into
+  AppState.updating with UPDATE_STARTED/UPDATE_COMPLETED events - the
+  LAST stray mode flag from the architecture audit is gone. 9 new
+  tests pin the guard fold (set during the run, cleared on success and
+  failure, re-entrant click ignored), the git decision points
+  (up-to-date vs pull-then-restart), and the shutdown order.
+
+  ITEM 6 COMPLETE, and with it ALL 11 hardening items. __main__.py:
+  3,990 -> ~650 lines of composition, hotkey/click wiring, run(), and
+  main(). Components: dictation_flow, meeting_flow, meeting_dialogs,
+  tray_menu, github_tray, app_control, icons.FlashController - each
+  with an app back-reference (the meeting_job pattern), lazy imports
+  for numpy/pyperclip/pystray deps so ALL are testable on the system
+  python, and unit tests the god-class made impossible (suite grew
+  189 -> 260+; venv 36 still green). All three stray flags folded or
+  rehomed: feature_suggest + updating in AppState, the flash gate in
+  icons.FlashController.
+
+  STILL OPEN after this round: (1) production validation - the owner
+  must restart the tray app onto current dev (it still runs pre-#167
+  bytecode) and use it normally; five signals in docs/testing.md;
+  gpu-guard.jsonl + heartbeat rss are the nvlddmkm crash-correlation
+  evidence. (2) MODE_TRANSITIONS warn-to-reject - the soak clock only
+  starts at that restart; tighten after the log stays clean for a few
+  days of real use. (3) Deferred hardware items recorded in the item
+  4/5 entries (mid-recording mic reopen, loopback stall coverage, CPU
+  floor for the GPU guard ladder).
 
 - **2026-07-03 (production bugs, owner-reported)**: two real bugs from
   field use, both fixed. (1) PIPELINE ABORT AFTER TRANSCRIPTION: every

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -1,0 +1,169 @@
+"""Tests for whisper_sync.app_control.AppControl (extraction 4, final).
+
+Pins the update guard fold (AppState.updating), the git step sequence
+decisions (up-to-date vs update-and-restart), and the shutdown order
+shared by restart and quit. Threads run inline; os._exit, subprocess,
+and sleeps are stubbed - a real exit would kill the test runner.
+"""
+
+import sys
+import threading
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from whisper_sync import app_control
+from whisper_sync.app_control import AppControl
+from whisper_sync.state_manager import StateManager
+
+
+class _InlineThread:
+    def __init__(self, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+class _FakeRecorder:
+    is_recording = False
+    stopped = 0
+
+    def stop(self):
+        self.stopped += 1
+
+
+class _FakeApp:
+    def __init__(self):
+        self.state = StateManager(None, {})
+        self.tray = types.SimpleNamespace(stop=mock.Mock())
+        self.recorder = _FakeRecorder()
+        self.worker = types.SimpleNamespace(stop=mock.Mock())
+        self._backup = types.SimpleNamespace(stop=mock.Mock())
+        self.meetings = types.SimpleNamespace(shutdown_post_worker=mock.Mock())
+
+
+class _FakeRun:
+    """Records git commands; returns per-command canned results."""
+
+    def __init__(self, rev_count="0"):
+        self.commands = []
+        self.rev_count = rev_count
+
+    def __call__(self, cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        self.commands.append(cmd[:3])
+        out = ""
+        if cmd[:2] == ["git", "rev-list"]:
+            out = self.rev_count
+        elif cmd[:2] == ["git", "branch"]:
+            out = "dev"
+        return types.SimpleNamespace(returncode=0, stdout=out, stderr="")
+
+
+class _ControlHarness(unittest.TestCase):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.control = AppControl(self.app)
+        patches = [
+            mock.patch.object(app_control.threading, "Thread", _InlineThread),
+            mock.patch.object(app_control, "notify"),
+            mock.patch.dict(sys.modules, {"keyboard": types.ModuleType("keyboard")}),
+            mock.patch.object(app_control.weekly_stats, "flush"),
+            mock.patch.object(app_control.lifecycle, "record_exit_reason"),
+            mock.patch.object(app_control.lifecycle, "log_exit_banner"),
+            mock.patch("time.sleep"),
+            mock.patch("os._exit"),
+        ]
+        sys.modules_backup = None
+        self.mocks = [p.start() for p in patches]
+        for p in patches:
+            self.addCleanup(p.stop)
+        self.notify = self.mocks[1]
+        self.os_exit = self.mocks[-1]
+        sys.modules["keyboard"].unhook_all = mock.Mock()
+
+
+class UpdateTests(_ControlHarness):
+    def test_update_folds_guard_into_appstate(self):
+        seen = []
+        with mock.patch.object(AppControl, "_run_update_steps",
+                               lambda s, sp, root, br: seen.append(
+                                   self.app.state.current.updating)):
+            self.control.update("dev")
+        self.assertEqual(seen, [True], "updating must be True during the run")
+        self.assertFalse(self.app.state.current.updating,
+                         "updating must clear when the run ends")
+
+    def test_second_update_ignored_while_running(self):
+        calls = []
+
+        def _steps(s, sp, root, br):
+            calls.append(br)
+            self.control.update("dev")  # re-entrant click mid-update
+
+        with mock.patch.object(AppControl, "_run_update_steps", _steps):
+            self.control.update("dev")
+        self.assertEqual(calls, ["dev"], "concurrent update must be a no-op")
+
+    def test_update_ignored_before_run(self):
+        self.app.state = None
+        self.control.update("dev")  # must not raise
+
+    def test_guard_clears_after_git_failure(self):
+        with mock.patch.object(AppControl, "_run_update_steps",
+                               side_effect=RuntimeError("boom")):
+            self.control.update("dev")
+        self.assertFalse(self.app.state.current.updating)
+        self.assertIn("Update failed", self.notify.call_args[0][0])
+
+
+class UpdateStepsTests(_ControlHarness):
+    def test_up_to_date_does_not_restart(self):
+        run = _FakeRun(rev_count="0")
+        fake_sp = types.SimpleNamespace(run=run)
+        with mock.patch.object(AppControl, "restart") as restart:
+            self.control._run_update_steps(fake_sp, "root", "dev")
+        restart.assert_not_called()
+        self.assertTrue(any("up to date" in str(c).lower()
+                            for c in self.notify.call_args_list))
+
+    def test_new_commits_pull_then_restart(self):
+        run = _FakeRun(rev_count="3")
+        fake_sp = types.SimpleNamespace(run=run)
+        with mock.patch.object(AppControl, "restart") as restart:
+            self.control._run_update_steps(fake_sp, "root", "dev")
+        restart.assert_called_once()
+        self.assertIn(["git", "pull", "origin"], run.commands)
+
+
+class ShutdownTests(_ControlHarness):
+    def test_cleanup_stops_everything(self):
+        self.app.recorder.is_recording = True
+        self.control._cleanup()
+        self.assertEqual(self.app.recorder.stopped, 1)
+        self.app.worker.stop.assert_called_once()
+        self.app._backup.stop.assert_called_once()
+        self.app.meetings.shutdown_post_worker.assert_called_once()
+        sys.modules["keyboard"].unhook_all.assert_called_once()
+
+    def test_quit_stops_tray_and_records_reason(self):
+        self.control.quit()
+        self.app.tray.stop.assert_called_once()
+        app_control.lifecycle.record_exit_reason.assert_called_once_with(
+            app_control.lifecycle.REASON_USER_QUIT)
+        self.os_exit.assert_not_called()
+
+    def test_restart_spawns_new_process_then_exits(self):
+        with mock.patch("subprocess.Popen") as popen:
+            self.control.restart()
+        popen.assert_called_once()
+        self.assertIn("whisper_sync", popen.call_args[0][0])
+        self.app.tray.stop.assert_called_once()
+        self.os_exit.assert_called_once_with(0)
+        app_control.lifecycle.record_exit_reason.assert_called_once_with(
+            app_control.lifecycle.REASON_USER_RESTART)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -57,6 +57,7 @@ from .dictation_flow import DictationFlow
 from .meeting_flow import MeetingFlow
 from .tray_menu import TrayMenu
 from .github_tray import GitHubTray
+from .app_control import AppControl
 from .meeting_dialogs import MeetingDialogs
 from .dialog_dispatcher import DialogDispatcher
 
@@ -126,6 +127,8 @@ class WhisperSync:
         # Tray menu + settings component and GitHub PR status glue.
         self.menu = TrayMenu(self)
         self.github = GitHubTray(self)
+        # Update/restart/quit lifecycle component (app_control.py).
+        self.control = AppControl(self)
 
     @staticmethod
     def _migrate_data():
@@ -248,174 +251,14 @@ class WhisperSync:
         if refresher is not None and self.tray is not None:
             refresher.request()
 
-    _updating = False  # Guard against concurrent update clicks
-
     def _update(self, branch="dev"):
-        """Pull latest code from a branch and restart if updated."""
-        if self._updating:
-            logger.debug("Update already in progress, ignoring")
-            return
-        self._updating = True
-
-        def _do_update():
-            import subprocess as _sp
-            from .executors import native_call
-            repo_root = str(get_install_root())
-
-            # One native-call span for the whole git sequence; over-marking
-            # is safe (idle GC just skips a tick), under-marking is not.
-            try:
-                with native_call("git-update"):
-                    self._run_update_steps(_sp, repo_root, branch)
-            except FileNotFoundError:
-                logger.error("git not found on PATH")
-                notify("Update failed", "git not found, check installation")
-            except _sp.TimeoutExpired:
-                logger.error("git command timed out during update")
-                notify("Update failed", "git timed out, check network")
-            except Exception as e:
-                logger.error(f"Update failed: {e}")
-                notify("Update failed", "Unexpected error, check console")
-            finally:
-                self._updating = False
-
-        threading.Thread(target=_do_update, daemon=True).start()
-
-    def _run_update_steps(self, _sp, repo_root: str, branch: str):
-        """Run the git fetch/checkout/pull sequence for self-update."""
-        notify("Updating WhisperSync...", f"Pulling latest from {branch}")
-
-                # Check for uncommitted changes
-        status = _sp.run(
-            ["git", "status", "--porcelain"],
-            cwd=repo_root, capture_output=True, text=True, timeout=10
-        )
-        if status.stdout.strip():
-            logger.warning(f"Uncommitted changes detected:\n{status.stdout.strip()}")
-
-        # Fetch
-        fetch = _sp.run(
-            ["git", "fetch", "origin", branch],
-            cwd=repo_root, capture_output=True, text=True, timeout=30
-        )
-        if fetch.returncode != 0:
-            logger.error(f"git fetch failed: {fetch.stderr}")
-            notify("Update failed", "git fetch failed, check console")
-            return
-
-        # Check if there are updates
-        diff = _sp.run(
-            ["git", "rev-list", f"HEAD..origin/{branch}", "--count"],
-            cwd=repo_root, capture_output=True, text=True, timeout=10
-        )
-        count_str = (diff.stdout or "").strip()
-        commit_count = int(count_str) if count_str.isdigit() else 0
-
-        if commit_count == 0:
-            notify("Already up to date", f"No new changes on {branch}")
-            return
-
-        # Checkout the target branch if not already on it
-        current = _sp.run(
-            ["git", "branch", "--show-current"],
-            cwd=repo_root, capture_output=True, text=True, timeout=10
-        )
-        if current.stdout.strip() != branch:
-            checkout = _sp.run(
-                ["git", "checkout", branch],
-                cwd=repo_root, capture_output=True, text=True, timeout=15
-            )
-            if checkout.returncode != 0:
-                logger.error(f"git checkout {branch} failed: {checkout.stderr}")
-                notify("Update failed", f"Could not switch to {branch}")
-                return
-
-        pull = _sp.run(
-            ["git", "pull", "origin", branch],
-            cwd=repo_root, capture_output=True, text=True, timeout=60
-        )
-        if pull.returncode != 0:
-            logger.error(f"git pull failed: {pull.stderr}")
-            notify("Update failed", "git pull failed, check console")
-            return
-
-        logger.info(f"Updated from {branch}: {commit_count} new commit(s)")
-        notify("Updated!", f"{commit_count} commit(s) from {branch}. Restarting...")
-
-        import time
-        time.sleep(2)  # Let the notification display
-        self._restart()
-
-    # Empirically chosen delay (seconds) to let pystray menu callbacks
-    # return before we call tray.stop(). Without this, WM_QUIT is posted
-    # but can't be processed while the callback is still on the stack.
-    _CALLBACK_DEFER_SECS = 0.3
-
-    def _cleanup(self):
-        """Shared shutdown sequence for restart and quit."""
-        try:
-            weekly_stats.flush()
-        except Exception:
-            logger.debug("Stats flush failed during shutdown", exc_info=True)
-        # Signal post-processing worker to shut down
-        try:
-            self.meetings.shutdown_post_worker()
-        except Exception:
-            logger.debug("Post-queue shutdown signal failed", exc_info=True)
-        try:
-            if self.recorder.is_recording:
-                self.recorder.stop()
-            self.worker.stop()
-            self._backup.stop()
-            keyboard.unhook_all()
-        except Exception:
-            logger.debug("Cleanup error during shutdown", exc_info=True)
+        self.control.update(branch)
 
     def _restart(self):
-        """Restart WhisperSync by cleaning up, stopping tray, then spawning.
-
-        Deferred to a background thread because pystray menu callbacks
-        run inside the Win32 message pump. tray.stop() posts WM_QUIT
-        but can't process it until the callback returns.
-        """
-        def _do_restart():
-            import subprocess
-            import time
-            lifecycle.record_exit_reason(lifecycle.REASON_USER_RESTART)
-            time.sleep(self._CALLBACK_DEFER_SECS)
-            self._cleanup()
-            # Spawn new process first so it starts loading immediately
-            subprocess.Popen(
-                [sys.executable, "-m", "whisper_sync"],
-                cwd=str(Path(__file__).parent.parent),
-            )
-            # Stop tray icon, then force-exit. os._exit() is needed because
-            # daemon threads (worker subprocesses, keyboard listener, etc.)
-            # can keep the process alive after tray.stop() returns.
-            if self.tray:
-                self.tray.stop()
-            time.sleep(0.2)
-            lifecycle.log_exit_banner(logger)
-            os._exit(0)
-
-        threading.Thread(target=_do_restart, daemon=True).start()
+        self.control.restart()
 
     def quit(self):
-        """Quit WhisperSync. Deferred like _restart for the same reason."""
-        def _do_quit():
-            import time
-            lifecycle.record_exit_reason(lifecycle.REASON_USER_QUIT)
-            time.sleep(self._CALLBACK_DEFER_SECS)
-            self._cleanup()
-            if self.tray:
-                self.tray.stop()
-            # Explicit banner for symmetry with _restart. In theory the
-            # atexit hook emits one when the interpreter shuts down, but
-            # daemon threads keeping the interpreter alive can swallow
-            # atexit; better to log here and let atexit be a no-op via
-            # the first-wins rule in record_exit_reason.
-            lifecycle.log_exit_banner(logger)
-        threading.Thread(target=_do_quit, daemon=True).start()
+        self.control.quit()
 
     def _prompt_large_download(self, model_name: str, size: str) -> bool:
         """Show a tkinter dialog asking if user wants to download a large model."""

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -73,7 +73,7 @@ class AppControl:
         """Run the git fetch/checkout/pull sequence for self-update."""
         notify("Updating WhisperSync...", f"Pulling latest from {branch}")
 
-                # Check for uncommitted changes
+        # Check for uncommitted changes
         status = _sp.run(
             ["git", "status", "--porcelain"],
             cwd=repo_root, capture_output=True, text=True, timeout=10
@@ -151,13 +151,14 @@ class AppControl:
         except Exception:
             logger.debug("Post-queue shutdown signal failed", exc_info=True)
         try:
-            # Lazy: keyboard is not installed on the CI system python.
-            import keyboard
-
             if self.app.recorder.is_recording:
                 self.app.recorder.stop()
             self.app.worker.stop()
             self.app._backup.stop()
+            # Lazy import last: keyboard is absent on the CI system
+            # python, and an ImportError here must never skip the
+            # recorder/worker/backup stops above.
+            import keyboard
             keyboard.unhook_all()
         except Exception:
             logger.debug("Cleanup error during shutdown", exc_info=True)

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -1,0 +1,209 @@
+"""Update, restart, and quit lifecycle - extracted from __main__.py.
+
+Hardening round item 6 (architecture spec A2), extraction 4 (final).
+AppControl owns the self-update flow (git fetch/checkout/pull against
+the repo checkout the tray app runs from), the shared shutdown
+sequence, and the deferred restart/quit paths (pystray menu callbacks
+run inside the Win32 message pump; tray.stop() posts WM_QUIT but the
+pump cannot process it until the callback returns, hence the
+background thread + defer).
+
+The old ``_updating`` class attribute is folded into
+``AppState.updating`` with UPDATE_STARTED / UPDATE_COMPLETED events -
+the last stray mode flag from the architecture audit.
+"""
+
+import os
+import sys
+import threading
+from pathlib import Path
+
+from . import lifecycle
+from . import weekly_stats
+from .logger import logger
+from .notifications import notify
+from .paths import get_install_root
+from .state_manager import UPDATE_STARTED, UPDATE_COMPLETED
+
+
+class AppControl:
+    """Owns update/restart/quit; reads services through ``app``."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def update(self, branch="dev"):
+        """Pull latest code from a branch and restart if updated.
+
+        The old _updating guard flag is folded into AppState.updating
+        (hardening item 6): same check-then-set semantics, but the whole
+        app mode is now inspectable in one snapshot.
+        """
+        state = self.app.state
+        if state is None or state.current.updating:
+            logger.debug("Update already in progress (or app not running), ignoring")
+            return
+        state.emit(UPDATE_STARTED, updating=True)
+
+        def _do_update():
+            import subprocess as _sp
+            from .executors import native_call
+            repo_root = str(get_install_root())
+
+            # One native-call span for the whole git sequence; over-marking
+            # is safe (idle GC just skips a tick), under-marking is not.
+            try:
+                with native_call("git-update"):
+                    self._run_update_steps(_sp, repo_root, branch)
+            except FileNotFoundError:
+                logger.error("git not found on PATH")
+                notify("Update failed", "git not found, check installation")
+            except _sp.TimeoutExpired:
+                logger.error("git command timed out during update")
+                notify("Update failed", "git timed out, check network")
+            except Exception as e:
+                logger.error(f"Update failed: {e}")
+                notify("Update failed", "Unexpected error, check console")
+            finally:
+                state.emit(UPDATE_COMPLETED, updating=False)
+
+        threading.Thread(target=_do_update, daemon=True).start()
+
+    def _run_update_steps(self, _sp, repo_root: str, branch: str):
+        """Run the git fetch/checkout/pull sequence for self-update."""
+        notify("Updating WhisperSync...", f"Pulling latest from {branch}")
+
+                # Check for uncommitted changes
+        status = _sp.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_root, capture_output=True, text=True, timeout=10
+        )
+        if status.stdout.strip():
+            logger.warning(f"Uncommitted changes detected:\n{status.stdout.strip()}")
+
+        # Fetch
+        fetch = _sp.run(
+            ["git", "fetch", "origin", branch],
+            cwd=repo_root, capture_output=True, text=True, timeout=30
+        )
+        if fetch.returncode != 0:
+            logger.error(f"git fetch failed: {fetch.stderr}")
+            notify("Update failed", "git fetch failed, check console")
+            return
+
+        # Check if there are updates
+        diff = _sp.run(
+            ["git", "rev-list", f"HEAD..origin/{branch}", "--count"],
+            cwd=repo_root, capture_output=True, text=True, timeout=10
+        )
+        count_str = (diff.stdout or "").strip()
+        commit_count = int(count_str) if count_str.isdigit() else 0
+
+        if commit_count == 0:
+            notify("Already up to date", f"No new changes on {branch}")
+            return
+
+        # Checkout the target branch if not already on it
+        current = _sp.run(
+            ["git", "branch", "--show-current"],
+            cwd=repo_root, capture_output=True, text=True, timeout=10
+        )
+        if current.stdout.strip() != branch:
+            checkout = _sp.run(
+                ["git", "checkout", branch],
+                cwd=repo_root, capture_output=True, text=True, timeout=15
+            )
+            if checkout.returncode != 0:
+                logger.error(f"git checkout {branch} failed: {checkout.stderr}")
+                notify("Update failed", f"Could not switch to {branch}")
+                return
+
+        pull = _sp.run(
+            ["git", "pull", "origin", branch],
+            cwd=repo_root, capture_output=True, text=True, timeout=60
+        )
+        if pull.returncode != 0:
+            logger.error(f"git pull failed: {pull.stderr}")
+            notify("Update failed", "git pull failed, check console")
+            return
+
+        logger.info(f"Updated from {branch}: {commit_count} new commit(s)")
+        notify("Updated!", f"{commit_count} commit(s) from {branch}. Restarting...")
+
+        import time
+        time.sleep(2)  # Let the notification display
+        self.restart()
+
+    # Empirically chosen delay (seconds) to let pystray menu callbacks
+    # return before we call tray.stop(). Without this, WM_QUIT is posted
+    # but can't be processed while the callback is still on the stack.
+    _CALLBACK_DEFER_SECS = 0.3
+
+    def _cleanup(self):
+        """Shared shutdown sequence for restart and quit."""
+        try:
+            weekly_stats.flush()
+        except Exception:
+            logger.debug("Stats flush failed during shutdown", exc_info=True)
+        # Signal post-processing worker to shut down
+        try:
+            self.app.meetings.shutdown_post_worker()
+        except Exception:
+            logger.debug("Post-queue shutdown signal failed", exc_info=True)
+        try:
+            # Lazy: keyboard is not installed on the CI system python.
+            import keyboard
+
+            if self.app.recorder.is_recording:
+                self.app.recorder.stop()
+            self.app.worker.stop()
+            self.app._backup.stop()
+            keyboard.unhook_all()
+        except Exception:
+            logger.debug("Cleanup error during shutdown", exc_info=True)
+
+    def restart(self):
+        """Restart WhisperSync by cleaning up, stopping tray, then spawning.
+
+        Deferred to a background thread because pystray menu callbacks
+        run inside the Win32 message pump. tray.stop() posts WM_QUIT
+        but can't process it until the callback returns.
+        """
+        def _do_restart():
+            import subprocess
+            import time
+            lifecycle.record_exit_reason(lifecycle.REASON_USER_RESTART)
+            time.sleep(self._CALLBACK_DEFER_SECS)
+            self._cleanup()
+            # Spawn new process first so it starts loading immediately
+            subprocess.Popen(
+                [sys.executable, "-m", "whisper_sync"],
+                cwd=str(Path(__file__).parent.parent),
+            )
+            # Stop tray icon, then force-exit. os._exit() is needed because
+            # daemon threads (worker subprocesses, keyboard listener, etc.)
+            # can keep the process alive after tray.stop() returns.
+            if self.app.tray:
+                self.app.tray.stop()
+            time.sleep(0.2)
+            lifecycle.log_exit_banner(logger)
+            os._exit(0)
+
+        threading.Thread(target=_do_restart, daemon=True).start()
+
+    def quit(self):
+        """Quit WhisperSync. Deferred like _restart for the same reason."""
+        def _do_quit():
+            import time
+            lifecycle.record_exit_reason(lifecycle.REASON_USER_QUIT)
+            time.sleep(self._CALLBACK_DEFER_SECS)
+            self._cleanup()
+            if self.app.tray:
+                self.app.tray.stop()
+            # Explicit banner for symmetry with _restart. In theory the
+            # atexit hook emits one when the interpreter shuts down, but
+            # daemon threads keeping the interpreter alive can swallow
+            # atexit; better to log here and let atexit be a no-op via
+            # the first-wins rule in record_exit_reason.
+            lifecycle.log_exit_banner(logger)
+        threading.Thread(target=_do_quit, daemon=True).start()

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -43,6 +43,8 @@ PR_STATUS_CHANGED = "pr_status_changed"
 SPEAKER_HEALTH_CHANGED = "speaker_health_changed"
 QUEUED = "queued"
 IDLE = "idle"
+UPDATE_STARTED = "update_started"
+UPDATE_COMPLETED = "update_completed"
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +75,13 @@ class AppState:
 
     speaker_ok: bool = True
     """Speaker loopback health (outer ring indicator)."""
+
+    updating: bool = False
+    """True while a self-update (git pull + restart) is in flight.
+
+    Folded in from __main__'s old _updating class attribute (hardening
+    item 6) - the last stray mode flag from the architecture audit.
+    """
 
     progress: float | None = None
     """0.0-1.0 for progress ring, None = no progress shown."""


### PR DESCRIPTION
## Summary

Hardening item 6, extraction 4 of 4 - this completes the __main__.py decomposition and with it the 2026-07-03 hardening round (all 11 items).

- **app_control.py - AppControl**: git self-update against the running checkout (fetch / rev-list / checkout / pull with per-step failure toasts), the shared shutdown sequence, and the deferred restart/quit paths (pystray menu callbacks run inside the Win32 message pump; tray.stop() posts WM_QUIT that cannot be processed until the callback returns).
- **AppState.updating fold**: the _updating class attribute becomes AppState.updating with UPDATE_STARTED/UPDATE_COMPLETED events - the last stray mode flag from the architecture audit (A1/A2). Same check-then-set semantics; the whole app mode is now inspectable in one snapshot.
- The app keeps thin _update/_restart/quit delegates, so the tray menu and all callers are unchanged.
- keyboard imports lazily (not on the CI system python).

__main__.py: 3,990 lines at round start -> ~650 lines of component composition, hotkey/click wiring, run(), and main(). Every workflow now lives in a tested component: dictation_flow, meeting_flow, meeting_dialogs, tray_menu, github_tray, app_control, icons.FlashController.

## Testing

- System suite: 260 passed (9 new in tests/test_app_control.py); venv suite: 36 passed; pyflakes clean.
- New coverage: the guard fold (updating True during the run, cleared on success AND failure, re-entrant click ignored, pre-run call safe), git decision points (up-to-date never restarts; new commits pull then restart), shutdown order (recorder/worker/backup/post-queue/hooks), quit vs restart exit-reason recording, restart spawn-then-exit.
- Full composition smoke test on the production venv: WhisperSync() instantiates all six components and builds the real 14-item menu.

## Docs (same PR)

TECHNICAL.md + CLAUDE.md module rows, and the plan doc's round-closing entry: item table flipped to MERGED, the still-open production-validation and MODE_TRANSITIONS-soak work recorded explicitly.