### PR TITLE
feat: GPU failover recovery - auto switch-back and startup probe

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,10 +27,13 @@ same PR that defers them.
 - **Loopback-stream stall coverage** - only the mic channel is
   monitored today; a dead loopback still records mic-only silently
   after the initial warning (item 4, H2 deferral).
-- **CPU floor for the GPU Guard ladder** - superseded 2026-07-04: now
-  the GPU power-state failover requirement in
-  specs/2026-07-04-voice-assistant-direction.md (device loss must not
-  crash or hang; respawn on cpu with cpu_fallback_model).
+- **WM_DEVICECHANGE removal events for GPU loss** - instant loss
+  detection needs a hidden top-level window + message pump
+  (message-only windows never receive broadcasts, the power_events.py
+  constraint). The shipped failover detects via probe streak +
+  crash-time probes instead: within one poll interval, and instantly
+  on any crash (assistant round step 1,
+  plans/2026-07-04-assistant-build-round.md).
 
 ## Feature gaps
 

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -46,8 +46,11 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   (hybrid laptops can power it off mid-session), the guard detects it
   via consecutive failed probes or a crash-time probe, toasts, and
   clamps model selection to `cpu_fallback_model` so the app never
-  retries CUDA against a dead device. Recovery is detected
-  automatically when the GPU returns.
+  retries CUDA against a dead device; every worker respawn is pinned
+  to cpu while the GPU is gone. Booting with the dGPU off pins the
+  first spawn the same way. When the GPU returns, the app switches
+  back automatically once idle (toast; never while recording,
+  transcribing, or intentionally asleep).
 - **CPU/GPU device selection** - auto-detect, force GPU, or force CPU
   from the tray menu; backup model has independent device/model
   settings.

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -13,7 +13,7 @@
 
 | # | Step | Spec anchor | Status |
 |---|------|-------------|--------|
-| 1 | GPU power-state failover (guard-owned, cpu_fallback_model) | GPU power-state resilience | IN PROGRESS |
+| 1 | GPU power-state failover (guard-owned, cpu_fallback_model) | GPU power-state resilience | MERGED (#180-#182) |
 | 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | NEEDS OWNER INPUT |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | QUEUED |
 | 4 | Per-app meeting auto-record (WASAPI session watch + app list) | Staged architecture, step 3 | QUEUED |
@@ -111,4 +111,20 @@ Recorded in BACKLOG.md in PR C.
   suspend/resume check, auto-sleep wake). tray_menu's manual device
   switch deliberately keeps its own restart: an explicit user choice
   must not be overridden by the overlay. Protected paths untouched;
-  WS_E2E run against the real worker.
+  WS_E2E run against the real worker (999s, OK - slow because the
+  owner was gaming on the GPU at the time; future E2E runs get a
+  warning first, or the CPU variant when the change is
+  device-agnostic).
+
+- **2026-07-04 (step 1 PR C)**: recovery + startup. guard.prime() runs
+  one synchronous probe before the first worker spawn, so booting with
+  the dGPU off pins the first spawn to cpu + fallback (startup
+  counterpart of the failover). On a lost -> recovered probe
+  transition the guard fires on_device_recovered (outside its lock);
+  AppControl.schedule_gpu_switchback restarts a pinned-cpu worker onto
+  the live config once idle - retrying each minute while busy,
+  aborting if the GPU is lost again, skipping while asleep (never grab
+  VRAM back mid-game) or when no pinned respawn ever happened.
+  auto_sleep._busy extracted to module-level app_busy() and shared.
+  BACKLOG: CPU-floor entry removed (shipped); WM_DEVICECHANGE instant
+  detection recorded as the deliberate deferral.

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -1,6 +1,10 @@
 # Voice assistant direction - 2026-07-04 intake
 
-Status: DIRECTION RECORDED; nothing beyond step 1 is committed.
+Status: DIRECTION RECORDED. Build-order step 1 (GPU power-state
+failover) SHIPPED 2026-07-04 (#180-#182); the NPU backend (step 6) is
+committed scope; steps 2-3 await the owner's phrase/whisper-mode
+decisions (open questions below). Round state:
+docs/plans/2026-07-04-assistant-build-round.md.
 Source: owner voice notes, 2026-07-04. This captures the intent and a
 proposed staged architecture so future sessions design against it
 instead of rediscovering it. The owner explicitly wants the always-on

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 from whisper_sync import app_control
 from whisper_sync.app_control import AppControl
-from whisper_sync.state_manager import StateManager
+from whisper_sync.state_manager import StateManager, SLEEP_STARTED
 
 
 class _InlineThread:
@@ -43,6 +43,7 @@ class _FakeApp:
             set_preload_model=mock.Mock(),
             restart=mock.Mock(),
             is_ready=mock.Mock(return_value=True),
+            device="cpu",
         )
         self._backup = types.SimpleNamespace(stop=mock.Mock())
         self.meetings = types.SimpleNamespace(shutdown_post_worker=mock.Mock())
