### PR TITLE
docs: assistant direction v2 - owner decisions, GPU fallover spec, hardware research

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,9 +27,10 @@ same PR that defers them.
 - **Loopback-stream stall coverage** - only the mic channel is
   monitored today; a dead loopback still records mic-only silently
   after the initial warning (item 4, H2 deferral).
-- **CPU floor for the GPU Guard ladder** - the downgrade ladder bottoms
-  out at the smallest model; forcing CPU per request needs a worker
-  restart path (item 1 deviation).
+- **CPU floor for the GPU Guard ladder** - superseded 2026-07-04: now
+  the GPU power-state fallover requirement in
+  specs/2026-07-04-voice-assistant-direction.md (device loss must not
+  crash or hang; respawn on cpu with cpu_fallback_model).
 
 ## Feature gaps
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -28,7 +28,7 @@ same PR that defers them.
   monitored today; a dead loopback still records mic-only silently
   after the initial warning (item 4, H2 deferral).
 - **CPU floor for the GPU Guard ladder** - superseded 2026-07-04: now
-  the GPU power-state fallover requirement in
+  the GPU power-state failover requirement in
   specs/2026-07-04-voice-assistant-direction.md (device loss must not
   crash or hang; respawn on cpu with cpu_fallback_model).
 

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -84,12 +84,116 @@ in this app behind config flags. That keeps WhisperSync loadable/
 unloadable and makes the future device port a matter of reimplementing
 tiers 0-2, which are deliberately tiny.
 
