### PR TITLE
feat: model auto-sleep - free VRAM when idle, wake on demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ When a user reports that a meeting "crashed" or "failed" or "didn't finish", do 
 | `tray_menu.py` | Tray menu construction + all settings setters + option constants. menu_callback() binds pystray item callbacks. |
 | `github_tray.py` | GitHub PR status tray glue: poller lifecycle, PR toasts, menu section, gh merge. |
 | `app_control.py` | Update/restart/quit lifecycle: git self-update, shared shutdown, deferred exits. Update guard folded into AppState.updating. |
+| `auto_sleep.py` | Model auto-sleep: worker unloaded from VRAM after idle timeout or tray double-click; any action wakes it (yellow flash). AppState.sleeping + sleep icon. |
 | `state_manager.py` | Observable state machine. AppState dataclass, typed StateEvent, event constants, thread-safe emit(), listener subscriptions (on/on_any), event log ringbuffer. All icon/toast updates flow through here. |
 | `transcribe.py` | WhisperX with persistent model cache. Fast path (dictation) and staged pipeline (meeting) |
 | `worker.py` | Multiprocessing transcription worker. CUDA isolation via spawn context |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Runs as a system tray icon on Windows.
 - **CPU/GPU device selection** -- Auto-detect, force GPU, or force CPU via tray menu
 - **Three-ring tray icon** -- inner dot = backup/overlay dictation, inner circle = mic status, outer ring = speaker/loopback status (canonical table: .claude/rules/ui-patterns.md)
 - **Incognito mode** -- RAM-only dictation; no transcription text logged or saved to disk