@@ -51,6 +52,7 @@ class _FakeApp:
             respawn_overlay=mock.Mock(return_value=None),
             log_external_event=mock.Mock(),
             effective_model=mock.Mock(side_effect=lambda m: m),
+            device_lost=False,
         )
 
 
@@ -196,6 +198,63 @@ class RestartWorkerTests(_ControlHarness):
     def test_failed_respawn_reports_false(self):
         self.app.worker.is_ready.return_value = False
         self.assertFalse(self.control.restart_worker("x"))
+
+
+class SwitchbackTests(_ControlHarness):
+    """schedule_gpu_switchback: pinned-cpu worker returns to the GPU
+    once the app is idle, and only when there is something to switch."""
+
+    def setUp(self):
+        super().setUp()
+        self.scheduled = []
+        fake_scheduler = types.SimpleNamespace(
+            call_later=lambda delay, fn, label=None:
+                self.scheduled.append((delay, fn, label)))
+        patches = [
+            mock.patch("whisper_sync.executors.submit_or_spawn",
+                       lambda lane, label, fn, native=False: fn()),
+            mock.patch("whisper_sync.scheduler.scheduler", fake_scheduler),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_idle_app_switches_back_with_toast(self):
+        self.control.schedule_gpu_switchback()
+        self.app.worker.restart.assert_called_once()
+        # Live config rebound, never the overlay.
+        self.app.worker.update_config.assert_called_once_with(self.app.cfg)
+        self.assertIn("GPU is back", self.notify.call_args_list[0][0][0])
+
+    def test_busy_app_retries_later_instead_of_restarting(self):
+        self.app.recorder.is_recording = True
+        self.control.schedule_gpu_switchback(retry_s=60.0)
+        self.app.worker.restart.assert_not_called()
+        self.assertEqual(len(self.scheduled), 1)
+        self.assertEqual(self.scheduled[0][0], 60.0)
+        # The rescheduled attempt succeeds once the app is idle again.
+        self.app.recorder.is_recording = False
+        self.scheduled[0][1]()
+        self.app.worker.restart.assert_called_once()
+
+    def test_aborts_when_gpu_lost_again(self):
+        self.app._gpu_guard.device_lost = True
+        self.control.schedule_gpu_switchback()
+        self.app.worker.restart.assert_not_called()
+        self.assertEqual(self.scheduled, [])
+
+    def test_skips_while_model_is_asleep(self):
+        # Never grab VRAM back mid-game: the wake respawn already lands
+        # on the live config.
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        self.control.schedule_gpu_switchback()
+        self.app.worker.restart.assert_not_called()
+
+    def test_skips_when_worker_was_never_pinned(self):
+        # A probe blip with no respawn in between: worker still on cuda.
+        self.app.worker.device = "cuda"
+        self.control.schedule_gpu_switchback()
+        self.app.worker.restart.assert_not_called()
 
 
 class ShutdownTests(_ControlHarness):

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -226,6 +226,15 @@ class SwitchbackTests(_ControlHarness):
         self.app.worker.update_config.assert_called_once_with(self.app.cfg)
         self.assertIn("GPU is back", self.notify.call_args_list[0][0][0])
 
+    def test_failed_switchback_does_not_claim_success(self):
+        # Review catch: the success toast must be gated on the respawn
+        # actually reporting ready.
+        self.app.worker.is_ready.return_value = False
+        self.control.schedule_gpu_switchback()
+        titles = [c[0][0] for c in self.notify.call_args_list]
+        self.assertNotIn("GPU is back", titles)
+        self.assertIn("GPU switch-back failed", titles)
+
     def test_busy_app_retries_later_instead_of_restarting(self):
         self.app.recorder.is_recording = True
         self.control.schedule_gpu_switchback(retry_s=60.0)

--- a/tests/test_gpu_guard.py
+++ b/tests/test_gpu_guard.py
@@ -31,7 +31,8 @@ class _Harness(unittest.TestCase):
         self.event_path = Path(self._tmp.name) / "gpu-guard.jsonl"
         self.toasts = []
 
-    def _guard(self, free_sequence=None, **cfg_overrides):
+    def _guard(self, free_sequence=None, on_device_recovered=None,
+               **cfg_overrides):
         seq = list(free_sequence or [])
 
         def _probe():
@@ -47,6 +48,7 @@ class _Harness(unittest.TestCase):
             notify=lambda t, m: self.toasts.append((t, m)),
             probe=_probe, probe_name="fake",
             event_path=self.event_path,
+            on_device_recovered=on_device_recovered,
         )
 
     def _events(self):