+## Owner decisions - 2026-07-04 (second intake)
+
+- **Always-on listener: GO.** Build steps 2-3 behind config flags.
+- **Meeting auto-record: per-app now, discovery later.** A configurable
+  app list (Zoom, Slack huddles, Teams, Meet, ...): when that app opens
+  an active audio session, recording auto-starts. Manual trigger stays.
+- **In-app wake-word training wanted**: a Train button walks through
+  recording the open phrase and the exit phrase; support saving 2-3
+  phrases. (Feasibility notes below.)
+- **Power efficiency is a primary constraint** (laptop, library use).
+
+## GPU power-state resilience (owner: "actually really important")
+
+The laptop (Core Ultra 9 285H + Arc 140T iGPU + RTX 5070 Ti, hybrid
+graphics) can power the discrete GPU on and off. Requirements:
+
+- Detect whether the dGPU is present/active; if yes, use the current
+  CUDA model selection unchanged.
+- If the dGPU turns off or disconnects MID-SESSION: the app must not
+  crash the machine and workers must not hang. Detection signals:
+  VramProbe starts failing (pynvml/nvidia-smi errors), CUDA errors out
+  of the worker, or WM_DEVICECHANGE removal events.
+- On loss: kill the worker (wedge detection already bounds a hang),
+  respawn on device=cpu with a CPU-appropriate model (new config key,
+  e.g. cpu_fallback_model, default small/base - CPU inference was
+  validated as acceptable earlier), toast the fallover, log it to
+  gpu-guard.jsonl.
+- CRITICAL: the respawn-after-crash path must NOT retry CUDA in a loop
+  when the GPU is gone (today it would). The fallover decision belongs
+  to GPU Guard - it already owns VRAM health and the downgrade ladder;
+  device fallover is the ladder's missing floor (the "CPU floor"
+  deferral in BACKLOG.md becomes this requirement).
+- When the dGPU returns: notify + offer switch-back (or auto, config).
+
+## Hardware portability (owner question, verified 2026-07-04)
+
+| Target | Verdict |
+|--------|---------|
+| Raspberry Pi 3/4/5, Orange Pi | Comfortable for tiers 0-2: silero-vad + openWakeWord run in real time on a Pi 3. This is the reference platform for Home Assistant voice work. |
+| ESP32-S3 | NOT too much to ask - it is the shipped standard for Home Assistant voice satellites, via microWakeWord (TFLite-Micro models designed for the S3). openWakeWord itself is too heavy for it; the S3 runs wake word + VAD locally and streams audio to a host for transcription. |
+| Plain ESP32 (non-S3) | Marginal; the S3 vector instructions matter. Prefer S3. |
+
+Portability consequence: keep tier 0-2 model formats to ONNX/TFLite
+and the interface tiny (audio in, wake events out); the same design
+ports from the laptop to a Pi (same code) or an S3 satellite
+(microWakeWord reimplementation, protocol unchanged).
+
+## Wake-word model landscape (owner question)
+
+- **openWakeWord** (Apache-2.0, dscripka; models on GitHub/HF Hub) -
+  the laptop/Pi choice. ONNX/TFLite, pretrained models, custom phrases
+  trained SYNTHETICALLY (Piper TTS generates the samples; no human
+  recordings needed), plus a per-user custom verifier layer trained on
+  a few real recordings in seconds.
+- **microWakeWord** (kahrendt/OHF-Voice) - same synthetic-training
+  approach, models small enough for ESP32-S3/TFLite-Micro. The
+  openWakeWord docs point efficiency-critical users here.
+- **Porcupine (Picovoice)** - commercial, free tier; type a phrase in
+  their console and get a model instantly; broadest MCU support.
+  Tradeoff: licensing + accounts, not fully local training.
+- **sherpa-onnx KWS (k2-fsa)** - open-source spotter where keywords are
+  defined AS TEXT at runtime (phoneme matching), no training run at
+  all. Weaker than a trained model but instant phrase changes.
+- LiveKit published a one-command wake-word training pipeline built on
+  the same synthetic approach - useful reference for the in-app
+  trainer.
+
+**In-app training design implication**: "click Train" cannot literally
+retrain openWakeWord on-device in seconds (synthetic pipeline + GPU,
+tens of minutes). The honest UX: (a) phrase presets from pretrained
+models; (b) per-user CUSTOM VERIFIER training in-app (record 3-5
+samples of open/exit phrases - seconds, fully local; a real
+openWakeWord feature); (c) fully custom phrases as a background
+training job (Piper + openWakeWord trainer on the dGPU while idle) or
+via sherpa-onnx text keywords for instant-but-weaker phrases. Support
+2-3 saved phrases as parallel models - cheap, same loop.
+
+## NPU (owner question)
+
+This laptop has an Intel AI Boost NPU (Core Ultra 9 285H, verified via
+device enumeration). Assessment:
+
+- VAD + wake word are ~1% CPU; moving them to the NPU is possible
+  (ONNX Runtime OpenVINO EP) but saves little - not the priority.
+- The REAL NPU win: the CPU-fallback/backup Whisper model. Running
+  whisper base/small through OpenVINO on the NPU instead of CPU cuts
+  the power draw of the library scenario and of always-available
+  dictation. This slots into the GPU-fallover work: fallback targets
+  become cpu OR npu-via-openvino.
+- Caveat: the worker stack is ctranslate2/whisperX (CUDA/CPU only). An
+  OpenVINO whisper path is a NEW backend for the backup transcriber,
+  not a config flip. Treat as a follow-up experiment after fallover
+  ships; measure quality/latency vs the CPU path first.
+
+## Build order (next sessions)
+
+1. GPU power-state fallover (guard-owned; includes cpu_fallback_model)
+   - the safety item, and auto-sleep's natural sibling.
+2. Tier 0+1 listener: always-on shared stream + ring buffer +
+   silero-vad + openWakeWord with a pretrained phrase, OFF by default,
+   listening icon state, tray toggle.
+3. Tier 2 splice: wake -> ring-buffer-prefixed dictation; outro phrase.
+4. Per-app meeting auto-record (WASAPI session watch + app list in
+   settings).
+5. In-app trainer (verifier first, background full training later).
+6. NPU/OpenVINO backup-transcriber experiment.
+
 ## Open questions to define before step 2
 
 - Wake word name and outro phrase(s); false-positive tolerance.
