### PR TITLE
feat: GPU power-state failover core (device-loss detection + cpu_fallback_model)

### DIFF
--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -42,3 +42,4 @@ fails if this table and the defaults file disagree on keys.
 | `gpu_guard_poll_seconds` | `30` | VRAM poll interval |
 | `gpu_guard_ladder` | `["large-v3", "medium", "small", "base"]` | Downgrade order as a JSON list (floor = last entry); non-list values are rejected and fall back to this default |
 | `gpu_guard_probe` | `null` | Force a probe backend (null = auto: pynvml, nvidia-smi) |
+| `cpu_fallback_model` | `base` | Model used when the GPU becomes unreachable (hybrid dGPU power-off) and transcription fails over to cpu |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -42,6 +42,12 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   worker crashes. Vendor-agnostic probes. All events (downgrades,
   suspend/resume, sleep/wake, mic stalls) land in `gpu-guard.jsonl`
   for crash-time correlation.
+- **GPU power-state failover** - if the dGPU becomes unreachable
+  (hybrid laptops can power it off mid-session), the guard detects it
+  via consecutive failed probes or a crash-time probe, toasts, and
+  clamps model selection to `cpu_fallback_model` so the app never
+  retries CUDA against a dead device. Recovery is detected
+  automatically when the GPU returns.
 - **CPU/GPU device selection** - auto-detect, force GPU, or force CPU
   from the tray menu; backup model has independent device/model
   settings.

--- a/tests/test_gpu_guard.py
+++ b/tests/test_gpu_guard.py
@@ -269,6 +269,29 @@ class DeviceFailoverTests(_Harness):
         self.assertFalse(g.device_lost)
         self.assertIsNone(g.respawn_overlay())
 
+    def test_cpu_period_does_not_bank_failures(self):
+        # Review catch: failures during an explicit-cpu period must not
+        # accumulate, or the first failure after switching back to auto
+        # would declare loss instantly, bypassing the 3-failure rule.
+        g = self._guard(free_sequence=[None] * 8, device="cpu")
+        for _ in range(5):
+            g.check_once()
+        g._cfg["device"] = "auto"
+        g.check_once()  # first failure after the switch: streak = 1
+        self.assertFalse(g.device_lost)
+        g.check_once()
+        g.check_once()  # third consecutive failure: now lost
+        self.assertTrue(g.device_lost)
+
+    def test_crash_event_logs_the_fresh_probe_reading(self):
+        # Review catch: the downgrade event must carry the reading from
+        # the probe that just ran, not the last poll's stale value.
+        g = self._guard(free_sequence=[3000])
+        g.note_pressure_trigger("worker_crash_dictation")
+        armed = [e for e in self._events() if e["event"] == "downgrade_armed"]
+        self.assertEqual(armed[0]["free_mb"], 3000)
+        self.assertEqual(armed[0]["total_mb"], 8192)
+
 
 class ProbeRegistryTests(unittest.TestCase):
     def test_get_probe_returns_none_when_no_provider(self):

--- a/tests/test_gpu_guard.py
+++ b/tests/test_gpu_guard.py
@@ -100,15 +100,19 @@ class WatermarkTests(_Harness):
 
 
 class LadderTests(_Harness):
+    # note_pressure_trigger probes device reachability before walking
+    # the ladder; these tests model a healthy (reachable) GPU, so each
+    # trigger consumes one successful probe from the sequence.
+
     def test_crash_trigger_escalates_immediately(self):
-        g = self._guard()
+        g = self._guard(free_sequence=[4000, 4000])
         g.note_pressure_trigger("worker_crash_meeting")
         self.assertEqual(g.effective_model("large-v3"), "medium")
         g.note_pressure_trigger("worker_crash_meeting")
         self.assertEqual(g.effective_model("large-v3"), "small")
 
     def test_ladder_floor_is_sticky_and_logged(self):
-        g = self._guard()
+        g = self._guard(free_sequence=[4000] * 10)
         for _ in range(10):
             g.note_pressure_trigger("worker_crash_dictation")
         self.assertEqual(g.effective_model("large-v3"), "base")
@@ -117,13 +121,13 @@ class LadderTests(_Harness):
     def test_downgrade_never_upgrades_a_smaller_request(self):
         # Caller already using 'base' for dictation must not be bumped
         # up to the guard's rung.