@@ -291,6 +293,50 @@ class DeviceFailoverTests(_Harness):
         armed = [e for e in self._events() if e["event"] == "downgrade_armed"]
         self.assertEqual(armed[0]["free_mb"], 3000)
         self.assertEqual(armed[0]["total_mb"], 8192)
+
+
+class StartupPrimeTests(_Harness):
+    """prime(): one synchronous probe before the first worker spawn."""
+
+    def test_boot_with_dgpu_off_pins_the_first_spawn(self):
+        g = self._guard(free_sequence=[None])
+        g.prime()
+        self.assertTrue(g.device_lost)
+        self.assertIsNotNone(g.respawn_overlay())
+        self.assertEqual(g.effective_model("large-v3"), "base")
+
+    def test_healthy_boot_stays_passthrough(self):
+        g = self._guard(free_sequence=[4000])
+        g.prime()
+        self.assertFalse(g.device_lost)
+        self.assertIsNone(g.respawn_overlay())
+
+    def test_disabled_guard_prime_is_inert(self):
+        g = self._guard(free_sequence=[None], gpu_guard=False)
+        g.prime()
+        self.assertFalse(g.device_lost)
+
+
+class RecoveryCallbackTests(_Harness):
+    def test_recovery_fires_callback_once_on_the_transition(self):
+        fired = []
+        g = self._guard(free_sequence=[None, None, None, 4000, 4000],
+                        on_device_recovered=lambda: fired.append(1))
+        for _ in range(5):
+            g.check_once()
+        self.assertEqual(fired, [1],
+                         "callback fires on the transition only, not on "
+                         "every healthy poll")
+
+    def test_callback_exception_does_not_break_the_guard(self):
+        def _boom():
+            raise RuntimeError("callback boom")
+
+        g = self._guard(free_sequence=[None, None, None, 4000, 4000],
+                        on_device_recovered=_boom)
+        for _ in range(5):
+            g.check_once()  # must not raise
+        self.assertFalse(g.device_lost)
 
 
 class ProbeRegistryTests(unittest.TestCase):

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -96,10 +96,23 @@ class WhisperSync:
         self._menu_refresher = None  # MenuRefresher, created in run()
         self._lock = threading.RLock()
         self._tray_lock = threading.Lock()  # Serialize all tray icon/title updates (pystray not thread-safe)
-        self._gpu_guard = GpuGuard(self.cfg, notify=notify)
+        self._gpu_guard = GpuGuard(
+            self.cfg, notify=notify,
+            # Fire-time lookup: self.control is composed below; the
+            # callback only runs on a lost -> recovered probe
+            # transition, long after composition.
+            on_device_recovered=lambda: self.control.schedule_gpu_switchback(),
+        )
+        # One synchronous probe before the first spawn: booting with the
+        # dGPU powered off pins the first worker to cpu + fallback model
+        # instead of loading the cuda model against a dead device.
+        self._gpu_guard.prime()
         dictation_model = self._gpu_guard.effective_model(
             self.cfg.get("dictation_model", self.cfg["model"]))
-        self.worker = TranscriptionWorker(self.cfg, preload_model=dictation_model)
+        _startup_overlay = self._gpu_guard.respawn_overlay()
+        _worker_cfg = ({**self.cfg.snapshot(), **_startup_overlay}
+                       if _startup_overlay else self.cfg)
+        self.worker = TranscriptionWorker(_worker_cfg, preload_model=dictation_model)
         self._backup = BackupTranscriber(self.cfg)
         # Single long-lived thread for ALL tkinter dialogs. tk.Tk() must not
         # be created on rotating worker threads; doing so corrupts Win32 heap

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -214,9 +214,14 @@ class AppControl:
                     label="gpu-switchback-retry",
                 )
                 return