-- Should wake-word capture be visible (icon state) and separately
-  toggleable from the tray? (Almost certainly yes: a "listening" ring.)
-- Privacy defaults: always-on listener OFF by default; whisper-mode
-  interaction; what, if anything, is ever written to disk before the
-  wake word fires (proposal: nothing - the ring buffer is RAM-only).
+- Privacy defaults confirmed: listener OFF by default, ring buffer
+  RAM-only until wake; how the listener interacts with whisper mode.
 - Command grammar beyond start/stop ("open X" needs an allowlist).

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -104,17 +104,17 @@ graphics) can power the discrete GPU on and off. Requirements:
   CUDA model selection unchanged.
 - If the dGPU turns off or disconnects MID-SESSION: the app must not
   crash the machine and workers must not hang. Detection signals:
-  VramProbe starts failing (pynvml/nvidia-smi errors), CUDA errors out
+  the VRAM probe (vram_probe.py) starts failing with pynvml/nvidia-smi errors, CUDA errors out
   of the worker, or WM_DEVICECHANGE removal events.
 - On loss: kill the worker (wedge detection already bounds a hang),
   respawn on device=cpu with a CPU-appropriate model (new config key,
   e.g. cpu_fallback_model, default small/base - CPU inference was
-  validated as acceptable earlier), toast the fallover, log it to
+  validated as acceptable earlier), toast the failover, log it to
   gpu-guard.jsonl.
 - CRITICAL: the respawn-after-crash path must NOT retry CUDA in a loop
-  when the GPU is gone (today it would). The fallover decision belongs
+  when the GPU is gone (today it would). The failover decision belongs
   to GPU Guard - it already owns VRAM health and the downgrade ladder;
-  device fallover is the ladder's missing floor (the "CPU floor"
+  device failover is the ladder's missing floor (the "CPU floor"
   deferral in BACKLOG.md becomes this requirement).
 - When the dGPU returns: notify + offer switch-back (or auto, config).
 
@@ -171,16 +171,16 @@ device enumeration). Assessment:
 - The REAL NPU win: the CPU-fallback/backup Whisper model. Running
   whisper base/small through OpenVINO on the NPU instead of CPU cuts
   the power draw of the library scenario and of always-available
-  dictation. This slots into the GPU-fallover work: fallback targets
+  dictation. This slots into the GPU-failover work: fallback targets
   become cpu OR npu-via-openvino.
 - Caveat: the worker stack is ctranslate2/whisperX (CUDA/CPU only). An
   OpenVINO whisper path is a NEW backend for the backup transcriber,
-  not a config flip. Treat as a follow-up experiment after fallover
+  not a config flip. Treat as a follow-up experiment after failover
   ships; measure quality/latency vs the CPU path first.
 
 ## Build order (next sessions)
 
-1. GPU power-state fallover (guard-owned; includes cpu_fallback_model)
+1. GPU power-state failover (guard-owned; includes cpu_fallback_model)
    - the safety item, and auto-sleep's natural sibling.
 2. Tier 0+1 listener: always-on shared stream + ring buffer +
    silero-vad + openWakeWord with a pretrained phrase, OFF by default,


### PR DESCRIPTION
## Summary

Second owner intake on the voice-assistant direction, plus researched answers to the hardware questions.

- Records the GO decisions: always-on listener (config-gated, off by default), per-app meeting auto-record (Zoom/Slack/Teams list, manual stays), in-app wake-phrase training (2-3 phrases).
- New first-class requirement: **GPU power-state resilience** - the hybrid-graphics laptop can power the dGPU off mid-session; device loss must never crash the machine or hang workers, and the respawn path must fall over to device=cpu with a cpu_fallback_model instead of retrying CUDA in a loop. Assigned to GPU Guard; supersedes the CPU-floor deferral in BACKLOG.md.
- Hardware portability matrix (Pi: comfortable; ESP32-S3: viable via microWakeWord, the Home Assistant voice-satellite standard), wake-word model landscape with tradeoffs, honest in-app training design (per-user verifier trains in seconds; fully custom phrases are a background synthetic-training job), NPU assessment (Intel AI Boost verified present on the Core Ultra 9 285H; the real win is an OpenVINO backup-transcriber path).
- Build order for the next sessions.

Docs-only PR; feature-docs sync tests pass.