### PR TITLE
feat: dictation always records - capture never waits on the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Runs as a system tray icon on Windows.
 - **CPU/GPU device selection** -- Auto-detect, force GPU, or force CPU via tray menu
 - **Three-ring tray icon** -- inner dot = backup/overlay dictation, inner circle = mic status, outer ring = speaker/loopback status (canonical table: .claude/rules/ui-patterns.md)
 - **Incognito mode** -- RAM-only dictation; no transcription text logged or saved to disk
-- **Model auto-sleep** -- unloads the model from VRAM after 30 idle minutes (configurable) or on tray double-click (for gaming); any dictation/meeting action wakes it and records immediately (disk-first), transcribing once the model reloads
+- **Model auto-sleep** -- unloads the model from VRAM after 30 idle minutes (configurable) or on tray double-click (for gaming); any dictation/meeting action wakes it and records immediately (disk-first), transcribing once the model reloads; whisper mode is the exception (see docs/features/shortcuts.md)
 - **Persistent dictation history** -- last 10 dictations in tray menu, survives restarts
 - **Session stats** -- dictation/meeting counts, averages, and uptime for the current session
 - **Windows toast notifications** -- native Windows notifications for transcription events

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Runs as a system tray icon on Windows.
 - **CPU/GPU device selection** -- Auto-detect, force GPU, or force CPU via tray menu
 - **Three-ring tray icon** -- inner dot = backup/overlay dictation, inner circle = mic status, outer ring = speaker/loopback status (canonical table: .claude/rules/ui-patterns.md)
 - **Incognito mode** -- RAM-only dictation; no transcription text logged or saved to disk
-- **Model auto-sleep** -- unloads the model from VRAM after 30 idle minutes (configurable) or on tray double-click (for gaming); any dictation/meeting action wakes it with the yellow loading flash
+- **Model auto-sleep** -- unloads the model from VRAM after 30 idle minutes (configurable) or on tray double-click (for gaming); any dictation/meeting action wakes it and records immediately (disk-first), transcribing once the model reloads
 - **Persistent dictation history** -- last 10 dictations in tray menu, survives restarts
 - **Session stats** -- dictation/meeting counts, averages, and uptime for the current session
 - **Windows toast notifications** -- native Windows notifications for transcription events

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -33,9 +33,10 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
 - **Model auto-sleep** - the worker (and all of its VRAM) unloads after
   `auto_sleep_minutes` of inactivity (default 30, 0 disables), or on
   demand by double-clicking the tray icon (for gaming). Any dictation