-            notify("GPU is back",
-                   "Switching transcription back to the GPU model.")
-            self.restart_worker("gpu_recovered")
+            # Toast only after the respawn actually succeeds (review
+            # catch: a pre-restart toast lies when the reload fails).
+            if self.restart_worker("gpu_recovered"):
+                notify("GPU is back",
+                       "Transcription switched back to the GPU model.")
+            else:
+                notify("GPU switch-back failed",
+                       "Worker did not reload; check the log.")
 
         submit_or_spawn(IO, "gpu-switchback", _attempt, native=True)
 

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -178,6 +178,48 @@ class AppControl:
         app.worker.restart()
         return app.worker.is_ready()
 
+    def schedule_gpu_switchback(self, retry_s: float = 60.0):
+        """Move a pinned-cpu worker back to the GPU once the app is idle.
+
+        Fired by the guard's on_device_recovered callback when the dGPU
+        becomes reachable again. The attempt runs on the IO executor
+        (restart_worker blocks) and re-checks every ``retry_s`` while
+        the app is busy. It aborts when the GPU is lost again (the
+        failover path owns it), while the model is asleep (the wake
+        respawn already lands on the live config - and grabbing VRAM
+        back mid-game would defeat manual sleep), or when the worker is
+        not actually on cpu (a probe blip with no pinned respawn in
+        between: nothing to switch). Repeated recover/lose transitions
+        can stack attempts; each attempt re-checks the guard first, so
+        a stale attempt degrades to a no-op or an idle-time restart.
+        """
+        from .executors import IO, submit_or_spawn
+
+        def _attempt():
+            app = self.app
+            if app._gpu_guard.device_lost:
+                return
+            state = app.state
+            if state is not None and state.current.sleeping:
+                return
+            if app.worker.device != "cpu":
+                return
+            from .auto_sleep import app_busy
+            if app_busy(app):
+                from .scheduler import scheduler
+                scheduler.call_later(
+                    retry_s,
+                    lambda: submit_or_spawn(IO, "gpu-switchback", _attempt,
+                                            native=True),
+                    label="gpu-switchback-retry",
+                )
+                return
+            notify("GPU is back",
+                   "Switching transcription back to the GPU model.")
+            self.restart_worker("gpu_recovered")
+
+        submit_or_spawn(IO, "gpu-switchback", _attempt, native=True)
+
     # Empirically chosen delay (seconds) to let pystray menu callbacks
     # return before we call tray.stop(). Without this, WM_QUIT is posted
     # but can't be processed while the callback is still on the stack.