-        g = self._guard()
+        g = self._guard(free_sequence=[4000])
         g.note_pressure_trigger("x")  # rung = medium
         self.assertEqual(g.effective_model("base"), "base")
         self.assertEqual(g.effective_model("small"), "small")
 
     def test_model_not_on_ladder_maps_to_rung(self):
-        g = self._guard()
+        g = self._guard(free_sequence=[4000])
         g.note_pressure_trigger("x")
         self.assertEqual(g.effective_model("distil-large-v3"), "medium")
 
@@ -144,10 +148,11 @@ class DisabledTests(_Harness):
     def test_invalid_ladder_config_falls_back_to_default(self):
         # Regression for PR #158 review: an empty or malformed ladder
         # must not crash escalation with an IndexError.
-        g = self._guard(gpu_guard_ladder=[])
+        g = self._guard(free_sequence=[4000], gpu_guard_ladder=[])
         g.note_pressure_trigger("x")
         self.assertEqual(g.effective_model("large-v3"), "medium")
-        g2 = self._guard(gpu_guard_ladder="large-v3")  # string, not list
+        # string, not list
+        g2 = self._guard(free_sequence=[4000], gpu_guard_ladder="large-v3")
         g2.note_pressure_trigger("x")
         self.assertEqual(g2.effective_model("large-v3"), "medium")
 
@@ -170,6 +175,99 @@ class DisabledTests(_Harness):
                         return_value=(None, None)):
             g.start(_NoProviderScheduler(), io_executor=None)
         self.assertIn("probe_unavailable", [e["event"] for e in self._events()])
+
+
+class DeviceFailoverTests(_Harness):
+    """GPU power-state failover (2026-07-04 voice-assistant spec)."""
+
+    def test_three_failed_polls_declare_device_lost(self):
+        g = self._guard(free_sequence=[None, None, None])
+        for _ in range(3):
+            g.check_once()
+        self.assertTrue(g.device_lost)
+        self.assertEqual(g.effective_model("large-v3"), "base")
+        events = [e for e in self._events() if e["event"] == "gpu_device_lost"]
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["fail_streak"], 3)
+        self.assertEqual(len(self.toasts), 1)
+
+    def test_two_failures_then_success_stays_healthy(self):
+        g = self._guard(free_sequence=[None, None, 4000])
+        for _ in range(3):
+            g.check_once()
+        self.assertFalse(g.device_lost)
+        self.assertEqual(g.effective_model("large-v3"), "large-v3")
+
+    def test_crash_with_failed_probe_fails_over_immediately(self):
+        g = self._guard(free_sequence=[None])
+        g.note_pressure_trigger("worker_crash_dictation")
+        self.assertTrue(g.device_lost)
+        self.assertEqual(g.effective_model("large-v3"), "base")
+        # While lost, the fallback clamp governs - no ladder escalation.
+        self.assertNotIn("downgrade_armed",
+                         [e["event"] for e in self._events()])
+
+    def test_crash_with_healthy_probe_keeps_ladder_semantics(self):
+        g = self._guard(free_sequence=[4000])
+        g.note_pressure_trigger("worker_crash_dictation")
+        self.assertFalse(g.device_lost)
+        self.assertEqual(g.effective_model("large-v3"), "medium")
+
+    def test_successful_poll_clears_loss(self):
+        g = self._guard(free_sequence=[None, None, None, 4000])
+        for _ in range(4):
+            g.check_once()
+        self.assertFalse(g.device_lost)
+        self.assertEqual(g.effective_model("large-v3"), "large-v3")
+        self.assertIn("gpu_device_recovered",
+                      [e["event"] for e in self._events()])
+
+    def test_fallback_never_upgrades_a_smaller_request(self):
+        g = self._guard(free_sequence=[None], cpu_fallback_model="small")
+        g.note_pressure_trigger("x")
+        self.assertEqual(g.effective_model("large-v3"), "small")
+        self.assertEqual(g.effective_model("base"), "base")
+
+    def test_explicit_cpu_device_never_declares_loss(self):
+        g = self._guard(free_sequence=[None, None, None, None], device="cpu")
+        for _ in range(3):
+            g.check_once()
+        g.note_pressure_trigger("worker_crash_dictation")
+        self.assertFalse(g.device_lost)
+        # The ladder still applies on explicit-cpu machines (existing
+        # semantics); only the failover path is gated off.
+        self.assertEqual(g.effective_model("large-v3"), "medium")
+
+    def test_respawn_overlay_pins_cpu_while_lost(self):
+        g = self._guard(free_sequence=[None])
+        self.assertIsNone(g.respawn_overlay())
+        g.note_pressure_trigger("worker_crash_meeting")
+        overlay = g.respawn_overlay()
+        self.assertEqual(overlay, {
+            "device": "cpu",
+            "model": "base",
+            "dictation_model": "base",
+            "compute_type": "int8",
+        })
+
+    def test_invalid_fallback_model_uses_base(self):
+        g = self._guard(free_sequence=[None], cpu_fallback_model=123)
+        g.note_pressure_trigger("x")
+        self.assertEqual(g.effective_model("large-v3"), "base")
+
+    def test_repeated_crashes_while_lost_toast_once(self):
+        g = self._guard(free_sequence=[None, None])
+        g.note_pressure_trigger("x")
+        g.note_pressure_trigger("x")
+        self.assertEqual(len(self.toasts), 1)
+        events = [e for e in self._events() if e["event"] == "gpu_device_lost"]
+        self.assertEqual(len(events), 1)
+
+    def test_providerless_guard_never_fails_over(self):
+        g = GpuGuard(_cfg(), notify=lambda t, m: None,
+                     probe=None, probe_name=None, event_path=self.event_path)
+        self.assertFalse(g.device_lost)
+        self.assertIsNone(g.respawn_overlay())
 
 
 class ProbeRegistryTests(unittest.TestCase):

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -41,5 +41,6 @@
     "small",
     "base"
   ],
