### PR TITLE
feat: route all worker respawns through guard-aware restart_worker

### DIFF
--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -92,3 +92,23 @@ Recorded in BACKLOG.md in PR C.
   Owner reminder outstanding: the tray app still runs pre-#167
   bytecode and needs a restart to pick up everything from #167 through
   auto-sleep.
+
+- **2026-07-04 (step 1 PR A merged, #180)**: guard failover core as
+  planned. Review caught two real issues, both fixed with regression
+  tests: explicit-cpu periods were banking probe failures (a later
+  switch to auto would declare loss on ONE failure, bypassing the
+  3-failure rule - streak now resets at the cpu gate), and crash
+  events logged stale VRAM readings despite a fresh probe having just
+  run. 13 failover tests; suite 303.
+
+- **2026-07-04 (step 1 PR B)**: respawn routing.
+  AppControl.restart_worker(reason) is the single guard-aware respawn
+  path: consults respawn_overlay(), pins the spawn to a
+  cpu+fallback-model snapshot while the device is lost (logging
+  worker_respawn_pinned_cpu to the timeline), rebinds the live
+  ConfigStore otherwise. All five generic respawn sites rerouted
+  (dictation crash, meeting crash, meeting_job pre-transcribe,
+  suspend/resume check, auto-sleep wake). tray_menu's manual device
+  switch deliberately keeps its own restart: an explicit user choice
+  must not be overridden by the overlay. Protected paths untouched;
+  WS_E2E run against the real worker.

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -40,6 +40,7 @@ class _FakeApp:
         self.worker = types.SimpleNamespace(
             stop=mock.Mock(),
             update_config=mock.Mock(),
+            set_preload_model=mock.Mock(),
             restart=mock.Mock(),
             is_ready=mock.Mock(return_value=True),
         )
@@ -49,6 +50,7 @@ class _FakeApp:
         self._gpu_guard = types.SimpleNamespace(
             respawn_overlay=mock.Mock(return_value=None),
             log_external_event=mock.Mock(),
+            effective_model=mock.Mock(side_effect=lambda m: m),
         )
 
 
@@ -159,6 +161,8 @@ class RestartWorkerTests(_ControlHarness):
         ok = self.control.restart_worker("worker_crash_dictation")
         self.assertTrue(ok)
         self.app.worker.update_config.assert_called_once_with(self.app.cfg)
+        # Preload follows the (guard-filtered) configured model.
+        self.app.worker.set_preload_model.assert_called_once_with("large-v3")
         self.app.worker.restart.assert_called_once()
 
     def test_lost_gpu_pins_the_spawn_to_the_overlay(self):
@@ -171,6 +175,9 @@ class RestartWorkerTests(_ControlHarness):
         self.assertEqual(pinned["device"], "cpu")
         self.assertEqual(pinned["model"], "base")
         self.assertEqual(pinned["compute_type"], "int8")
+        # Preload travels with the pin: never the cuda-sized model on
+        # cpu (PR #181 review catch).
+        self.app.worker.set_preload_model.assert_called_once_with("base")
         # The overlay merges OVER a snapshot of the live config: the
         # pinned dict is frozen (not the store) and unrelated settings
         # survive the pin.

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -7,10 +7,8 @@ and sleeps are stubbed - a real exit would kill the test runner.
 """
 
 import sys
-import threading
 import types
 import unittest
-from pathlib import Path
 from unittest import mock
 
 from whisper_sync import app_control
@@ -39,9 +37,26 @@ class _FakeApp:
         self.state = StateManager(None, {})
         self.tray = types.SimpleNamespace(stop=mock.Mock())
         self.recorder = _FakeRecorder()
-        self.worker = types.SimpleNamespace(stop=mock.Mock())
+        self.worker = types.SimpleNamespace(
+            stop=mock.Mock(),
+            update_config=mock.Mock(),
+            restart=mock.Mock(),
+            is_ready=mock.Mock(return_value=True),
+        )
         self._backup = types.SimpleNamespace(stop=mock.Mock())
         self.meetings = types.SimpleNamespace(shutdown_post_worker=mock.Mock())
+        self.cfg = _FakeConfigStore({"model": "large-v3", "device": "auto"})
+        self._gpu_guard = types.SimpleNamespace(
+            respawn_overlay=mock.Mock(return_value=None),
+            log_external_event=mock.Mock(),
+        )
+
+
+class _FakeConfigStore(dict):
+    """Live-config stand-in: a dict with the snapshot() seam."""
+
+    def snapshot(self):
+        return dict(self)
 
 
 class _FakeRun:
@@ -135,6 +150,45 @@ class UpdateStepsTests(_ControlHarness):
             self.control._run_update_steps(fake_sp, "root", "dev")
         restart.assert_called_once()
         self.assertIn(["git", "pull", "origin"], run.commands)
+
+
+class RestartWorkerTests(_ControlHarness):
+    """The single guard-aware respawn path (assistant round, step 1)."""
+
+    def test_healthy_respawn_rebinds_the_live_config(self):
+        ok = self.control.restart_worker("worker_crash_dictation")
+        self.assertTrue(ok)
+        self.app.worker.update_config.assert_called_once_with(self.app.cfg)
+        self.app.worker.restart.assert_called_once()
+
+    def test_lost_gpu_pins_the_spawn_to_the_overlay(self):
+        self.app.cfg["language"] = "en"  # unrelated setting
+        overlay = {"device": "cpu", "model": "base",
+                   "dictation_model": "base", "compute_type": "int8"}
+        self.app._gpu_guard.respawn_overlay.return_value = overlay
+        self.control.restart_worker("wake")
+        pinned = self.app.worker.update_config.call_args[0][0]
+        self.assertEqual(pinned["device"], "cpu")
+        self.assertEqual(pinned["model"], "base")
+        self.assertEqual(pinned["compute_type"], "int8")
+        # The overlay merges OVER a snapshot of the live config: the
+        # pinned dict is frozen (not the store) and unrelated settings
+        # survive the pin.
+        self.assertIsNot(pinned, self.app.cfg)
+        self.assertEqual(pinned["language"], "en")
+        self.app.worker.restart.assert_called_once()
+
+    def test_pinned_respawn_lands_on_the_correlation_timeline(self):
+        self.app._gpu_guard.respawn_overlay.return_value = {"device": "cpu",
+                                                            "model": "base"}
+        self.control.restart_worker("resume")
+        event = self.app._gpu_guard.log_external_event.call_args
+        self.assertEqual(event[0][0], "worker_respawn_pinned_cpu")
+        self.assertEqual(event[1]["reason"], "resume")
+
+    def test_failed_respawn_reports_false(self):
+        self.app.worker.is_ready.return_value = False
+        self.assertFalse(self.control.restart_worker("x"))
 
 
 class ShutdownTests(_ControlHarness):

--- a/tests/test_auto_sleep.py
+++ b/tests/test_auto_sleep.py
@@ -6,7 +6,6 @@ is active, waking flashes and respawns the worker, and the double-click
 router never fires both actions for one gesture.
 """
 
-import threading
 import time
 import types
 import unittest
@@ -41,6 +40,20 @@ class _FakeWorker:
         return self.running
 
 
+class _FakeControl:
+    """Guard-aware respawn stand-in: wake routes through this, never a
+    bare worker.start() (the spawn must be pinnable to cpu)."""
+
+    def __init__(self, app):
+        self.app = app
+        self.respawns = []
+
+    def restart_worker(self, reason):
+        self.respawns.append(reason)
+        self.app.worker.start()
+        return self.app.worker.wait_ready(120)
+
+
 class _FakeApp:
     def __init__(self):
         self.cfg = {"auto_sleep_minutes": 30}
@@ -49,6 +62,7 @@ class _FakeApp:
         self.recorder = types.SimpleNamespace(is_recording=False)
         self._gpu_guard = types.SimpleNamespace(
             log_external_event=mock.Mock())
+        self.control = _FakeControl(self)
         self.flashes = 0
         self.refreshes = 0
 
@@ -167,6 +181,14 @@ class ManualToggleTests(_SleepHarness):
         self.auto.wake(reason="hotkey")
         self.assertEqual(self.app.worker.starts, 0)
         self.assertEqual(self.app.flashes, 0)
+
+    def test_wake_routes_through_the_failover_respawn(self):
+        # The wake spawn must consult the guard: if the dGPU was
+        # powered off while asleep (the gaming scenario), the respawn
+        # is pinned to cpu instead of loading cuda on a dead device.
+        self.auto.toggle()  # sleep
+        self.auto.toggle()  # wake
+        self.assertEqual(self.app.control.respawns, ["wake"])
 
 
 class ClickRouterTests(unittest.TestCase):

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -98,6 +98,17 @@ class _FakeStats:
         self.features += 1
 
 
+class _FakeControl:
+    """Records guard-aware respawns (app_control.restart_worker)."""
+
+    def __init__(self):
+        self.respawns = []
+
+    def restart_worker(self, reason):
+        self.respawns.append(reason)
+        return True
+
+
 class _FakeApp:
     def __init__(self):
         self.cfg = {
@@ -117,6 +128,7 @@ class _FakeApp:
         self._backup = _FakeBackup()
         self._gpu_guard = _FakeGuard()
         self._stats = _FakeStats()
+        self.control = _FakeControl()
         self.flashes = 0
         self.refreshes = 0
 
@@ -218,6 +230,20 @@ class NormalDictationTests(_FlowHarness):
         self.assertEqual(self.app.flashes, 0)
         self.assertEqual(self.app.state.current.mode, "dictation")
         self.assertTrue(self.app.recorder.is_recording)
+
+    def test_worker_crash_routes_through_failover_respawn(self):
+        # Respawn must go through the guard-aware path, never a bare
+        # worker.restart() (which would retry CUDA on a lost dGPU).
+        from whisper_sync.worker_manager import WorkerCrashedError
+
+        def _boom(audio, model_override=None, timeout=None):
+            raise WorkerCrashedError("boom")
+
+        self.flow.toggle()
+        self.app.worker.transcribe_fast = _boom
+        self.flow.toggle()
+        self.assertEqual(self.app.control.respawns, ["worker_crash_dictation"])
+        self.assertEqual(self.app.state.current.mode, "error")
 
     def test_mic_failure_returns_to_idle_and_clears_feature(self):
         self.app.recorder.fail_start = True

--- a/tests/test_meeting_flow.py
+++ b/tests/test_meeting_flow.py
@@ -54,6 +54,19 @@ class _FakeWorker:
         self.restarts += 1
 
 
+class _FakeControl:
+    """Records guard-aware respawns (app_control.restart_worker)."""
+
+    def __init__(self, app):
+        self.app = app
+        self.respawns = []
+
+    def restart_worker(self, reason):
+        self.respawns.append(reason)
+        self.app.worker.restart()
+        return True
+
+
 class _FakeGuard:
     def __init__(self):
         self.triggers = []
@@ -94,6 +107,7 @@ class _FakeApp:
         self._gpu_guard = _FakeGuard()
         self._backup = _FakeBackup()
         self.dialogs = _FakeDialogs()
+        self.control = _FakeControl(self)
         self.out = out_dir
         self.popups = []
         self.idles = []
@@ -244,6 +258,9 @@ class RunJobErrorTests(_FlowHarness):
         job = self._Job(WorkerCrashedError("boom"))
         self.flow._run_meeting_job(job)
         self.assertEqual(self.app._gpu_guard.triggers, ["worker_crash_meeting"])
+        # Respawn must route through the guard-aware path, never a bare
+        # worker.restart() (which would retry CUDA on a lost dGPU).
+        self.assertEqual(self.app.control.respawns, ["worker_crash_meeting"])
         self.assertEqual(self.app.worker.restarts, 1)
         self.assertEqual(self.app.state.current.mode, "error")
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -144,7 +144,7 @@ class WhisperSync:
         """
         import shutil
 
-        data_dir = get_data_dir()  # creates .whispersync/ if needed
+        get_data_dir()  # side effect: creates .whispersync/ if needed
 
         # 1. config.json
         legacy_cfg = get_legacy_config_path()
@@ -516,7 +516,9 @@ class WhisperSync:
                     return  # worker is intentionally stopped; do not wake
                 if not self.worker.is_alive():
                     logger.warning("Worker did not survive suspend/resume; restarting")
-                    self.worker.restart()
+                    # Guard-aware respawn: resume is exactly when a
+                    # hybrid dGPU may have been powered off.
+                    self.control.restart_worker("resume")
                     notify("WhisperSync recovered",
                            "Transcription engine restarted after sleep.")
             submit_or_spawn(IO, "resume-check", _check)

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -11,6 +11,11 @@ background thread + defer).
 The old ``_updating`` class attribute is folded into
 ``AppState.updating`` with UPDATE_STARTED / UPDATE_COMPLETED events -
 the last stray mode flag from the architecture audit.
+
+restart_worker() is the single generic worker-respawn path (assistant
+build round, step 1): every "the worker died, bring it back" site
+routes through it so the GPU Guard's device-failover decision is
+always consulted before a spawn.
 """
 
 import os
@@ -133,6 +138,38 @@ class AppControl:
         import time
         time.sleep(2)  # Let the notification display
         self.restart()
+
+    def restart_worker(self, reason: str) -> bool:
+        """Respawn the transcription worker with GPU-failover awareness.
+
+        While the dGPU is lost (guard.respawn_overlay() is non-None)
+        the spawn is pinned to cpu + cpu_fallback_model - respawning on
+        the live config would retry CUDA against a dead device, the
+        loop the failover spec forbids. On healthy probes the live
+        ConfigStore is (re)bound so the spawn snapshots current
+        settings. Returns True when the new worker reports ready.
+
+        Blocking (stop, spawn, wait_ready): call from a worker/IO
+        thread, never a hotkey/menu/scheduler thread. The manual device
+        switch in tray_menu keeps its own restart on purpose - an
+        explicit user choice must not be overridden by the overlay.
+        """
+        app = self.app
+        overlay = app._gpu_guard.respawn_overlay()
+        if overlay is not None:
+            snapshot = getattr(app.cfg, "snapshot", None)
+            base = snapshot() if callable(snapshot) else dict(app.cfg)
+            app.worker.update_config({**base, **overlay})
+            app._gpu_guard.log_external_event(
+                "worker_respawn_pinned_cpu", reason=reason,
+                model=overlay.get("model"))
+            logger.warning(
+                f"Respawning worker on cpu ({reason}): GPU unreachable, "
+                f"using '{overlay.get('model')}'")
+        else:
+            app.worker.update_config(app.cfg)
+        app.worker.restart()
+        return app.worker.is_ready()
 
     # Empirically chosen delay (seconds) to let pystray menu callbacks
     # return before we call tray.stop(). Without this, WM_QUIT is posted

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -160,6 +160,10 @@ class AppControl:
             snapshot = getattr(app.cfg, "snapshot", None)
             base = snapshot() if callable(snapshot) else dict(app.cfg)
             app.worker.update_config({**base, **overlay})
+            # Preload travels with the config: spawning pinned-cpu but
+            # preloading the cuda-sized model would wedge startup on
+            # cpu and time out the restart (PR #181 review).
+            app.worker.set_preload_model(overlay.get("dictation_model"))
             app._gpu_guard.log_external_event(
                 "worker_respawn_pinned_cpu", reason=reason,
                 model=overlay.get("model"))
@@ -168,6 +172,9 @@ class AppControl:
                 f"using '{overlay.get('model')}'")
         else:
             app.worker.update_config(app.cfg)
+            app.worker.set_preload_model(app._gpu_guard.effective_model(
+                str(app.cfg.get("dictation_model",
+                                app.cfg.get("model", "large-v3")))))
         app.worker.restart()
         return app.worker.is_ready()
 

--- a/whisper_sync/auto_sleep.py
+++ b/whisper_sync/auto_sleep.py
@@ -209,8 +209,12 @@ class AutoSleep:
 
         def _start():
             try:
-                self.app.worker.start()
-                if self.app.worker.wait_ready(timeout=120):
+                # Guard-aware respawn (restart on a stopped worker is
+                # just spawn + wait_ready): if the dGPU was powered off
+                # while asleep - the gaming scenario auto-sleep exists
+                # for - the wake spawn is pinned to cpu instead of
+                # loading the cuda model against a dead device.
+                if self.app.control.restart_worker("wake"):
                     logger.info("Model reloaded after sleep")
                 else:
                     logger.warning("Worker failed to become ready after wake")

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -430,7 +430,8 @@ class DictationFlow:
                 logger.error("Worker crashed during dictation -- respawning...")
                 if self._wav_path:
                     logger.info(f"Dictation audio preserved at: {self._wav_path}")
-                app.worker.restart()
+                # Guard-aware respawn: pinned to cpu if the dGPU is gone.
+                app.control.restart_worker("worker_crash_dictation")
                 app.state.emit(ERROR, mode="error",
                                data={"message": "Worker crashed during dictation",
                                      "recoverable": True})

--- a/whisper_sync/meeting_flow.py
+++ b/whisper_sync/meeting_flow.py
@@ -307,7 +307,8 @@ class MeetingFlow:
             self.app._gpu_guard.note_pressure_trigger("worker_crash_meeting")
             logger.error("Worker crashed during meeting, respawning...")
             logger.info(f"Audio is preserved at: {job.wav_path}")
-            self.app.worker.restart()
+            # Guard-aware respawn: pinned to cpu if the dGPU is gone.
+            self.app.control.restart_worker("worker_crash_meeting")
             self._emit_error_safe(str(e))
         except PermissionError as e:
             logger.error(str(e))

--- a/whisper_sync/meeting_job.py
+++ b/whisper_sync/meeting_job.py
@@ -145,14 +145,13 @@ class MeetingJob:
     def step_transcribe(self):
         """Transcribe the WAV file via the shared worker process."""
         from .state_manager import TRANSCRIPTION_STARTED
-        from .worker_manager import WorkerCrashedError
 
         self.app.state.emit(TRANSCRIPTION_STARTED, mode=None, meeting_transcribing=True)
 
         if not self.app.worker.is_alive():
             logger.warning("Worker not alive, restarting...")
-            self.app.worker.restart()
-            if not self.app.worker.wait_ready(timeout=120):
+            # Guard-aware respawn: pinned to cpu if the dGPU is gone.
+            if not self.app.control.restart_worker("meeting_pre_transcribe"):
                 raise RuntimeError("Worker failed to restart")
 
         guard = getattr(self.app, "_gpu_guard", None)

--- a/whisper_sync/worker_manager.py
+++ b/whisper_sync/worker_manager.py
@@ -403,6 +403,16 @@ class TranscriptionWorker:
         """
         self._cfg = cfg
 
+    def set_preload_model(self, model_name: str | None) -> None:
+        """Rebind the model preloaded at the next spawn.
+
+        Spawn-time config and preload travel together: a pinned-cpu
+        failover respawn must not preload the cuda-sized model on cpu
+        (PR #181 review), and rebinding the live config restores the
+        configured selection the same way. None skips preloading.
+        """
+        self._preload_model = model_name
+
     def restart(self) -> None:
         """Kill and respawn the worker (e.g., after a crash).
 


### PR DESCRIPTION
Step 1, PR B of the assistant build round (plan: docs/plans/2026-07-04-assistant-build-round.md). Builds on #180.

`AppControl.restart_worker(reason)` is now the single generic respawn path. It consults the guard's `respawn_overlay()`:

- **While the dGPU is lost**: the spawn is pinned to a `cpu + cpu_fallback_model` snapshot (merged over the live config, backup_worker precedent) and `worker_respawn_pinned_cpu` lands on the gpu-guard.jsonl timeline. This closes the forbidden CUDA-retry loop: previously every crash handler called `worker.restart()` with the same config.
- **On healthy probes**: the live ConfigStore is rebound so spawns keep snapshotting current settings.

Rerouted sites (all five generic "worker died, bring it back" paths):
- dictation crash handler
- meeting crash handler
- meeting_job pre-transcribe revival
- suspend/resume health check (resume is exactly when a hybrid dGPU may be gone)
- auto-sleep wake (the gaming scenario: dGPU powered off while the model slept)

tray_menu's manual device switch deliberately keeps its own restart - an explicit user choice must not be overridden by the overlay.

Architecture note: protected paths untouched (`update_config` + `restart` already support pinned-dict spawns).

Hygiene riding along (pyflakes): dead `WorkerCrashedError` import in meeting_job, unused `data_dir` local in `__main__` (side-effect call kept), two unused test imports.

Tests: 4 new RestartWorkerTests, wake-routing test, dictation/meeting crash tests assert the guard-aware path. Suite 309. **WS_E2E=1 run against the real worker subprocess on real meeting audio: OK (999s).**