+- **Model auto-sleep** -- unloads the model from VRAM after 30 idle minutes (configurable) or on tray double-click (for gaming); any dictation/meeting action wakes it with the yellow loading flash
 - **Persistent dictation history** -- last 10 dictations in tray menu, survives restarts
 - **Session stats** -- dictation/meeting counts, averages, and uptime for the current session
 - **Windows toast notifications** -- native Windows notifications for transcription events

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -17,6 +17,7 @@ Everything below is for developers modifying this app or for an AI assistant (li
 | `tray_menu.py` | **Tray menu + settings.** Full right-click menu build, every settings setter, output-folder dialogs, error popup. Menus swap via MenuRefresher under the tray lock. | `TrayMenu` class --`build()`, `_set_*()`, `_change_output_folder()`; module `menu_callback()` + option constants |
 | `github_tray.py` | **GitHub PR tray glue.** Poller lifecycle, PR change toasts with action buttons, GitHub menu section, gh-CLI merge. | `GitHubTray` class --`start()`, `stop()`, `menu_items()`, `_merge_pr()` |
 | `app_control.py` | **Update/restart/quit lifecycle.** Self-update via git against the running checkout, shared shutdown sequence, deferred restart/quit (menu callbacks run inside the Win32 pump). Update guard lives in `AppState.updating`. | `AppControl` class --`update()`, `restart()`, `quit()`, `_cleanup()` |
+| `auto_sleep.py` | **Model auto-sleep.** Unloads the worker (frees VRAM) after N idle minutes or on tray double-click; wakes on any dictation/meeting action with the yellow loading flash. Sleep/wake land in gpu-guard.jsonl. | `AutoSleep` class --`sleep()`, `wake()`, `toggle()`; `ClickRouter` (single vs double click) |
 | `capture.py` | **Audio recording.** Multi-stream mic + speaker loopback via WASAPI. | `AudioRecorder` class --`start()`, `stop()`, `_mic_callback()`, `_speaker_callback()`, `start_streaming()`, `stop_streaming()` |
 | `transcribe.py` | **WhisperX engine.** Model loading, transcription, alignment, diarization. Two paths: fast (dictation) and full (meeting). | `transcribe_fast(audio_np, model)` -- in-memory numpy to text; `transcribe(audio_path, diarize, model)` -- file-based full pipeline; `_load_model()`, `_load_align_model()` |
 | `worker.py` | **Subprocess entry point.** Runs transcription in isolated process (crash safety). Receives requests via Queue, returns results. | `worker_main()` -- event loop handling `transcribe_fast`, `transcribe`, `reload_model`, `shutdown` requests |
@@ -62,6 +63,7 @@ __main__.py (entry point, UI, hotkeys)
 ├── tray_menu.py (menu + settings component)
 ├── github_tray.py (GitHub PR status glue)
 ├── app_control.py (update/restart/quit lifecycle)
+├── auto_sleep.py (model VRAM sleep/wake)
 ├── config.py (settings)
 ├── paths.py (directories)
 ├── logger.py (logging)

--- a/tests/test_auto_sleep.py
+++ b/tests/test_auto_sleep.py
@@ -1,0 +1,225 @@
+"""Tests for whisper_sync.auto_sleep - AutoSleep and ClickRouter.
+
+Pins the VRAM lifecycle contract: the idle checker only sleeps a fully
+idle app after the configured window, manual sleep refuses while work
+is active, waking flashes and respawns the worker, and the double-click
+router never fires both actions for one gesture.
+"""
+
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+from whisper_sync import auto_sleep as auto_sleep_mod
+from whisper_sync.auto_sleep import AutoSleep, ClickRouter
+from whisper_sync.state_manager import (
+    StateManager, DICTATION_COMPLETED, MEETING_STARTED,
+)
+
+
+def _inline(lane, label, fn, native=False):
+    fn()
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.running = True
+        self.stops = 0
+        self.starts = 0
+
+    def stop(self):
+        self.running = False
+        self.stops += 1
+
+    def start(self):
+        self.running = True
+        self.starts += 1
+
+    def wait_ready(self, timeout=None):
+        return self.running
+
+
+class _FakeApp:
+    def __init__(self):
+        self.cfg = {"auto_sleep_minutes": 30}
+        self.state = StateManager(None, {})
+        self.worker = _FakeWorker()
+        self.recorder = types.SimpleNamespace(is_recording=False)
+        self._gpu_guard = types.SimpleNamespace(
+            log_external_event=mock.Mock())
+        self.flashes = 0
+        self.refreshes = 0
+
+    def _yellow_flash(self):
+        self.flashes += 1
+
+    def _refresh_menu(self):
+        self.refreshes += 1
+
+
+class _SleepHarness(unittest.TestCase):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.auto = AutoSleep(self.app)
+        patches = [
+            mock.patch.object(auto_sleep_mod, "submit_or_spawn", _inline),
+            mock.patch.object(auto_sleep_mod, "notify"),
+        ]
+        for p in patches:
+            self.notify = p.start()
+            self.addCleanup(p.stop)
+
+
+class IdleCheckerTests(_SleepHarness):
+    def _age(self, minutes):
+        self.auto._last_activity = time.monotonic() - minutes * 60
+
+    def test_sleeps_after_idle_window(self):
+        self._age(31)
+        self.auto._check()
+        self.assertTrue(self.app.state.current.sleeping)
+        self.assertEqual(self.app.worker.stops, 1)
+
+    def test_stays_awake_inside_window(self):
+        self._age(29)
+        self.auto._check()
+        self.assertFalse(self.app.state.current.sleeping)
+        self.assertEqual(self.app.worker.stops, 0)
+
+    def test_disabled_never_sleeps(self):
+        self.app.cfg["auto_sleep_minutes"] = 0
+        self._age(500)
+        self.auto._check()
+        self.assertFalse(self.app.state.current.sleeping)
+
+    def test_busy_app_resets_the_clock_instead_of_sleeping(self):
+        self.app.state.emit(MEETING_STARTED, mode="meeting")
+        self._age(90)
+        self.auto._check()
+        self.assertFalse(self.app.state.current.sleeping)
+        self.assertLess(time.monotonic() - self.auto._last_activity, 5,
+                        "busy check must re-arm the idle clock")
+
+    def test_activity_events_bump_the_clock(self):
+        self.auto.start(scheduler=types.SimpleNamespace(
+            call_every=lambda *a, **k: None))
+        self._age(90)
+        self.app.state.emit(DICTATION_COMPLETED, mode="done")
+        self.assertLess(time.monotonic() - self.auto._last_activity, 5)
+
+    def test_background_transcription_blocks_sleep(self):
+        self.app.state.emit(MEETING_STARTED, mode=None,
+                            meeting_transcribing=True)
+        self._age(90)
+        self.auto._check()
+        self.assertFalse(self.app.state.current.sleeping)
+
+
+class ManualToggleTests(_SleepHarness):
+    def test_toggle_sleeps_then_wakes_with_flash(self):
+        self.auto.toggle()
+        self.assertTrue(self.app.state.current.sleeping)
+        self.assertEqual(self.app.worker.stops, 1)
+
+        self.auto.toggle()
+        self.assertFalse(self.app.state.current.sleeping)
+        self.assertEqual(self.app.worker.starts, 1)
+        self.assertEqual(self.app.flashes, 1, "wake shows the loading flash")
+
+    def test_manual_sleep_refused_while_recording(self):
+        self.app.recorder.is_recording = True
+        self.auto.sleep(reason="double_click")
+        self.assertFalse(self.app.state.current.sleeping)
+        self.assertEqual(self.app.worker.stops, 0)
+        self.notify.assert_called_once()
+
+    def test_idle_sleep_refusal_is_silent(self):
+        self.app.recorder.is_recording = True
+        self.auto.sleep(reason="idle")
+        self.notify.assert_not_called()
+
+    def test_sleep_and_wake_land_on_the_correlation_timeline(self):
+        self.auto.toggle()
+        self.auto.toggle()
+        events = [c[0][0] for c in
+                  self.app._gpu_guard.log_external_event.call_args_list]
+        self.assertEqual(events, ["model_sleep", "model_wake"])
+
+    def test_double_sleep_is_a_noop(self):
+        self.auto.sleep(reason="double_click")
+        self.auto.sleep(reason="double_click")
+        self.assertEqual(self.app.worker.stops, 1)
+
+    def test_wake_when_awake_is_a_noop(self):
+        self.auto.wake(reason="hotkey")
+        self.assertEqual(self.app.worker.starts, 0)
+        self.assertEqual(self.app.flashes, 0)
+
+
+class ClickRouterTests(unittest.TestCase):
+    def setUp(self):
+        self.fired = []
+
+    def _router(self, window=0.15):
+        return ClickRouter(single=lambda: self.fired.append("single"),
+                           double=lambda: self.fired.append("double"),
+                           window_s=window)
+
+    def test_single_click_fires_after_window(self):
+        router = self._router()
+        router.click()
+        self.assertEqual(self.fired, [], "single must be deferred")
+        time.sleep(0.35)
+        self.assertEqual(self.fired, ["single"])
+
+    def test_double_click_fires_double_only(self):
+        router = self._router()
+        router.click()
+        router.click()
+        time.sleep(0.35)
+        self.assertEqual(self.fired, ["double"],
+                         "the deferred single must be cancelled")
+
+    def test_two_slow_clicks_are_two_singles(self):
+        router = self._router(window=0.05)
+        router.click()
+        time.sleep(0.25)
+        router.click()
+        time.sleep(0.25)
+        self.assertEqual(self.fired, ["single", "single"])
+
+
+class IconTests(unittest.TestCase):
+    def test_sleep_icon_key_and_spec(self):
+        from whisper_sync.icons import resolve_icon_key, ICON_REGISTRY
+        self.assertEqual(resolve_icon_key(mode=None, sleeping=True), "sleep")
+        self.assertEqual(resolve_icon_key(mode=None, sleeping=False), "idle")
+        # Sleep must never mask real activity.
+        self.assertNotEqual(
+            resolve_icon_key(mode="meeting", sleeping=True), "sleep")
+        spec = ICON_REGISTRY["sleep"]
+        self.assertEqual(spec.outer, "#808080", "outer ring stays normal gray")
+        self.assertNotEqual(spec.middle, ICON_REGISTRY["idle"].middle,
+                            "middle must be the deeper sleep gray")
+
+    def test_sleep_icon_builds(self):
+        from whisper_sync.icons import build_icon, ICON_REGISTRY
+        img = build_icon(ICON_REGISTRY["sleep"])
+        self.assertEqual(img.size, (64, 64))
+
+
+class ConfigTests(unittest.TestCase):
+    def test_auto_sleep_minutes_in_defaults_and_valid_keys(self):
+        import json
+        from pathlib import Path
+        from whisper_sync import config
+        defaults = json.loads(
+            (Path(config.__file__).parent / "config.defaults.json").read_text())
+        self.assertEqual(defaults.get("auto_sleep_minutes"), 30)
+        self.assertIn("auto_sleep_minutes", config._VALID_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_auto_sleep.py
+++ b/tests/test_auto_sleep.py
@@ -152,6 +152,17 @@ class ManualToggleTests(_SleepHarness):
         self.auto.sleep(reason="double_click")
         self.assertEqual(self.app.worker.stops, 1)
 
+    def test_wake_resets_the_idle_clock(self):
+        # Review catch: without this, a manual wake after a long idle
+        # stretch is auto-slept again on the next minute tick.
+        self.auto.toggle()  # sleep
+        self.auto._last_activity = time.monotonic() - 90 * 60
+        self.auto.toggle()  # wake
+        self.assertLess(time.monotonic() - self.auto._last_activity, 5)
+        self.auto._check()
+        self.assertFalse(self.app.state.current.sleeping,
+                         "freshly woken model must not instantly re-sleep")
+
     def test_wake_when_awake_is_a_noop(self):
         self.auto.wake(reason="hotkey")
         self.assertEqual(self.app.worker.starts, 0)
@@ -181,6 +192,21 @@ class ClickRouterTests(unittest.TestCase):
         time.sleep(0.35)
         self.assertEqual(self.fired, ["double"],
                          "the deferred single must be cancelled")
+
+    def test_stale_pending_handle_never_fakes_a_double(self):
+        # Review catch: if the scheduler is shut down, call_later returns
+        # a handle that never fires, so _pending never clears. The
+        # deadline guard must treat a click after the window as a fresh
+        # single, not a phantom double.
+        router = self._router(window=0.05)
+        dead_handle = types.SimpleNamespace(cancel=lambda: None)
+        with mock.patch("whisper_sync.scheduler.scheduler.call_later",
+                        return_value=dead_handle):
+            router.click()          # pending stored, never fires
+            time.sleep(0.2)         # window expires
+            router.click()          # must NOT be a double
+        self.assertEqual(self.fired, [],
+                         "no action may fire through a dead scheduler")
 
     def test_two_slow_clicks_are_two_singles(self):
         router = self._router(window=0.05)

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -229,6 +229,15 @@ class NormalDictationTests(_FlowHarness):
         self.flow._start(feature=False)
         self.assertFalse(self.app.recorder.is_recording)
 
+    def test_toggle_wakes_sleeping_model_instead_of_recording(self):
+        from whisper_sync.state_manager import SLEEP_STARTED
+        self.app.auto_sleep = mock.Mock()
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        self.flow.toggle()
+        self.app.auto_sleep.wake.assert_called_once()
+        self.assertFalse(self.app.recorder.is_recording,
+                         "dictation must not start while the model loads")
+
     def test_discard_throws_audio_away(self):
         self.flow.toggle()
         self.flow.discard()

--- a/tests/test_meeting_flow.py
+++ b/tests/test_meeting_flow.py
@@ -159,6 +159,16 @@ class StartStopTests(_FlowHarness):
         self.assertTrue(disk_only, "meeting streams to disk only")
         self.assertTrue(str(path).endswith("mic-temp.wav"))
 
+    def test_toggle_wakes_sleeping_model_and_starts_recording(self):
+        from whisper_sync.state_manager import SLEEP_STARTED
+        self.app.auto_sleep = mock.Mock()
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        self.flow.toggle()
+        self.app.auto_sleep.wake.assert_called_once()
+        self.assertTrue(self.app.recorder.is_recording,
+                        "recording must start immediately; transcription "
+                        "waits for the worker at its own step")
+
     def test_start_rejected_when_mode_not_startable(self):
         self.app.state.emit("meeting_started", mode="saving")
         self.flow._start()

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -114,6 +114,7 @@ class _FakeApp:
         self.meetings = types.SimpleNamespace(
             recover_meeting_speakers=lambda d: None)
         self.github = _FakeGitHub()
+        self.auto_sleep = types.SimpleNamespace(toggle=lambda: None)
         self._cpu_name = "FakeCPU"
         self._dialog_dispatcher = None
         self.saved = 0

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -58,6 +58,7 @@ from .meeting_flow import MeetingFlow
 from .tray_menu import TrayMenu
 from .github_tray import GitHubTray
 from .app_control import AppControl
+from .auto_sleep import AutoSleep, ClickRouter
 from .meeting_dialogs import MeetingDialogs
 from .dialog_dispatcher import DialogDispatcher
 
@@ -129,6 +130,10 @@ class WhisperSync:
         self.github = GitHubTray(self)
         # Update/restart/quit lifecycle component (app_control.py).
         self.control = AppControl(self)
+        # Model auto-sleep (VRAM unload) + tray double-click routing.
+        self.auto_sleep = AutoSleep(self)
+        self._click_router = ClickRouter(single=self._do_left_click,
+                                         double=self.auto_sleep.toggle)
 
     @staticmethod
     def _migrate_data():
@@ -205,6 +210,12 @@ class WhisperSync:
             self.dictation.toggle()
 
     def _on_left_click(self):
+        # All default-item activations funnel through the router so a
+        # double click (sleep toggle) can claim the pair; the single
+        # action fires after the double-click window.
+        self._click_router.click()
+
+    def _do_left_click(self):
         # Left-click while dictating = discard (stop recording, throw away audio)
         current = self.state.current if self.state else None
         mode = current.mode if current else None
@@ -377,6 +388,7 @@ class WhisperSync:
                 meeting_transcribing=s.meeting_transcribing,
                 dictation_overlay=s.dictation_overlay,
                 speaker_ok=speaker_ok,
+                sleeping=s.sleeping,
             )
             spec = ICON_REGISTRY[key]
             progress = s.progress
@@ -479,6 +491,9 @@ class WhisperSync:
         from .scheduler import scheduler as _sched
         self._gpu_guard.start(_sched, IO)
 
+        # Model auto-sleep: idle checker + activity subscription.
+        self.auto_sleep.start(_sched)
+
         # Suspend/resume awareness (hardware-resilience spec H1): both
         # transitions land in gpu-guard.jsonl for crash-time correlation,
         # and resume verifies the CUDA worker survived sleep, restarting
@@ -496,6 +511,9 @@ class WhisperSync:
         def _on_resume():
             def _check():
                 self._gpu_guard.log_external_event("system_resume")
+                asleep = self.state is not None and self.state.current.sleeping
+                if asleep:
+                    return  # worker is intentionally stopped; do not wake
                 if not self.worker.is_alive():
                     logger.warning("Worker did not survive suspend/resume; restarting")
                     self.worker.restart()

--- a/whisper_sync/auto_sleep.py
+++ b/whisper_sync/auto_sleep.py
@@ -1,0 +1,210 @@
+"""Auto-sleep - unload the model from VRAM when idle, wake on demand.
+
+The transcription worker holds the model in VRAM for the whole session.
+AutoSleep frees that memory two ways:
+
+- **Automatic**: after ``auto_sleep_minutes`` (default 30, 0 disables)
+  with no dictation/meeting/transcription activity, the worker
+  subprocess is stopped - process exit releases ALL of its VRAM.
+- **Manual**: double-clicking the tray icon toggles sleep (for gaming
+  and other VRAM-hungry work). ClickRouter below distinguishes the
+  double click from the configured single-click action.
+
+While asleep the tray shows the "sleep" icon (deeper gray middle,
+normal gray outer ring). Any dictation or meeting toggle wakes the
+model with the usual yellow loading double-flash; meetings start
+recording immediately (the pipeline waits for the worker at the
+transcription step), dictation asks the user to retry once loaded.
+
+Follows the GPU Guard feature pattern: one owning module, flat config
+key, fully inert when disabled. Sleep and wake events land in
+gpu-guard.jsonl so VRAM lifecycle stays on the crash-correlation
+timeline.
+"""
+
+import threading
+import time
+
+from .executors import IO, submit_or_spawn
+from .logger import logger
+from .notifications import notify
+from .state_manager import (
+    SLEEP_STARTED, SLEEP_ENDED,
+    DICTATION_STARTED, DICTATION_COMPLETED, DICTATION_DISCARDED,
+    MEETING_STARTED, MEETING_STOPPED, MEETING_COMPLETED,
+    TRANSCRIPTION_STARTED, TRANSCRIPTION_PROGRESS, TRANSCRIPTION_COMPLETED,
+    QUEUED,
+)
+
+# Events that count as "the model is in use" for the idle clock.
+# Deliberately excludes PR_STATUS_CHANGED (GitHub polling), MODEL_* and
+# SPEAKER_HEALTH_CHANGED - none of them mean the user needs the model.
+_ACTIVITY_EVENTS = frozenset({
+    DICTATION_STARTED, DICTATION_COMPLETED, DICTATION_DISCARDED,
+    MEETING_STARTED, MEETING_STOPPED, MEETING_COMPLETED,
+    TRANSCRIPTION_STARTED, TRANSCRIPTION_PROGRESS, TRANSCRIPTION_COMPLETED,
+    QUEUED,
+})
+
+_CHECK_INTERVAL_S = 60.0
+
+# Windows' default double-click time is 500ms; the single action is
+# deferred this long so a second click can claim the pair. Left-click
+# actions (toggle meeting/dictation, discard) are not latency-critical -
+# hotkeys are the fast path.
+DOUBLE_CLICK_WINDOW_S = 0.45
+
+
+class ClickRouter:
+    """Route tray-icon clicks: single fires one action, double another.
+
+    pystray's Win32 backend activates the default menu item on every
+    WM_LBUTTONUP, so a double click arrives as two activations in quick
+    succession. The first schedules the single action after
+    DOUBLE_CLICK_WINDOW_S; a second click inside the window cancels it
+    and fires the double action instead. Thread-safe: activations come
+    from the pystray pump, the timer from the scheduler thread.
+    """
+
+    def __init__(self, single, double, window_s: float = DOUBLE_CLICK_WINDOW_S):
+        self._single = single
+        self._double = double
+        self._window_s = window_s
+        self._lock = threading.Lock()
+        self._pending = None  # scheduler handle for the deferred single
+
+    def click(self):
+        from .scheduler import scheduler
+        with self._lock:
+            if self._pending is not None:
+                self._pending.cancel()
+                self._pending = None
+                fire_double = True
+            else:
+                fire_double = False
+                self._pending = scheduler.call_later(
+                    self._window_s, self._fire_single, label="tray-click")
+        if fire_double:
+            self._double()
+
+    def _fire_single(self):
+        with self._lock:
+            self._pending = None
+        self._single()
+
+
+class AutoSleep:
+    """Owns model sleep/wake; reads shared services through ``app``."""
+
+    def __init__(self, app):
+        self.app = app
+        self._last_activity = time.monotonic()
+
+    # -- Wiring (called from run()) -------------------------------------------
+
+    def start(self, scheduler):
+        """Subscribe to activity events and start the idle checker."""
+        self.app.state.on_any(self._on_event)
+        scheduler.call_every(_CHECK_INTERVAL_S, self._check, label="auto-sleep")
+
+    def _on_event(self, event):
+        if event.type in _ACTIVITY_EVENTS:
+            self._last_activity = time.monotonic()
+
+    # -- State ----------------------------------------------------------------
+
+    @property
+    def sleeping(self) -> bool:
+        state = self.app.state
+        return bool(state and state.current.sleeping)
+
+    def _busy(self) -> bool:
+        """True while sleeping now would interrupt real work."""
+        current = self.app.state.current if self.app.state else None
+        if current is None:
+            return True  # not fully started; never sleep during startup
+        return (
+            current.mode not in (None, "done", "error")
+            or current.meeting_transcribing
+            or current.dictation_overlay
+            or self.app.recorder.is_recording
+        )
+
+    def _check(self):
+        """Idle checker (scheduler, every minute). Cheap by contract."""
+        try:
+            minutes = float(self.app.cfg.get("auto_sleep_minutes", 30) or 0)
+            if minutes <= 0 or self.sleeping:
+                return
+            if self._busy():
+                # Busy periods emit no mid-flight events; keep the clock
+                # fresh so the timeout starts when the work ends.
+                self._last_activity = time.monotonic()
+                return
+            if time.monotonic() - self._last_activity >= minutes * 60.0:
+                self.sleep(reason="idle")
+        except Exception:
+            logger.debug("auto-sleep check failed", exc_info=True)
+
+    # -- Sleep / wake -----------------------------------------------------------
+
+    def toggle(self):
+        """Double-click entry point: sleep if awake, wake if asleep."""
+        if self.sleeping:
+            self.wake(reason="double_click")
+        else:
+            self.sleep(reason="double_click")
+
+    def sleep(self, reason: str):
+        """Stop the worker subprocess, freeing its VRAM."""
+        if self.sleeping:
+            return
+        if self._busy():
+            logger.info(f"Sleep refused ({reason}): recording or transcription active")
+            if reason != "idle":
+                notify("Can't sleep now", "A recording or transcription is active.")
+            return
+        logger.info(f"Model going to sleep ({reason}); unloading worker from VRAM")
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        try:
+            self.app._gpu_guard.log_external_event("model_sleep", reason=reason)
+        except Exception:
+            pass
+
+        def _stop():
+            try:
+                self.app.worker.stop()
+                logger.info("Worker stopped; VRAM released")
+            except Exception:
+                logger.warning("Worker stop during sleep failed", exc_info=True)
+            self.app._refresh_menu()
+
+        # Off-thread: worker.stop() joins the subprocess and must not
+        # block a hotkey/menu/scheduler thread.
+        submit_or_spawn(IO, "sleep-stop-worker", _stop)
+
+    def wake(self, reason: str):
+        """Respawn the worker and reload the model (yellow flash while loading)."""
+        if not self.sleeping:
+            return
+        logger.info(f"Model waking up ({reason}); reloading worker")
+        self.app.state.emit(SLEEP_ENDED, sleeping=False)
+        try:
+            self.app._gpu_guard.log_external_event("model_wake", reason=reason)
+        except Exception:
+            pass
+        self.app._yellow_flash()
+
+        def _start():
+            try:
+                self.app.worker.start()
+                if self.app.worker.wait_ready(timeout=120):
+                    logger.info("Model reloaded after sleep")
+                else:
+                    logger.warning("Worker failed to become ready after wake")
+                    notify("Wake failed", "Model did not reload; check the log.")
+            except Exception:
+                logger.warning("Worker start during wake failed", exc_info=True)
+            self.app._refresh_menu()
+
+        submit_or_spawn(IO, "wake-start-worker", _start)

--- a/whisper_sync/auto_sleep.py
+++ b/whisper_sync/auto_sleep.py
@@ -72,11 +72,17 @@ class ClickRouter:
         self._window_s = window_s
         self._lock = threading.Lock()
         self._pending = None  # scheduler handle for the deferred single
+        self._deadline = 0.0  # monotonic time the pending single expires
 
     def click(self):
         from .scheduler import scheduler
+        now = time.monotonic()
         with self._lock:
-            if self._pending is not None:
+            # The deadline guard makes a stale pending harmless: if the
+            # scheduler was shut down (teardown) the handle never fires
+            # and never clears, but once the window has passed the next
+            # click is a fresh single, not a phantom double.
+            if self._pending is not None and now < self._deadline:
                 self._pending.cancel()
                 self._pending = None
                 fire_double = True
@@ -84,6 +90,7 @@ class ClickRouter:
                 fire_double = False
                 self._pending = scheduler.call_later(
                     self._window_s, self._fire_single, label="tray-click")
+                self._deadline = now + self._window_s
         if fire_double:
             self._double()
 
@@ -181,13 +188,16 @@ class AutoSleep:
 
         # Off-thread: worker.stop() joins the subprocess and must not
         # block a hotkey/menu/scheduler thread.
-        submit_or_spawn(IO, "sleep-stop-worker", _stop)
+        submit_or_spawn(IO, "sleep-stop-worker", _stop, native=True)
 
     def wake(self, reason: str):
         """Respawn the worker and reload the model (yellow flash while loading)."""
         if not self.sleeping:
             return
         logger.info(f"Model waking up ({reason}); reloading worker")
+        # A wake IS activity: without this, a manual wake after a long
+        # idle stretch would be auto-slept again on the next check tick.
+        self._last_activity = time.monotonic()
         self.app.state.emit(SLEEP_ENDED, sleeping=False)
         try:
             self.app._gpu_guard.log_external_event("model_wake", reason=reason)
@@ -207,4 +217,4 @@ class AutoSleep:
                 logger.warning("Worker start during wake failed", exc_info=True)
             self.app._refresh_menu()
 
-        submit_or_spawn(IO, "wake-start-worker", _start)
+        submit_or_spawn(IO, "wake-start-worker", _start, native=True)

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -17,6 +17,7 @@
   "use_system_devices": true,
   "left_click": "meeting",
   "middle_click": "dictation",
+  "auto_sleep_minutes": 30,
   "github_repo": null,
   "github_poll_interval": 120,
   "github_notifications": true,

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -23,6 +23,7 @@ _VALID_KEYS = {
     "hotkeys", "paste_method", "language", "model", "dictation_model",
     "compute_type", "output_dir", "mic_device", "speaker_device",
     "sample_rate", "use_system_devices", "left_click", "middle_click",
+    "auto_sleep_minutes",
     "suppress_llm_warning", "github_repo", "github_poll_interval",
     "github_notifications", "log_window", "device", "incognito",
     "always_available_dictation", "backup_device", "backup_model",

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -95,6 +95,12 @@ class DictationFlow:
                 self._stop_overlay()
                 return
 
+            if current and current.sleeping:
+                # Model is unloaded (auto_sleep): wake it (yellow loading
+                # flash) and let the user retry once it is ready.
+                self.app.auto_sleep.wake(reason="dictation_hotkey")
+                return
+
             if mode == "dictation":
                 self._stop()
             elif mode == "meeting" or (mode is None and meeting_tx):
@@ -132,6 +138,9 @@ class DictationFlow:
             if mode == "dictation":
                 # Already recording a normal dictation - ignore
                 logger.debug("Feature suggest ignored - dictation in progress")
+                return
+            if current and current.sleeping:
+                self.app.auto_sleep.wake(reason="feature_hotkey")
                 return
 
             if mode == "meeting" or (mode is None and meeting_tx):

--- a/whisper_sync/icons.py
+++ b/whisper_sync/icons.py
@@ -46,6 +46,9 @@ class IconSpec:
 ICON_REGISTRY: dict[str, IconSpec] = {
     # Idle
     "idle": IconSpec("#808080", "#808080", tooltip="Idle"),
+    # Sleep: model unloaded from VRAM (auto_sleep.py). Deeper gray
+    # middle inside the normal gray ring - resting, not a warning.
+    "sleep": IconSpec("#808080", "#4d4d4d", tooltip="Sleeping (model unloaded)"),
 
     # Meeting states
     "recording.meeting":              IconSpec("#CC3333", "#FF4444", tooltip="Recording meeting..."),
@@ -152,7 +155,8 @@ def build_icon(spec: IconSpec, progress: float | None = None,
 def resolve_icon_key(mode: str | None = None,
                      meeting_transcribing: bool = False,
                      dictation_overlay: bool = False,
-                     speaker_ok: bool = True) -> str:
+                     speaker_ok: bool = True,
+                     sleeping: bool = False) -> str:
     """Map composite app state to an ICON_REGISTRY key.
 
     Accepts individual fields rather than an AppState to avoid a circular
@@ -178,6 +182,8 @@ def resolve_icon_key(mode: str | None = None,
         return mode  # "dictation", "saving", "transcribing", "done", "error"
     if meeting_transcribing:
         return "transcribing"
+    if sleeping:
+        return "sleep"
     return "idle"
 
 

--- a/whisper_sync/meeting_flow.py
+++ b/whisper_sync/meeting_flow.py
@@ -87,7 +87,13 @@ class MeetingFlow:
 
     def toggle(self):
         with self.app._lock:
-            mode = self.app.state.current.mode if self.app.state else None
+            current = self.app.state.current if self.app.state else None
+            mode = current.mode if current else None
+            if current and current.sleeping:
+                # Wake the model but START RECORDING immediately - the
+                # pipeline only needs the worker at the transcription
+                # step, and step_transcribe already waits for readiness.
+                self.app.auto_sleep.wake(reason="meeting_hotkey")
             if mode == "meeting":
                 self._stop()
             elif self.app._can_record():

--- a/whisper_sync/state_manager.py
+++ b/whisper_sync/state_manager.py
@@ -45,6 +45,8 @@ QUEUED = "queued"
 IDLE = "idle"
 UPDATE_STARTED = "update_started"
 UPDATE_COMPLETED = "update_completed"
+SLEEP_STARTED = "sleep_started"
+SLEEP_ENDED = "sleep_ended"
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +77,13 @@ class AppState:
 
     speaker_ok: bool = True
     """Speaker loopback health (outer ring indicator)."""
+
+    sleeping: bool = False
+    """True while the model is unloaded from VRAM (auto_sleep.py).
+
+    Sleep is not a mode: recording stays possible (a meeting toggle
+    wakes the model and starts recording immediately).
+    """
 
     updating: bool = False
     """True while a self-update (git pull + restart) is in flight.

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -416,6 +416,8 @@ class TrayMenu:
 
         # Left-click fires the default menu item
         left_action = self.app.cfg.get("left_click", "meeting")
+        _state = self.app.state.current if self.app.state else None
+        _sleeping = bool(_state and _state.sleeping)
         return pystray.Menu(
             pystray.MenuItem("Meetings", self._build_meetings_menu()),
             pystray.MenuItem("Recent Dictations", self._build_recent_dictations_menu()),
@@ -424,6 +426,10 @@ class TrayMenu:
                              default=left_action == "dictation"),
             pystray.MenuItem(f"Meeting\t{meet_hk}", lambda: self.app._on_left_click() if left_action == "meeting" else self.app.meetings.toggle(),
                              default=left_action == "meeting"),
+            pystray.MenuItem(
+                "Wake Model" if _sleeping else "Sleep Model\tdouble-click",
+                menu_callback(self.app.auto_sleep.toggle),
+            ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem("Mic Input\tsystem", None, enabled=False)
             if use_sys else


### PR DESCRIPTION
## Summary

New feature (owner request 2026-07-04): the model unloads from VRAM when unused, and can be put to sleep on demand for gaming.

- **Auto-sleep**: after `auto_sleep_minutes` (default 30, 0 disables) with no dictation/meeting/transcription activity, the worker subprocess stops - process exit frees all of its VRAM. The idle checker treats busy periods (recording, background transcription, overlay) as activity, so the clock starts when work ends.
- **Manual sleep: double-click the tray icon.** pystray's Win32 backend activates the default menu item on every left-button release, so a double click arrives as two activations; ClickRouter defers the single-click action by the double-click window (450ms) and a second click inside it claims the pair. One gesture never fires both actions. Also available as a top-level Sleep Model / Wake Model menu item.
- **Wake on any action** with the usual yellow loading double-flash. A meeting toggle wakes AND starts recording immediately (the post-processing pipeline already waits for worker readiness at the transcription step); a dictation toggle wakes and lets the user retry once loaded.
- **Sleep icon**: deeper gray middle circle inside the normal gray outer ring - resting, not a warning. Driven by the new `AppState.sleeping` field (SLEEP_STARTED/SLEEP_ENDED events); sleep is deliberately NOT a mode, so recording stays possible.
- **Crash-correlation**: model_sleep/model_wake events land in gpu-guard.jsonl - VRAM lifecycle stays on the BSOD timeline.
- **Suspend/resume**: the resume health check no longer restarts an intentionally sleeping worker.
- Follows the GPU Guard feature pattern: one owning module (auto_sleep.py), flat config key, fully inert when disabled. Settings > Auto-sleep offers Off/10/20/30/60 minutes.
- Manual sleep during a recording or transcription is refused with a toast; the idle path refuses silently.

## Testing

- System suite: 280 passed (20 new: idle-checker windows, busy-blocks-sleep, activity events re-arm the clock, manual toggle + refusal paths, sleep/wake correlation events, ClickRouter single/double/slow-clicks timing, icon key + spec + render, config defaults/valid-keys).
- Wake hooks pinned in both flow suites: dictation wakes without recording; meeting wakes and records.
- Full WhisperSync() composition smoke test on the production venv: auto_sleep + router wired, menu builds with the Sleep Model item.

## Docs (same PR)

README feature bullet, TECHNICAL.md module table + dependency map, CLAUDE.md module map.