-  "gpu_guard_probe": null
+  "gpu_guard_probe": null,
+  "cpu_fallback_model": "base"
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -33,6 +33,7 @@ _VALID_KEYS = {
     "gpu_guard_single_instance",
     "gpu_guard", "gpu_guard_low_vram_mb", "gpu_guard_poll_seconds",
     "gpu_guard_ladder", "gpu_guard_probe",
+    "cpu_fallback_model",
 }
 
 

--- a/whisper_sync/gpu_guard.py
+++ b/whisper_sync/gpu_guard.py
@@ -174,6 +174,13 @@ class GpuGuard:
                                 total_mb=result.total_mb)
                     logger.info("GPU guard: GPU reachable again")
                 return
+            if str(self._cfg.get("device", "auto")).lower() == "cpu":
+                # The user never wanted cuda; nothing to fail over. Keep
+                # the streak at zero so an explicit-cpu period does not
+                # bank failures that would fire instantly after a later
+                # switch to auto/cuda (review catch on this PR).
+                self._probe_fail_streak = 0
+                return
             self._probe_fail_streak += 1
             if self._device_lost:
                 return
@@ -181,8 +188,6 @@ class GpuGuard:
             if (not from_crash
                     and self._probe_fail_streak < DEVICE_LOST_AFTER_FAILURES):
                 return