--- a/whisper_sync/auto_sleep.py
+++ b/whisper_sync/auto_sleep.py
@@ -50,6 +50,24 @@ _ACTIVITY_EVENTS = frozenset({
 
 _CHECK_INTERVAL_S = 60.0
 
+
+def app_busy(app) -> bool:
+    """True while stopping or replacing the worker would interrupt work.
+
+    Shared by AutoSleep (sleep decisions) and the GPU switch-back in
+    app_control (a recovered dGPU waits for idle before the worker is
+    restarted onto it).
+    """
+    current = app.state.current if app.state else None
+    if current is None:
+        return True  # not fully started; treat as busy
+    return (
+        current.mode not in (None, "done", "error")
+        or current.meeting_transcribing
+        or current.dictation_overlay
+        or app.recorder.is_recording
+    )
+
 # Windows' default double-click time is 500ms; the single action is
 # deferred this long so a second click can claim the pair. Left-click
 # actions (toggle meeting/dictation, discard) are not latency-critical -
@@ -129,15 +147,7 @@ class AutoSleep:
 
     def _busy(self) -> bool:
         """True while sleeping now would interrupt real work."""
-        current = self.app.state.current if self.app.state else None
-        if current is None:
-            return True  # not fully started; never sleep during startup
-        return (
-            current.mode not in (None, "done", "error")
-            or current.meeting_transcribing
-            or current.dictation_overlay
-            or self.app.recorder.is_recording
-        )
+        return app_busy(self.app)
 
     def _check(self):
         """Idle checker (scheduler, every minute). Cheap by contract."""

--- a/whisper_sync/gpu_guard.py
+++ b/whisper_sync/gpu_guard.py
@@ -55,9 +55,11 @@ class GpuGuard:
 
     def __init__(self, cfg, notify: Optional[Callable[[str, str], None]] = None,
                  probe=None, probe_name: str | None = None,
-                 event_path: Path | None = None):
+                 event_path: Path | None = None,
+                 on_device_recovered: Optional[Callable[[], None]] = None):
         self._cfg = cfg
         self._notify = notify or (lambda title, msg: None)
+        self._on_device_recovered = on_device_recovered
         self._lock = threading.Lock()
         self._level = 0            # rungs below the requested model
         self._armed_low = False    # hysteresis: True while below watermark
@@ -98,6 +100,28 @@ class GpuGuard:
         return "base"
 
     # -- lifecycle ------------------------------------------------------------
+
+    def prime(self) -> None:
+        """Resolve the probe provider and observe ONE synchronous probe.
+
+        Called before the first worker spawn: a hybrid laptop booted
+        with the dGPU powered off then pins that first spawn to cpu +
+        cpu_fallback_model (the startup counterpart of the mid-session
+        failover) instead of loading the cuda model against a dead
+        device. Cost: one probe (~100ms via nvidia-smi; bounded by its
+        10s timeout on a wedged driver). No-op when disabled or
+        providerless.
+        """
+        if not self.enabled:
+            return
+        if self._probe is None:
+            from .vram_probe import get_probe
+            self._probe_name, self._probe = get_probe(
+                self._cfg.get("gpu_guard_probe") or None
+            )
+        if self._probe is None:
+            return
+        self._observe_probe_result(self._probe(), source="startup")
 
     def start(self, scheduler, io_executor) -> None:
         """Begin polling. No-op when disabled or no probe provider exists."""
@@ -163,17 +187,29 @@ class GpuGuard:
         state. None counts one strike: DEVICE_LOST_AFTER_FAILURES
         consecutive poll strikes - or a single strike observed at a
         worker crash (any non-"poll" source) - declare the device lost.
+        The recovery callback fires OUTSIDE the lock: it schedules the
+        switch-back, which re-enters the guard (respawn_overlay).
         """
+        recovered = False
         with self._lock:
             if result is not None:
                 self._probe_fail_streak = 0
                 if self._device_lost:
                     self._device_lost = False
+                    recovered = True
                     self._event("gpu_device_recovered", source=source,
                                 free_mb=result.free_mb,
                                 total_mb=result.total_mb)
                     logger.info("GPU guard: GPU reachable again")
-                return
+        if recovered and self._on_device_recovered is not None:
+            try:
+                self._on_device_recovered()
+            except Exception:
+                logger.warning("GPU guard: on_device_recovered callback failed",
+                               exc_info=True)
+        if result is not None:
+            return
+        with self._lock:
             if str(self._cfg.get("device", "auto")).lower() == "cpu":
                 # The user never wanted cuda; nothing to fail over. Keep
                 # the streak at zero so an explicit-cpu period does not


### PR DESCRIPTION
Step 1, PR C (final) of the assistant build round. Builds on #180 + #181; closes out the GPU power-state failover spec requirements.

**Recovery (the dGPU returns):**
- The guard fires `on_device_recovered` on the lost -> recovered probe transition (outside its lock - the callback re-enters the guard).
- `AppControl.schedule_gpu_switchback` restarts a pinned-cpu worker onto the live config **once the app is idle**: retries each minute while busy, aborts if the GPU is lost again, skips while the model is intentionally asleep (never grab VRAM back mid-game - the wake respawn already lands on the live config), and skips when no pinned respawn ever happened (a probe blip; worker still on cuda). Toasts on the actual switch.
- `auto_sleep`'s busy check extracted to module-level `app_busy()` and shared by both callers.

**Startup (booting with the dGPU off):**
- `guard.prime()` runs one synchronous probe before the first worker spawn; a failed startup probe pins that first spawn to cpu + `cpu_fallback_model` instead of loading the cuda-sized model against a dead device. Cost: one probe (~100ms; bounded by the nvidia-smi 10s timeout).

**Docs:** features.md failover bullet now covers pinned respawns, startup, and switch-back; BACKLOG swaps the shipped CPU-floor entry for the WM_DEVICECHANGE deferral (hidden-window message pump; probe-based detection shipped instead); spec status line and the round plan mark step 1 MERGED (#180-#182).

Architecture note: no protected paths in this PR.

Tests: 3 StartupPrimeTests, 2 RecoveryCallbackTests, 5 SwitchbackTests. Suite 319.