-  or meeting action wakes it with the yellow loading flash; meetings
-  start recording immediately while the model loads. Sleeping shows
-  the deep-gray sleep icon.
+  or meeting action wakes it with the yellow loading flash and starts
+  recording immediately - capture never waits on the model (whisper
+  mode excepted: RAM-only dictation still requires a loaded model).
+  Sleeping shows the deep-gray sleep icon.
 - **GPU Guard** - VRAM watermark polling with a sticky model downgrade
   ladder (large-v3 -> medium -> small -> base) on low-VRAM readings or
   worker crashes. Vendor-agnostic probes. All events (downgrades,

--- a/docs/features/shortcuts.md
+++ b/docs/features/shortcuts.md
@@ -14,9 +14,12 @@ default hotkeys below match `config.defaults.json`.
 
 During a meeting, the dictation and feature hotkeys record through the
 backup model (overlay dictation) without touching the meeting audio.
-While the model is asleep, any of these wakes it: meetings start
-recording immediately; dictation flashes yellow and is ready to retry
-once loaded.
+While the model is asleep (or still loading at startup), any of these
+wakes it AND starts recording immediately - recordings are disk-first,
+so capture never waits on the model. A dictation stopped before the
+model is ready just shows the yellow transcribing state a little
+longer. Exception: whisper mode (RAM-only) still requires a loaded
+model.
 
 ## Tray icon clicks
 

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -1,0 +1,95 @@
+# Voice assistant direction - 2026-07-04 intake
+
+Status: DIRECTION RECORDED; nothing beyond step 1 is committed.
+Source: owner voice notes, 2026-07-04. This captures the intent and a
+proposed staged architecture so future sessions design against it
+instead of rediscovering it. The owner explicitly wants the always-on
+ideas DEFINED before any build.
+
+## The owner's intent (paraphrased)
+
+WhisperSync is slowly evolving into a simple, mostly-offline voice
+assistant:
+
+1. Capture must never be blocked - "no matter what, when I dictate, it
+   always works" (shipped as step 1, see below).
+2. A wake word ("hey Hal" - name TBD) on an always-on, power-efficient
+   listening loop: speak to start a dictation, an outro phrase ("that's
+   it" / "send request") to stop. Windows mic sharing already allows a
+   non-exclusive always-on stream.
+3. Meetings detected (or at least startable by voice) so recording
+   never depends on remembering a hotkey.
+4. After a meeting: auto-suggested artifacts (markdown minutes, action
+   items) with harness-style actionable suggestions - "want me to send
+   that Slack message? Here's a draft."
+5. Long-term: the same feature set ported to another always-on device;
+   voice commands that open applications; recognition and dictation
+   stay offline/local, only the ACTIONS use an LLM + OAuth.
+
+## Staged architecture proposal
+
+### Step 1 - capture never waits (SHIPPED, this PR)
+Dictation and meetings record disk-first regardless of model state;
+transcription waits for the model. This is the foundation: every later
+stage assumes capture is always safe and cheap.
+
+### Step 2 - wake word, done the power-efficient way
+Do NOT loop Whisper over 5-second windows - that keeps the GPU hot and
+defeats auto-sleep. The standard tiered pattern, all local and CPU:
+
+- Tier 0: WASAPI shared always-on stream into a small ring buffer
+  (seconds), plus cheap RMS/VAD gating (webrtcvad or silero-vad ONNX,
+  ~1% CPU) so tiers above run only on speech.
+- Tier 1: a dedicated keyword-spotting model on the VAD-gated audio -
+  openWakeWord or a Porcupine-style KWS (millisecond CPU inference,
+  custom "hey Hal" trainable). These run 24/7 on laptops by design.
+- Tier 2: on wake-word hit, splice the ring buffer into a normal
+  disk-first dictation (no lost syllables), wake the big model
+  (auto_sleep.wake already does this), and end on the outro phrase -
+  detectable by the same KWS or by a VAD long-silence rule.
+- The whole listener is a feature-pattern module (one owner, flat
+  config keys, inert when disabled) and NEVER blocks the mic
+  exclusively.
+
+### Step 3 - meeting awareness
+Cheapest reliable signal is not audio: a meeting almost always means a
+communications app has an active audio session. WASAPI session
+enumeration (which app holds an active render/capture stream - Zoom,
+Teams, Meet tab) is a poll-cheap, offline heuristic; toast "Meeting
+detected - record?" with a one-click start (or auto-start policy per
+app). Voice ("hey Hal, record the meeting") comes free with step 2
+command routing.
+
+### Step 4 - actions layer (the only online part)
+Keep the boundary hard: capture/transcribe/diarize stay offline; the
+actions layer consumes FINISHED artifacts (minutes.md, action items)
+and drafts outbound actions for one-click approval. Token-efficient
+because it runs once per meeting on a compact artifact, not on a
+live audio stream. Two viable shapes:
+
+- **Claude CLI headless** (`claude -p`), which the pipeline already
+  uses for minutes/speaker ID: extend the minutes prompt to also emit
+  a structured action-items block with suggested drafts. MCP servers
+  (Slack etc.) give the CLI real, OAuth'd tools; the human stays the
+  approve/send button - which also respects harness rules: WhisperSync
+  never sends anything itself, it presents drafts.
+- **The Aloop/PM harness**: WhisperSync just drops artifacts in a
+  watched location; the existing harness picks them up and owns
+  suggestions/OAuth. Cleaner separation; WhisperSync stays a light
+  local app (the owner's standing constraint) and the "voice assistant
+  brain" lives in the successor API-first application.
+
+Recommendation: step 4 via artifact handoff (second shape), steps 2-3
+in this app behind config flags. That keeps WhisperSync loadable/
+unloadable and makes the future device port a matter of reimplementing
+tiers 0-2, which are deliberately tiny.
+
+## Open questions to define before step 2
+
+- Wake word name and outro phrase(s); false-positive tolerance.
+- Should wake-word capture be visible (icon state) and separately
+  toggleable from the tray? (Almost certainly yes: a "listening" ring.)
+- Privacy defaults: always-on listener OFF by default; whisper-mode
+  interaction; what, if anything, is ever written to disk before the
+  wake word fires (proposal: nothing - the ring buffer is RAM-only).
+- Command grammar beyond start/stop ("open X" needs an allowlist).

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -50,8 +50,16 @@ class _FakeWorker:
     def __init__(self):
         self.ready = True
         self.calls = []
+        self.wait_calls = 0
+        self.loads_on_wait = True  # model finishes loading when waited on
 
     def is_ready(self):
+        return self.ready
+
+    def wait_ready(self, timeout=None):
+        self.wait_calls += 1
+        if self.loads_on_wait:
+            self.ready = True
         return self.ready
 
     def transcribe_fast(self, audio, model_override=None, timeout=None):
@@ -202,11 +210,14 @@ class NormalDictationTests(_FlowHarness):
         self.flow.toggle()
         self.assertIsNone(self.flow._cap_handle)
 
-    def test_worker_not_ready_flashes_and_stays_idle(self):
+    def test_worker_not_ready_still_records_disk_first(self):
+        # App startup / model loading: dictation always works now; only
+        # the transcription waits (yellow state lasts longer).
         self.app.worker.ready = False
         self.flow.toggle()
-        self.assertEqual(self.app.flashes, 1)
-        self.assertIsNone(self.app.state.current.mode)
+        self.assertEqual(self.app.flashes, 0)
+        self.assertEqual(self.app.state.current.mode, "dictation")
+        self.assertTrue(self.app.recorder.is_recording)
 
     def test_mic_failure_returns_to_idle_and_clears_feature(self):
         self.app.recorder.fail_start = True
@@ -229,14 +240,51 @@ class NormalDictationTests(_FlowHarness):
         self.flow._start(feature=False)
         self.assertFalse(self.app.recorder.is_recording)
 
-    def test_toggle_wakes_sleeping_model_instead_of_recording(self):
+    def test_toggle_wakes_sleeping_model_and_records_immediately(self):
+        # Dictation is disk-first, so sleep must not block recording:
+        # wake the model AND start capturing in the same gesture.
         from whisper_sync.state_manager import SLEEP_STARTED
         self.app.auto_sleep = mock.Mock()
+        self.app.worker.ready = False  # sleeping worker is not ready
         self.app.state.emit(SLEEP_STARTED, sleeping=True)
         self.flow.toggle()
         self.app.auto_sleep.wake.assert_called_once()
-        self.assertFalse(self.app.recorder.is_recording,
-                         "dictation must not start while the model loads")
+        self.assertTrue(self.app.recorder.is_recording,
+                        "recording must start while the model loads")
+
+    def test_sleeping_toggle_in_whisper_mode_wakes_but_does_not_record(self):
+        # RAM-only capture has no crash net; the old refuse stands.
+        from whisper_sync.state_manager import SLEEP_STARTED
+        self.app.cfg["incognito"] = True
+        self.app.auto_sleep = mock.Mock()
+        self.app.worker.ready = False
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        self.flow.toggle()
+        self.app.auto_sleep.wake.assert_called_once()
+        self.assertFalse(self.app.recorder.is_recording)
+        self.assertEqual(self.app.flashes, 1)
+
+    def test_stop_waits_for_model_then_pastes(self):
+        # Start while loading, stop before ready: the process step must
+        # block on wait_ready and then transcribe normally.
+        self.app.worker.ready = False
+        self.flow.toggle()
+        self.assertTrue(self.app.recorder.is_recording)
+        self.flow.toggle()
+        self.assertEqual(self.app.worker.wait_calls, 1)
+        self.paste.assert_called_once()
+        self.assertEqual(self.app.state.current.mode, "done")
+
+    def test_stop_preserves_audio_when_model_never_loads(self):
+        self.app.worker.ready = False
+        self.app.worker.loads_on_wait = False
+        self.flow.toggle()
+        wav = self.flow._wav_path
+        self.flow.toggle()
+        self.paste.assert_not_called()
+        self.assertEqual(self.app.state.current.mode, "error")
+        self.assertEqual(self.flow._wav_path, wav,
+                         "crash-safety WAV must not be deleted on failure")
 
     def test_discard_throws_audio_away(self):
         self.flow.toggle()

--- a/whisper_sync/auto_sleep.py
+++ b/whisper_sync/auto_sleep.py
@@ -12,9 +12,10 @@ AutoSleep frees that memory two ways:
 
 While asleep the tray shows the "sleep" icon (deeper gray middle,
 normal gray outer ring). Any dictation or meeting toggle wakes the
-model with the usual yellow loading double-flash; meetings start
-recording immediately (the pipeline waits for the worker at the
-transcription step), dictation asks the user to retry once loaded.
+model with the usual yellow loading double-flash AND starts recording
+immediately - both flows are disk-first, so capture never waits on the
+model. Meetings transcribe at their own pipeline step; dictation waits
+for readiness at stop time (the yellow state simply lasts longer).
 
 Follows the GPU Guard feature pattern: one owning module, flat config
 key, fully inert when disabled. Sleep and wake events land in

--- a/whisper_sync/auto_sleep.py
+++ b/whisper_sync/auto_sleep.py
@@ -14,7 +14,8 @@ While asleep the tray shows the "sleep" icon (deeper gray middle,
 normal gray outer ring). Any dictation or meeting toggle wakes the
 model with the usual yellow loading double-flash AND starts recording
 immediately - both flows are disk-first, so capture never waits on the
-model. Meetings transcribe at their own pipeline step; dictation waits
+model (exception: whisper/incognito dictation is RAM-only and still
+requires a loaded model). Meetings transcribe at their own pipeline step; dictation waits
 for readiness at stop time (the yellow state simply lasts longer).
 
 Follows the GPU Guard feature pattern: one owning module, flat config

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -352,9 +352,11 @@ class DictationFlow:
                     logger.info("Waiting for the model to load before "
                                 "transcribing dictation...")
                     if not app.worker.wait_ready(timeout=180):
+                        where = (f"audio preserved at: {self._wav_path}"
+                                 if self._wav_path else
+                                 "disk streaming was unavailable, audio lost")
                         raise RuntimeError(
-                            "Model did not load in time; dictation audio "
-                            f"preserved at: {self._wav_path}")
+                            f"Model did not load in time; dictation {where}")
                 text = None
                 used_backup = False
                 if use_backup:

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -96,10 +96,10 @@ class DictationFlow:
                 return
 
             if current and current.sleeping:
-                # Model is unloaded (auto_sleep): wake it (yellow loading
-                # flash) and let the user retry once it is ready.
+                # Model is unloaded (auto_sleep): wake it and KEEP GOING.
+                # Dictation streams to disk, so recording starts now and
+                # transcription waits for the model at stop time.
                 self.app.auto_sleep.wake(reason="dictation_hotkey")
-                return
 
             if mode == "dictation":
                 self._stop()
@@ -141,7 +141,6 @@ class DictationFlow:
                 return
             if current and current.sleeping:
                 self.app.auto_sleep.wake(reason="feature_hotkey")
-                return
 
             if mode == "meeting" or (mode is None and meeting_tx):
                 self._toggle_during_meeting(feature=True)
@@ -212,10 +211,18 @@ class DictationFlow:
 
         app = self.app
         _meeting_tx = app.state.current.meeting_transcribing if app.state else False
-        if not app.worker.is_ready() and not (_meeting_tx and BackupTranscriber.is_enabled(app.cfg)):
-            logger.warning("Worker not ready yet - ignoring dictation request")
-            app._yellow_flash()
-            return
+        if not app.worker.is_ready():
+            has_backup = _meeting_tx and BackupTranscriber.is_enabled(app.cfg)
+            if app.cfg.get("incognito", False) and not has_backup:
+                # RAM-only capture has no crash net and nothing to
+                # transcribe it promptly - keep the old refuse behavior.
+                logger.warning("Worker not ready and whisper mode is on - "
+                               "ignoring dictation request")
+                app._yellow_flash()
+                return
+            # Disk-first recording works fine without the model: record
+            # now, transcribe when it finishes loading (stop path waits).
+            logger.info("Dictation recording while the model loads (disk-first)")
         # Atomic claim: only start if mode is still startable. A worker
         # completion (or a double-fired hotkey on another thread) changing
         # mode between the toggle's check and this start is rejected here
@@ -338,6 +345,16 @@ class DictationFlow:
 
             t0 = _time.perf_counter()
             try:
+                if not use_backup and not app.worker.is_ready():
+                    # Started while the model was loading (wake from sleep
+                    # or app startup). The yellow transcribing state simply
+                    # lasts longer; the audio is already safe on disk.
+                    logger.info("Waiting for the model to load before "
+                                "transcribing dictation...")
+                    if not app.worker.wait_ready(timeout=180):
+                        raise RuntimeError(
+                            "Model did not load in time; dictation audio "
+                            f"preserved at: {self._wav_path}")
                 text = None
                 used_backup = False
                 if use_backup:


### PR DESCRIPTION
## Summary

Owner request (2026-07-04): dictation streams to disk first, so sleeping/loading models must not block it. "No matter what, when I dictate, it always works."

- A dictation or feature-suggest toggle while the model is asleep now **wakes the model AND starts recording** in the same gesture - matching what meetings already do.
- The startup worker-not-ready gate is removed for disk-first capture: recording starts immediately; the stop path blocks on wait_ready(180) before transcribing, so a dictation stopped mid-load just shows the yellow transcribing state longer.
- If the model never becomes ready, the crash-safety WAV is preserved (it is only deleted on success) and the normal error path fires with the path in the log.
- **Whisper mode is the deliberate exception**: RAM-only capture has no crash net, so the old refuse-and-flash behavior stands - the owner scoped this change to non-whisper mode.

Also lands docs/specs/2026-07-04-voice-assistant-direction.md recording the owner's larger direction (wake word via tiered VAD+keyword-spotting, meeting detection via WASAPI session enumeration, an offline/online boundary where only the actions layer touches an LLM). This PR is step 1 of that staging: capture never waits.

## Testing

- 25 dictation-flow tests (5 new/updated): sleeping toggle records immediately, whisper-mode exception wakes without recording, stop waits for readiness then pastes, model-never-loads preserves the WAV and errors cleanly, startup not-ready records disk-first without flashing.
- Full suite: 290 passed.

## Docs (same PR)

auto_sleep docstring, docs/features/features.md + shortcuts.md, README bullet - all previously described the old ask-to-retry behavior.