### PR TITLE
docs: living feature catalog + backlog; enforce sync with tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,16 @@ Local speech-to-text for Windows. GPU-accelerated transcription with speaker dia
 ### Note for AI Agents
 When a user reports that a meeting "crashed" or "failed" or "didn't finish", do NOT suggest re-recording. The audio and transcript.json are almost always preserved. First check `docs/TECHNICAL.md#recovery-and-backfill` and direct the user to the tray Meetings submenu, or to manual REPL recovery via `whisper_sync.flatten` and `whisper_sync.speakers`.
 
+## Living feature catalog
+
+`docs/features/` (features.md, shortcuts.md, defaults.md) is the source
+of truth for what the app does, how to drive it, and every setting's
+default. Any PR that adds/changes a feature, hotkey, click behavior, or
+config key MUST update the matching file in the same PR.
+`tests/test_feature_docs.py` enforces the mechanical parts (key
+inventory, default hotkeys, spot-checked defaults). Deferred work goes
+to `docs/BACKLOG.md` in the PR that defers it.
+
 ## Module Map
 
 | Module | Purpose |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ For the full design, see [docs/specs/2026-03-24-governance-learning-loop-design.
 ## For Contributors
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) - branch naming, the PR pipeline (Copilot review + CI test gate + auto-merge), commit format
+- [docs/features/](docs/features/) - the living catalog: features, shortcuts and interactions, every setting with its default (kept in sync by tests)
+- [docs/BACKLOG.md](docs/BACKLOG.md) - deferred and known-open work with sources
 - [docs/development.md](docs/development.md) - setup, debugging, running the test suites
 - [docs/testing.md](docs/testing.md) - the single testing entry point: automated suites, manual checklist, where results are recorded
 - [docs/plans/2026-07-03-hardening-round.md](docs/plans/2026-07-03-hardening-round.md) - current project state (the stability rebuild that preceded it: [docs/plans/2026-05-11-stability-rebuild.md](docs/plans/2026-05-11-stability-rebuild.md))

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,52 @@
+# Backlog - deferred and known-open work
+
+Deliberate deferrals and known gaps, swept from the plan docs and code
+on 2026-07-04 (owner request). Each entry cites where the decision was
+recorded. Remove entries when shipped; add new deferrals here in the
+same PR that defers them.
+
+## Owner-gated (waiting on real-world use)
+
+- **Production validation of the 2026-06/07 rebuild + hardening** - the
+  five signals in [docs/testing.md](testing.md) need evidence from the
+  updated running app (restart onto current dev first).
+- **MODE_TRANSITIONS warn-to-reject** - the transition table currently
+  logs unexpected transitions but allows them; tighten to reject after
+  the post-restart soak stays clean for a few days
+  (plans/2026-07-03-hardening-round.md, item 7).
+- **nvlddmkm crash correlation** - `gpu-guard.jsonl` (downgrades,
+  suspend/resume, sleep/wake, mic stalls) plus heartbeat rss lines are
+  the timeline to compare against Windows crash times
+  (specs/2026-07-03-owner-directive-verbatim.md).
+
+## Hardware resilience (deferred by design, detection shipped first)
+
+- **Mid-recording mic stream reopen** - stall detection ships; the
+  automatic reopen needs the capture format-ladder rework
+  (hardening item 4, H2 deferral).
+- **Loopback-stream stall coverage** - only the mic channel is
+  monitored today; a dead loopback still records mic-only silently
+  after the initial warning (item 4, H2 deferral).
+- **CPU floor for the GPU Guard ladder** - the downgrade ladder bottoms
+  out at the smallest model; forcing CPU per request needs a worker
+  restart path (item 1 deviation).
+
+## Feature gaps
+
+- **middle_click has no plumbing** - the config key, CLICK_ACTIONS
+  entry, and `_on_middle_click` handler exist, but pystray's Win32
+  backend only surfaces left/right buttons; middle clicks never reach
+  the app. Implement via a message-hook extension or remove the
+  setting (discovered 2026-07-04 during the auto-sleep click work).
+- **Installer refresh** - install experience predates most current
+  features. Planned shape (owner, 2026-07-04): screens generated from
+  [docs/features/](features/) - a features screen, a
+  shortcuts/interaction screen, and a defaults/configuration screen -
+  so the installer stays current automatically.
+
+## Hygiene
+
+- **Timeout constants naming (A4 remainder)** - the magic shutdown
+  joins (2/3/5s) in the primitives still want named module constants
+  with rationale comments (architecture spec A4; the paste
+  scheduler-job part shipped in #161).

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -6,6 +6,8 @@ Everything below is for developers modifying this app or for an AI assistant (li
 
 ## Complete File Reference
 
+For the user-facing catalog (features, shortcuts, settings), see [features/](features/). Deferred work: [BACKLOG.md](BACKLOG.md).
+
 ### Python Files (whisper_sync/)
 
 | File | Purpose | Key Classes/Functions |

--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -1,6 +1,6 @@
 # Settings and defaults
 
-Every configurable key with its shipped default. The source of truth
+Every shipped defaults key (whisper_sync/config.defaults.json) with its default value. The source of truth
 is `whisper_sync/config.defaults.json`; user overrides live in
 `<output_dir>/.whispersync/config.json`. Update IN THE SAME PR as any
 key addition/removal/default change - `tests/test_feature_docs.py`
@@ -40,5 +40,5 @@ fails if this table and the defaults file disagree on keys.
 | `gpu_guard` | `true` | VRAM watchdog + model downgrade ladder |
 | `gpu_guard_low_vram_mb` | `750` | Free-VRAM watermark that arms a downgrade |
 | `gpu_guard_poll_seconds` | `30` | VRAM poll interval |
-| `gpu_guard_ladder` | `large-v3, medium, small, base` | Downgrade order (floor = last entry) |
+| `gpu_guard_ladder` | `["large-v3", "medium", "small", "base"]` | Downgrade order as a JSON list (floor = last entry); non-list values are rejected and fall back to this default |
 | `gpu_guard_probe` | `null` | Force a probe backend (null = auto: pynvml, nvidia-smi) |

--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -1,0 +1,44 @@
+# Settings and defaults
+
+Every configurable key with its shipped default. The source of truth
+is `whisper_sync/config.defaults.json`; user overrides live in
+`<output_dir>/.whispersync/config.json`. Update IN THE SAME PR as any
+key addition/removal/default change - `tests/test_feature_docs.py`
+fails if this table and the defaults file disagree on keys.
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `hotkeys` | dictation `ctrl+shift+space`, meeting `ctrl+shift+m`, feature `ctrl+shift+alt+f` | Global hotkeys (see shortcuts.md) |
+| `paste_method` | `clipboard` | How dictation text is delivered: clipboard+Ctrl+V or simulated keystrokes |
+| `language` | `en` | Transcription language |
+| `model` | `large-v3` | Meeting transcription model |
+| `dictation_model` | `large-v3` | Dictation model (may be auto-downgraded by GPU Guard) |
+| `compute_type` | `float16` | Whisper compute precision |
+| `output_dir` | `transcriptions` | Meeting output root (relative paths resolve from the repo root) |
+| `mic_device` | `null` | Explicit mic device id (null = default) |
+| `speaker_device` | `null` | Explicit loopback device id (null = default) |
+| `sample_rate` | `16000` | Capture sample rate (Hz) |
+| `batch_size` | `auto` | Whisper batch size |
+| `use_system_devices` | `true` | Follow Windows default devices instead of the explicit ids |
+| `left_click` | `meeting` | Tray single-left-click action (`meeting` / `dictation` / `none`) |
+| `middle_click` | `dictation` | Reserved: no middle-click plumbing yet (docs/BACKLOG.md) |
+| `auto_sleep_minutes` | `30` | Idle minutes before the model unloads from VRAM (0 = never) |
+| `github_repo` | `null` | `owner/repo` for PR status in the tray (null = off) |
+| `github_poll_interval` | `120` | PR poll interval (seconds) |
+| `github_notifications` | `true` | Toasts on PR review-state changes |
+| `log_window` | `normal` | Console verbosity: off / normal / detailed / verbose |
+| `device` | `auto` | Compute device: auto / cuda / cpu |
+| `incognito` | `false` | Whisper mode: RAM-only dictation, nothing on disk |
+| `always_available_dictation` | `true` | Allow dictation during meetings via the backup model |
+| `backup_device` | `cpu` | Device for the backup transcriber |
+| `backup_model` | `base` | Model for the backup transcriber |
+| `diarize_primary` | `balanced_mix` | First diarization method |
+| `diarize_fallback` | `per_channel` | Second diarization method |
+| `diarize_last_resort` | `raw_audio` | Final diarization fallback |
+| `dictation_max_minutes` | `30` | Auto-stop cap for a forgotten dictation hotkey (0 = off) |
+| `gpu_guard_single_instance` | `true` | Named-mutex single instance + orphan worker reaping |
+| `gpu_guard` | `true` | VRAM watchdog + model downgrade ladder |
+| `gpu_guard_low_vram_mb` | `750` | Free-VRAM watermark that arms a downgrade |
+| `gpu_guard_poll_seconds` | `30` | VRAM poll interval |
+| `gpu_guard_ladder` | `large-v3, medium, small, base` | Downgrade order (floor = last entry) |
+| `gpu_guard_probe` | `null` | Force a probe backend (null = auto: pynvml, nvidia-smi) |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -1,0 +1,81 @@
+# Features
+
+The living feature catalog. Update this file IN THE SAME PR as any
+feature change (add/remove/behavior change) - the installer and README
+treat this folder as the source of truth for what the app does.
+`tests/test_feature_docs.py` enforces the mechanical parts (defaults
+and hotkeys); the prose here is on the PR author.
+
+Companion files: [shortcuts.md](shortcuts.md) (how to interact),
+[defaults.md](defaults.md) (every setting and its default).
+
+## Core
+
+- **Dictation** - hotkey-toggled speech-to-text pasted into the focused
+  window (clipboard or simulated keystrokes). Streams to disk for crash
+  recovery; auto-stops at a configurable cap so a forgotten hotkey
+  cannot grow unbounded.
+- **Meeting recording** - mic + speaker loopback captured to a stereo
+  WAV, then a sequential post-processing pipeline: transcription with
+  diarization, speaker identification (Claude CLI with manual
+  fallback), readable transcript, minutes generation, rename
+  suggestion. Recording never waits on the pipeline.
+- **Per-channel stereo diarization** - 3-tier cascade
+  (balanced mix, per channel, raw audio) selectable per meeting from
+  the save dialog.
+- **Always-available dictation** - dictate during an active meeting via
+  a second mic stream and the backup model (CPU or secondary GPU).
+- **Feature suggestions** - a dedicated hotkey records a voice note to
+  the feature log and formats it via Claude CLI.
+
+## Model and VRAM lifecycle
+
+- **Model auto-sleep** - the worker (and all of its VRAM) unloads after
+  `auto_sleep_minutes` of inactivity (default 30, 0 disables), or on
+  demand by double-clicking the tray icon (for gaming). Any dictation
+  or meeting action wakes it with the yellow loading flash; meetings
+  start recording immediately while the model loads. Sleeping shows
+  the deep-gray sleep icon.
+- **GPU Guard** - VRAM watermark polling with a sticky model downgrade
+  ladder (large-v3 -> medium -> small -> base) on low-VRAM readings or
+  worker crashes. Vendor-agnostic probes. All events (downgrades,
+  suspend/resume, sleep/wake, mic stalls) land in `gpu-guard.jsonl`
+  for crash-time correlation.
+- **CPU/GPU device selection** - auto-detect, force GPU, or force CPU
+  from the tray menu; backup model has independent device/model
+  settings.
+
+## Resilience
+
+- **Crash-safe audio** - all recordings stream to disk; orphaned WAVs
+  are detected at startup and offered for recovery (dictations to
+  clipboard, meetings through the naming dialog and pipeline).
+- **Worker crash recovery** - the transcription subprocess is respawned
+  on crash; wedged workers are detected via liveness pings and killed
+  after 90s of silence.
+- **Single-instance guard** - a named mutex prevents duplicate tray
+  instances; orphaned worker processes from a previous crash are
+  reaped at startup.
+- **Suspend/resume awareness** - sleep/resume events are logged and the
+  worker is health-checked (and restarted if needed) after resume.
+- **Mic stall detection** - a toast fires when the mic stops delivering
+  audio mid-recording (device unplugged, Bluetooth drop).
+- **Self-update** - tray menu pulls the latest main/dev and restarts.
+
+## Quality of life
+
+- **Three-ring tray icon** - inner dot = overlay dictation, middle =
+  mic/mode, outer ring = speaker loopback health; deep-gray middle =
+  model asleep (canonical table: `.claude/rules/ui-patterns.md`).
+- **Incognito (Whisper) mode** - RAM-only dictation; nothing logged or
+  written to disk.
+- **Persistent dictation history** - last 10 dictations in the tray
+  menu, survives restarts.
+- **Weekly + session stats** - counts, character totals, uptime.
+- **Windows toast notifications** - configurable per event type, with
+  action buttons (recover, merge PR, rename meeting).
+- **GitHub PR status** - open-PR poller with tray menu section, change
+  toasts, and one-click gh merge.
+- **Meeting split tool** - `python -m whisper_sync.split_meeting`
+  divides a recorded meeting into portions with re-flattened
+  transcripts (safe against name collisions).

--- a/docs/features/shortcuts.md
+++ b/docs/features/shortcuts.md
@@ -1,0 +1,51 @@
+# Shortcuts and interactions
+
+Every way to drive the app. Update IN THE SAME PR as any hotkey or
+click-behavior change; `tests/test_feature_docs.py` verifies the
+default hotkeys below match `config.defaults.json`.
+
+## Hotkeys (defaults, configurable in Settings > Hotkeys)
+
+| Hotkey | Action |
+|--------|--------|
+| `ctrl+shift+space` | Toggle dictation (start / stop-and-paste) |
+| `ctrl+shift+m` | Toggle meeting recording (start / stop-and-save) |
+| `ctrl+shift+alt+f` | Toggle feature-suggestion recording |
+
+During a meeting, the dictation and feature hotkeys record through the
+backup model (overlay dictation) without touching the meeting audio.
+While the model is asleep, any of these wakes it: meetings start
+recording immediately; dictation flashes yellow and is ready to retry
+once loaded.
+
+## Tray icon clicks
+
+| Gesture | Action |
+|---------|--------|
+| Left click (single) | Configured action (default: toggle meeting; `left_click` setting). While dictating: discard the recording. |
+| Left double-click | Sleep / wake the model (unload from or reload into VRAM) |
+| Right click | Open the menu |
+
+The single-click action fires after a short double-click window
+(~450ms), so one gesture never triggers both. Note: `middle_click`
+exists in config but currently has no plumbing (see docs/BACKLOG.md).
+
+## Tray menu highlights
+
+- **Meetings** - recent meetings with per-meeting speaker re-identify.
+- **Recent Dictations** - last 10; click to copy, plus Open Logs /
+  Clear History.
+- **Sleep Model / Wake Model** - same as double-click.
+- **Settings** - devices, models, hotkeys, paste method, click actions,
+  compute device, diarization, auto-sleep, notifications, whisper
+  mode, log window, output folder.
+- **Update** - self-update from main (stable) or dev (labs), then
+  restart.
+
+## Icon states (summary)
+
+Gray ring + gray middle = idle. Deep-gray middle = model asleep. Red =
+recording meeting. Green = dictating. Blue/animated = transcribing.
+Yellow double-flash = model loading or request queued. Broken outer
+ring = speaker loopback unavailable. Full table:
+`.claude/rules/ui-patterns.md`.

--- a/tests/test_feature_docs.py
+++ b/tests/test_feature_docs.py
@@ -1,0 +1,72 @@
+"""docs/features/ must stay in sync with the shipped configuration.
+
+The features folder is the source the installer and README draw from,
+so drift is a real user-facing bug: a setting without documentation,
+or documentation for a setting that no longer exists. These tests make
+the mechanical parts of the same-PR docs rule enforceable - key
+inventory and default hotkeys - so only the prose is on the author.
+"""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).parent.parent
+_DEFAULTS = json.loads(
+    (_REPO / "whisper_sync" / "config.defaults.json").read_text(encoding="utf-8"))
+_FEATURES_DIR = _REPO / "docs" / "features"
+
+
+class DefaultsDocTests(unittest.TestCase):
+    def setUp(self):
+        self.doc = (_FEATURES_DIR / "defaults.md").read_text(encoding="utf-8")
+        # Keys documented as `key` at the start of a table row.
+        self.doc_keys = set(re.findall(r"^\| `([a-z_0-9]+)`", self.doc,
+                                       flags=re.MULTILINE))
+
+    def test_every_config_key_is_documented(self):
+        missing = set(_DEFAULTS) - self.doc_keys
+        self.assertFalse(
+            missing,
+            f"config.defaults.json keys missing from docs/features/defaults.md: "
+            f"{sorted(missing)} - document them in the same PR",
+        )
+
+    def test_no_stale_keys_are_documented(self):
+        stale = self.doc_keys - set(_DEFAULTS)
+        self.assertFalse(
+            stale,
+            f"docs/features/defaults.md documents keys that no longer exist: "
+            f"{sorted(stale)} - remove them in the same PR",
+        )
+
+    def test_documented_defaults_match_for_scalar_keys(self):
+        # Spot-check the values users most depend on.
+        for key in ("auto_sleep_minutes", "model", "paste_method",
+                    "dictation_max_minutes", "gpu_guard_low_vram_mb"):
+            row = re.search(rf"^\| `{key}` \| `([^`]+)`", self.doc,
+                            flags=re.MULTILINE)
+            self.assertIsNotNone(row, f"no default cell for {key}")
+            self.assertEqual(row.group(1), str(_DEFAULTS[key]),
+                             f"documented default for {key} is stale")
+
+
+class ShortcutsDocTests(unittest.TestCase):
+    def test_default_hotkeys_are_documented_verbatim(self):
+        doc = (_FEATURES_DIR / "shortcuts.md").read_text(encoding="utf-8")
+        for name, combo in _DEFAULTS["hotkeys"].items():
+            self.assertIn(combo, doc,
+                          f"default hotkey {name}={combo} missing from "
+                          "docs/features/shortcuts.md")
+
+
+class FeaturesDocTests(unittest.TestCase):
+    def test_features_doc_exists_and_links_companions(self):
+        doc = (_FEATURES_DIR / "features.md").read_text(encoding="utf-8")
+        self.assertIn("shortcuts.md", doc)
+        self.assertIn("defaults.md", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_split_meeting.py
+++ b/tests/test_split_meeting.py
@@ -55,6 +55,13 @@ class _SplitHarness(unittest.TestCase):
         scratch.mkdir()
         wav = scratch / "recording.wav"
         _write_wav(wav, self.DURATION)
+        # Pin the mtime to second 30 of the current minute: portion
+        # prefixes derive from mtime minus offsets inside DURATION, and a
+        # real mtime within a couple seconds of a minute boundary gave
+        # portions DIFFERENT MMDD_HHMM prefixes - the duplicate-name test
+        # then saw distinct destinations and flaked (CI 2026-07-04).
+        pinned = datetime.now().replace(second=30, microsecond=0).timestamp()
+        os.utime(str(wav), (pinned, pinned))
         # Recreate split_meeting's own math: portion 1 start time derives
         # from the wav mtime minus total duration.
         mtime = datetime.fromtimestamp(os.path.getmtime(str(wav)))


### PR DESCRIPTION
## Summary

Owner request (2026-07-04): a real-time-maintained record of features, shortcuts, and defaults, structured so the installer refresh can generate its screens from it - plus a sweep of everything deferred or not yet added.

- **docs/features/** - features.md (grouped catalog), shortcuts.md (hotkeys, tray clicks incl. double-click sleep, icon states), defaults.md (every config key + shipped default).
- **tests/test_feature_docs.py** - the same-PR docs rule becomes enforceable where it can be mechanical: every config.defaults.json key must be documented, stale keys fail, key defaults are spot-checked, default hotkeys must appear verbatim. Since the system suite gates auto-merge, catalog drift now fails CI instead of rotting.
- **docs/BACKLOG.md** - the deferred-items sweep: owner-gated validation + MODE_TRANSITIONS tightening, mid-recording mic reopen + loopback stall coverage (H2), GPU-guard CPU floor, the dead middle_click plumbing (pystray's Win32 backend never surfaces middle clicks - config key exists but does nothing), the installer refresh plan (screens generated from docs/features/), and the A4 timeout-naming remainder.
- README, CLAUDE.md (same-PR rule section), TECHNICAL.md link the catalog.

## Testing

System suite 287 passed (5 new sync tests).