-            if str(self._cfg.get("device", "auto")).lower() == "cpu":
-                return  # the user never wanted cuda; nothing to fail over
             self._device_lost = True
             fallback = self._fallback_model()
             self._event("gpu_device_lost", source=source,
@@ -215,8 +220,15 @@ class GpuGuard:
         with self._lock:
             if self._device_lost:
                 return  # cpu failover governs; ladder rungs are meaningless
-            self._escalate_locked(trigger=reason,
-                                  free_mb=self._last_free_mb, total_mb=None)
+            if result is not None:
+                # The probe just ran; log the fresh reading instead of
+                # the last poll's (which may be stale or None).
+                self._last_free_mb = result.free_mb
+            self._escalate_locked(
+                trigger=reason,
+                free_mb=self._last_free_mb,
+                total_mb=result.total_mb if result is not None else None,
+            )
 
     def _escalate_locked(self, trigger: str, free_mb, total_mb) -> None:
         ladder = self._ladder()

--- a/whisper_sync/gpu_guard.py
+++ b/whisper_sync/gpu_guard.py
@@ -21,6 +21,15 @@ Behavior (spec B1-B3):
   to ``gpu-guard.jsonl`` in the data dir - the artifact for correlating
   against Windows crash/BSOD times, and the machine surface for the
   API-first extension app.
+
+Device failover (2026-07-04 voice-assistant-direction spec): hybrid
+laptops can power the dGPU off mid-session. Three consecutive failed
+probes - or a worker crash whose immediate probe fails - declare the
+device lost: ``effective_model`` clamps to ``cpu_fallback_model`` and
+``respawn_overlay()`` tells the respawn path to pin the next worker
+spawn to cpu, so a dead GPU is never retried in a loop. A later
+successful probe clears the state. Explicit ``device: cpu`` configs
+never declare loss (the user never wanted cuda).
 """
 
 from __future__ import annotations
@@ -35,6 +44,11 @@ from .logger import logger
 
 DEFAULT_LADDER = ["large-v3", "medium", "small", "base"]
 
+# Consecutive failed polls before the device is declared lost. At the
+# default 30s poll this is ~90s worst-case detection; a worker crash
+# whose immediate probe fails short-circuits the wait entirely.
+DEVICE_LOST_AFTER_FAILURES = 3
+
 
 class GpuGuard:
     """Owns watermark monitoring, the downgrade ladder, and the event log."""
@@ -48,6 +62,8 @@ class GpuGuard:
         self._level = 0            # rungs below the requested model
         self._armed_low = False    # hysteresis: True while below watermark
         self._last_free_mb: int | None = None
+        self._device_lost = False  # dGPU unreachable; cpu failover active
+        self._probe_fail_streak = 0
         self._probe = probe
         self._probe_name = probe_name
         self._event_path = event_path
@@ -71,6 +87,15 @@ class GpuGuard:
 
     def _watermark_mb(self) -> int:
         return int(self._cfg.get("gpu_guard_low_vram_mb", 750))
+
+    def _fallback_model(self) -> str:
+        """Validated cpu_fallback_model; malformed config falls back to base."""
+        model = self._cfg.get("cpu_fallback_model", "base")
+        if isinstance(model, str) and model:
+            return model
+        logger.warning(
+            f"GPU guard: invalid cpu_fallback_model {model!r}; using 'base'")
+        return "base"
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -114,8 +139,9 @@ class GpuGuard:
     def check_once(self) -> None:
         """One probe + watermark evaluation. Runs on the IO executor."""
         result = self._probe() if self._probe else None
+        self._observe_probe_result(result, source="poll")
         if result is None:
-            return  # transient probe failure; next poll retries
+            return
         with self._lock:
             self._last_free_mb = result.free_mb
             watermark = self._watermark_mb()
@@ -130,15 +156,65 @@ class GpuGuard:
                 self._event("vram_recovered", free_mb=result.free_mb,
                             total_mb=result.total_mb, level=self._level)
 
+    def _observe_probe_result(self, result, source: str) -> None:
+        """Track device reachability from one probe outcome.
+
+        A ProbeResult proves the GPU is reachable and clears any loss
+        state. None counts one strike: DEVICE_LOST_AFTER_FAILURES
+        consecutive poll strikes - or a single strike observed at a
+        worker crash (any non-"poll" source) - declare the device lost.
+        """
+        with self._lock:
+            if result is not None:
+                self._probe_fail_streak = 0
+                if self._device_lost:
+                    self._device_lost = False
+                    self._event("gpu_device_recovered", source=source,
+                                free_mb=result.free_mb,
+                                total_mb=result.total_mb)
+                    logger.info("GPU guard: GPU reachable again")
+                return
+            self._probe_fail_streak += 1
+            if self._device_lost:
+                return
+            from_crash = source != "poll"
+            if (not from_crash
+                    and self._probe_fail_streak < DEVICE_LOST_AFTER_FAILURES):
+                return
+            if str(self._cfg.get("device", "auto")).lower() == "cpu":
+                return  # the user never wanted cuda; nothing to fail over
+            self._device_lost = True
+            fallback = self._fallback_model()
+            self._event("gpu_device_lost", source=source,
+                        fail_streak=self._probe_fail_streak)
+            logger.warning(
+                f"GPU guard: GPU unreachable ({source}); failing over to "
+                f"'{fallback}' on cpu until it returns"
+            )
+            self._notify(
+                "WhisperSync switched to CPU",
+                f"The GPU is not reachable; using '{fallback}' until it returns.",
+            )
+
     def note_pressure_trigger(self, reason: str) -> None:
         """Escalate one rung immediately (worker crash, OOM exhaustion).
 
         Inert without a probe provider: on providerless machines the
         guard must never alter model selection (documented contract).
+
+        Probes device reachability first: a crash WITH an unreachable
+        GPU is the power-off signature on hybrid laptops and fails over
+        to cpu instead of walking the ladder - the ladder assumes the
+        GPU still exists.
         """
         if not self.enabled or self._probe is None:
             return
+        # Probe outside the lock: nvidia-smi can take seconds.
+        result = self._probe()
+        self._observe_probe_result(result, source=reason)
         with self._lock:
+            if self._device_lost:
+                return  # cpu failover governs; ladder rungs are meaningless
             self._escalate_locked(trigger=reason,
                                   free_mb=self._last_free_mb, total_mb=None)
 
@@ -172,10 +248,17 @@ class GpuGuard:
         is the LOWER of the requested model and the current ladder rung -
         a downgrade may never upgrade a caller that already asked for a
         small model. Models not on the ladder map to the current rung.
+
+        While the device is lost the result is instead clamped to
+        ``cpu_fallback_model``: the worker runs (or will respawn) on
+        cpu, where the configured cuda-sized model would be unusably
+        slow.
         """
         if not self.enabled or self._probe is None:
             return requested
         with self._lock:
+            if self._device_lost:
+                return self._clamp_locked(requested, self._fallback_model())
             return self._effective_locked(requested)
 
     def _effective_locked(self, requested: str) -> str:
@@ -188,6 +271,51 @@ class GpuGuard:
         except ValueError:
             return ladder[rung_index]
         return ladder[max(requested_index, rung_index)]
+
+    def _clamp_locked(self, requested: str, ceiling: str) -> str:
+        """The smaller of requested and ceiling by ladder position.
+
+        A failover may never upgrade a caller that already asked for a
+        smaller model; models not on the ladder resolve to the ceiling.
+        """
+        ladder = self._ladder()
+        try:
+            ceiling_index = ladder.index(ceiling)
+        except ValueError:
+            return ceiling
+        try:
+            requested_index = ladder.index(requested)
+        except ValueError:
+            return ceiling
+        return ladder[max(requested_index, ceiling_index)]
+
+    @property
+    def device_lost(self) -> bool:
+        """True while the dGPU is unreachable and cpu failover governs."""
+        with self._lock:
+            return self._device_lost
+
+    def respawn_overlay(self) -> dict | None:
+        """Config overlay for the NEXT worker spawn, or None for live config.
+
+        While the device is lost every spawn must be pinned to cpu with
+        the fallback model - a live-config respawn would retry CUDA in
+        a loop (spec: forbidden). The caller merges this over a config
+        snapshot and hands it to ``worker.update_config()`` before
+        restarting (the backup_worker pinned-dict precedent).
+        """
+        if not self.enabled or self._probe is None:
+            return None
+        with self._lock:
+            if not self._device_lost:
+                return None
+            fallback = self._fallback_model()
+            return {
+                "device": "cpu",
+                "model": fallback,
+                "dictation_model": fallback,
+                "compute_type": "int8",
+            }
 
     def log_external_event(self, event: str, **fields) -> None:
         """Append a non-guard subsystem event to gpu-guard.jsonl.
@@ -206,6 +334,7 @@ class GpuGuard:
                 "provider": self._probe_name,
                 "level": self._level,
                 "last_free_mb": self._last_free_mb,
+                "device_lost": self._device_lost,
             }
 
     # -- event log ---------------------------------------------------------------


### PR DESCRIPTION
Step 1, PR A of the assistant build round (plan: docs/plans/2026-07-04-assistant-build-round.md, spec: docs/specs/2026-07-04-voice-assistant-direction.md).

Hybrid laptops can power the dGPU off mid-session. GPU Guard now owns device-loss detection and the failover decision:

- **Detection**: 3 consecutive failed VRAM probes (~90s at default poll), or a worker crash whose immediate probe fails (the power-off signature), declare the device lost. Events `gpu_device_lost` / `gpu_device_recovered` land in gpu-guard.jsonl; a toast announces the failover. A successful probe clears the state.
- **Model clamp**: while lost, `effective_model()` returns the new `cpu_fallback_model` key (default `base`, the validated backup-transcriber path) instead of walking the ladder, and never upgrades a smaller request.
- **respawn_overlay() seam**: returns the pinned `{device: cpu, model, dictation_model, compute_type: int8}` overlay for the next worker spawn. Consumed by the respawn-routing PR (next) so a dead GPU is never retried in a loop.
- **Gates**: explicit `device: cpu` configs and providerless machines never fail over.

Architecture note: no protected paths touched - device resolution (auto -> cpu) and the cpu int8 compute map already live in the worker; this PR adds only the decision layer plus the config key (defaults + _VALID_KEYS + docs/features same-PR rule).

Tests: 11 new failover tests; ladder tests updated to model a healthy probe since note_pressure_trigger now consumes one. CI-equivalent suite: 301 passed.