### PR TITLE
feat: per-app meeting auto-record via the mic consent store (step 4, PR 1)

### DIFF
--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -43,3 +43,7 @@ fails if this table and the defaults file disagree on keys.
 | `gpu_guard_ladder` | `["large-v3", "medium", "small", "base"]` | Downgrade order as a JSON list (floor = last entry); non-list values are rejected and fall back to this default |
 | `gpu_guard_probe` | `null` | Force a probe backend (null = auto: pynvml, nvidia-smi) |
 | `cpu_fallback_model` | `base` | Model used when the GPU becomes unreachable (hybrid dGPU power-off) and transcription fails over to cpu |
+| `meeting_auto_record` | `false` | Auto-start a meeting recording when a watched app starts using the mic (per-app meeting auto-record) |
+| `meeting_watch_apps` | `["zoom.exe", "slack.exe", "teams.exe", "ms-teams.exe", "msteams", "discord.exe"]` | Watched apps: `*.exe` matches a desktop exe name exactly; a token without `.exe` matches an MSIX package family prefix. Browsers are deliberately absent (any tab audio would trigger) |
+| `meeting_watch_poll_seconds` | `5` | Mic consent-store poll interval |
+| `meeting_watch_stop_after_s` | `30` | Sustained mic release before an AUTO-started recording stops (manual recordings are never auto-stopped) |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -20,6 +20,15 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   diarization, speaker identification (Claude CLI with manual
   fallback), readable transcript, minutes generation, rename
   suggestion. Recording never waits on the pipeline.
+- **Per-app meeting auto-record** (off by default) - when a watched
+  communications app (Zoom, Slack, Teams, Discord; configurable) starts
+  using the microphone, recording auto-starts with a toast; when that
+  app releases the mic for `meeting_watch_stop_after_s`, the
+  auto-started recording stops through the normal save flow. Detection
+  reads the Windows mic-in-use consent store (capture-specific: an app
+  playing a notification sound never looks like a call) and only acts
+  on transitions it observes, so stale entries cannot false-trigger.
+  Manual recordings are never auto-stopped.
 - **Per-channel stereo diarization** - 3-tier cascade
   (balanced mix, per channel, raw audio) selectable per meeting from
   the save dialog.

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -16,7 +16,7 @@
 | 1 | GPU power-state failover (guard-owned, cpu_fallback_model) | GPU power-state resilience | MERGED (#180-#182) |
 | 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | NEEDS OWNER INPUT |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | QUEUED |
-| 4 | Per-app meeting auto-record (WASAPI session watch + app list) | Staged architecture, step 3 | QUEUED |
+| 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | IN PROGRESS |
 | 5 | In-app wake-word trainer (verifier first, full training later) | Wake-word model landscape | QUEUED |
 | 6 | NPU/OpenVINO backup-transcriber backend (committed scope) | NPU section | QUEUED |
 | - | Installer refresh (screens generated from docs/features/) | BACKLOG.md | QUEUED |
@@ -84,6 +84,38 @@ broadcasts, same constraint as power_events.py). Probe streak +
 crash-time probe covers detection within one poll interval (default
 30s) and instantly on any crash, which is when detection matters.
 Recorded in BACKLOG.md in PR C.
+
+## Step 4 plan - per-app meeting auto-record
+
+Requirement (spec, owner second intake): a configurable app list
+(Zoom, Slack huddles, Teams, ...); when a watched app is in a call,
+recording auto-starts. Manual trigger stays. Steps 2-3 being blocked
+on owner input, step 4 has no dependency on the listener and proceeds
+first (standing authorization).
+
+DELIBERATE DEVIATION from the spec's mechanism sketch: detection reads
+the Windows CapabilityAccessManager mic consent store (stdlib winreg)
+instead of WASAPI session enumeration. Rationale: session enumeration
+needs pycaw/comtypes (new dependencies) and primarily sees RENDER
+sessions (a notification sound would look like a call); the consent
+store is the OS's own mic-in-use indicator - capture-specific, zero
+dependencies, poll-cheap. Verified live on the dev machine 2026-07-04,
+which also surfaced the stale-entry hazard (a dead Slack version's
+entry stuck active) that dictates transition-only triggering.
+
+PRs:
+
+- **PR 1 - watcher module**: meeting_watch.py (consent-store probe,
+  per-entry transition detection with 2-poll debounce, auto-start via
+  meetings.toggle under the app lock, auto-stop only for auto-started
+  recordings after sustained release, disabled-state reset), four
+  config keys, wiring in __main__, features/defaults docs, fake-probe
+  test suite.
+- **PR 2 - tray surface**: settings toggle + watched-apps visibility
+  in the tray menu, manual-validation notes. Browser/Meet detection
+  stays out (any tab's audio would trigger); revisit with the
+  listener's voice command ("record the meeting") or a window-title
+  heuristic later.
 
 ## Progress log
 

--- a/tests/test_meeting_watch.py
+++ b/tests/test_meeting_watch.py
@@ -123,6 +123,35 @@ class TriggerTests(_WatchHarness):
         self._run_polls([{game: False}, {game: True}, {game: True}])
         self.assertEqual(self.app.meetings.toggles, 0)
 
+    def test_newly_watched_stale_entry_does_not_trigger(self):
+        # Review catch: the baseline covers ALL entries, so editing
+        # meeting_watch_apps mid-session cannot promote a stale
+        # always-active entry into a "transition".
+        self.app.cfg["meeting_watch_apps"] = ["zoom.exe"]
+        self._run_polls([{STALE_SLACK: True}, {STALE_SLACK: True}])
+        self.app.cfg["meeting_watch_apps"] = ["zoom.exe", "slack.exe"]
+        self._run_polls([{STALE_SLACK: True}] * 3)
+        self.assertEqual(self.app.meetings.toggles, 0)
+
+    def test_entry_appearing_active_is_a_real_acquire(self):
+        # The consent store only creates entries on actual mic use, so
+        # an entry APPEARING active (first-ever use, or a fresh app
+        # version directory) is a genuine transition.
+        self._run_polls([{}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 1)
+
+    def test_busy_at_debounce_retries_until_recordable(self):
+        # Review catch: a dictation in flight at the debounce moment
+        # must not lose the whole meeting - the start retries while the
+        # mic stays held.
+        self.app.state.emit("dictation_started", mode="dictation")
+        self._run_polls([{ZOOM: False}] + [{ZOOM: True}] * 3)
+        self.assertEqual(self.app.meetings.toggles, 0)
+        self.app.state.emit("idle", mode=None)
+        self._run_polls([{ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 1)
+        self.assertEqual(self.mode, "meeting")
+
     def test_manual_recording_already_running_is_left_alone(self):
         self.app.state.emit(MEETING_STARTED, mode="meeting")
         self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
@@ -158,6 +187,16 @@ class AutoStopTests(_WatchHarness):
         self.assertEqual(self.mode, None)
         self.assertIn("Meeting recording stopped",
                       self.notify.call_args[0][0])
+
+    def test_stop_timing_never_undershoots_the_configured_release(self):
+        # Review catch: round() stopped at 28s with poll=7/stop=30;
+        # the ceiling makes it 5 polls = 35s, never less than 30.
+        self.app.cfg["meeting_watch_poll_seconds"] = 7
+        self._start_auto_meeting()
+        self._run_polls([{ZOOM: False}] * 4)
+        self.assertEqual(self.mode, "meeting", "4 polls = 28s < 30s")
+        self._run_polls([{ZOOM: False}])
+        self.assertEqual(self.mode, None)
 
     def test_brief_release_then_reacquire_keeps_recording(self):
         self._start_auto_meeting()

--- a/tests/test_meeting_watch.py
+++ b/tests/test_meeting_watch.py
@@ -1,0 +1,235 @@
+"""Tests for whisper_sync.meeting_watch - per-app meeting auto-record.
+
+Everything runs against a fake consent-store probe and a fake app; no
+registry, no scheduler thread (check_once is driven directly). One
+integration test touches the real consent store read path on Windows
+to pin the does-not-crash contract.
+"""
+
+import threading
+import types
+import unittest
+from unittest import mock
+
+from whisper_sync import meeting_watch as mw
+from whisper_sync.meeting_watch import MeetingWatch, entry_matches
+from whisper_sync.state_manager import StateManager, MEETING_STARTED, IDLE
+
+ZOOM = "c:#program files#zoom#bin#zoom.exe"
+STALE_SLACK = "c:#users#x#appdata#local#slack#app-4.50.140#slack.exe"
+
+
+class _FakeMeetings:
+    """Toggle stand-in that mirrors the real mode contract."""
+
+    def __init__(self, app):
+        self.app = app
+        self.toggles = 0
+
+    def toggle(self):
+        self.toggles += 1
+        current = self.app.state.current
+        if current.mode == "meeting":
+            self.app.state.emit(IDLE, mode=None)
+        else:
+            self.app.state.emit(MEETING_STARTED, mode="meeting")
+
+
+class _FakeApp:
+    def __init__(self):
+        self.cfg = {
+            "meeting_auto_record": True,
+            "meeting_watch_apps": ["zoom.exe", "slack.exe", "msteams"],
+            "meeting_watch_poll_seconds": 5,
+            "meeting_watch_stop_after_s": 30,
+        }
+        self._lock = threading.RLock()
+        self.state = StateManager(None, {})
+        self.recorder = types.SimpleNamespace(is_recording=False)
+        self.meetings = _FakeMeetings(self)
+
+    def _can_record(self):
+        mode = self.state.current.mode
+        return mode is None or mode in ("transcribing", "done", "error")
+
+
+class _WatchHarness(unittest.TestCase):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.polls = []  # list of {entry: active} dicts, or None
+        self.watch = MeetingWatch(self.app, read_entries=self._next_poll)
+        p = mock.patch.object(mw, "notify")
+        self.notify = p.start()
+        self.addCleanup(p.stop)
+
+    def _next_poll(self):
+        return self.polls.pop(0) if self.polls else {}
+
+    def _run_polls(self, snapshots):
+        # Count-driven, never consumption-driven: a DISABLED watcher
+        # returns before reading the store, so `while self.polls` would
+        # spin forever (this exact bug hung the first suite run).
+        self.polls = list(snapshots)
+        for _ in snapshots:
+            self.watch.check_once()
+
+    @property
+    def mode(self):
+        return self.app.state.current.mode
+
+
+class TriggerTests(_WatchHarness):
+    def test_observed_transition_plus_debounce_starts_recording(self):
+        self._run_polls([
+            {ZOOM: False},  # baseline
+            {ZOOM: True},   # transition observed (streak 1)
+            {ZOOM: True},   # debounce satisfied -> start
+        ])
+        self.assertEqual(self.app.meetings.toggles, 1)
+        self.assertEqual(self.mode, "meeting")
+        self.assertIn("Meeting recording started",
+                      self.notify.call_args[0][0])
+
+    def test_entry_already_active_at_baseline_never_triggers(self):
+        # The stale-entry hazard: a dead app version's entry can be
+        # stuck active forever - only observed transitions count.
+        self._run_polls([{STALE_SLACK: True}] * 5)
+        self.assertEqual(self.app.meetings.toggles, 0)
+
+    def test_one_poll_blip_does_not_trigger(self):
+        self._run_polls([
+            {ZOOM: False},
+            {ZOOM: True},   # mic permission check blip
+            {ZOOM: False},
+            {ZOOM: False},
+        ])
+        self.assertEqual(self.app.meetings.toggles, 0)
+
+    def test_no_retrigger_while_continuously_active(self):
+        self._run_polls([{ZOOM: False}] + [{ZOOM: True}] * 6)
+        self.assertEqual(self.app.meetings.toggles, 1)
+
+    def test_stale_sibling_does_not_mask_the_live_entry(self):
+        live = "c:#users#x#appdata#local#slack#app-4.50.143#slack.exe"
+        self._run_polls([
+            {STALE_SLACK: True, live: False},
+            {STALE_SLACK: True, live: True},
+            {STALE_SLACK: True, live: True},
+        ])
+        self.assertEqual(self.app.meetings.toggles, 1)
+
+    def test_unwatched_app_is_ignored(self):
+        game = "d:#games#overwatch#overwatch.exe"
+        self._run_polls([{game: False}, {game: True}, {game: True}])
+        self.assertEqual(self.app.meetings.toggles, 0)
+
+    def test_manual_recording_already_running_is_left_alone(self):
+        self.app.state.emit(MEETING_STARTED, mode="meeting")
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 0)
+        # And the manual recording is never auto-stopped afterwards.
+        self._run_polls([{ZOOM: False}] * 8)
+        self.assertEqual(self.mode, "meeting")
+
+    def test_second_meeting_after_release_retriggers(self):
+        self._run_polls([
+            {ZOOM: False},
+            {ZOOM: True}, {ZOOM: True},              # meeting 1 starts
+        ])
+        # meeting 1 ends: sustained release auto-stops (6 polls at 5s/30s)
+        self._run_polls([{ZOOM: False}] * 6)
+        self.assertEqual(self.mode, None)
+        # meeting 2: a fresh transition triggers again
+        self._run_polls([{ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 3)  # start, stop, start
+
+
+class AutoStopTests(_WatchHarness):
+    def _start_auto_meeting(self):
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.mode, "meeting")
+
+    def test_sustained_release_stops_the_auto_started_recording(self):
+        self._start_auto_meeting()
+        # 30s at 5s polls = 6 release polls
+        self._run_polls([{ZOOM: False}] * 5)
+        self.assertEqual(self.mode, "meeting", "not yet - needs 6 polls")
+        self._run_polls([{ZOOM: False}])
+        self.assertEqual(self.mode, None)
+        self.assertIn("Meeting recording stopped",
+                      self.notify.call_args[0][0])
+
+    def test_brief_release_then_reacquire_keeps_recording(self):
+        self._start_auto_meeting()
+        self._run_polls([{ZOOM: False}] * 3 + [{ZOOM: True}] * 2
+                        + [{ZOOM: False}] * 5)
+        self.assertEqual(self.mode, "meeting",
+                         "release counter must reset on reacquire")
+
+    def test_manual_stop_relinquishes_ownership(self):
+        self._start_auto_meeting()
+        self.app.meetings.toggle()  # user stops via hotkey
+        self.assertEqual(self.mode, None)
+        toggles = self.app.meetings.toggles
+        self._run_polls([{ZOOM: False}] * 8)
+        self.assertEqual(self.app.meetings.toggles, toggles,
+                         "watcher must not stop or restart anything")
+
+
+class LifecycleTests(_WatchHarness):
+    def test_disabled_is_inert_and_reenabling_reseeds_baseline(self):
+        self.app.cfg["meeting_auto_record"] = False
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 0)
+        # Re-enable while zoom is mid-call: the first poll is a fresh
+        # baseline, so the already-active entry must not trigger.
+        self.app.cfg["meeting_auto_record"] = True
+        self._run_polls([{ZOOM: True}] * 3)
+        self.assertEqual(self.app.meetings.toggles, 0)
+
+    def test_unreadable_store_changes_nothing(self):
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, None, {ZOOM: True}])
+        # None polls carry no information; the streak continues on the
+        # next real read.
+        self.assertEqual(self.app.meetings.toggles, 1)
+
+    def test_start_registers_one_poll_job(self):
+        calls = []
+        sched = types.SimpleNamespace(
+            call_every=lambda s, fn, label=None: calls.append((s, label)))
+        self.watch.start(sched, io_executor=types.SimpleNamespace(
+            submit_native=lambda label, fn: fn()))
+        self.assertEqual(calls, [(5.0, "meeting-watch")])
+
+
+class MatchingTests(unittest.TestCase):
+    def test_exe_token_matches_leaf_only(self):
+        self.assertTrue(entry_matches(ZOOM, ["zoom.exe"]))
+        self.assertFalse(
+            entry_matches("c:#tools#zoom.exe#helper.exe", ["zoom.exe"]),
+            "an exe token must match the path leaf, never a segment")
+
+    def test_packaged_token_matches_family_prefix(self):
+        self.assertTrue(entry_matches(
+            "msteams_8wekyb3d8bbwe", ["msteams"]))
+        self.assertFalse(entry_matches(
+            "microsoft.windowscamera_8wekyb3d8bbwe", ["msteams"]))
+
+    def test_matching_is_case_insensitive_and_skips_blanks(self):
+        self.assertTrue(entry_matches(ZOOM, ["ZOOM.EXE"]))
+        self.assertFalse(entry_matches(ZOOM, ["", "  "]))
+
+
+class RealStoreTests(unittest.TestCase):
+    def test_read_mic_entries_does_not_crash_on_this_machine(self):
+        result = mw.read_mic_entries()
+        # Windows: a dict (possibly empty) of lowercase ids -> bool.
+        # Elsewhere: None. Either way, never an exception.
+        if result is not None:
+            for key, value in result.items():
+                self.assertEqual(key, key.lower())
+                self.assertIsInstance(value, bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -147,6 +147,10 @@ class WhisperSync:
         self.auto_sleep = AutoSleep(self)
         self._click_router = ClickRouter(single=self._do_left_click,
                                          double=self.auto_sleep.toggle)
+        # Per-app meeting auto-record (meeting_watch.py): mic consent
+        # store polling; auto-starts/stops recordings for watched apps.
+        from .meeting_watch import MeetingWatch
+        self.meeting_watch = MeetingWatch(self)
 
     @staticmethod
     def _migrate_data():
@@ -506,6 +510,10 @@ class WhisperSync:
 
         # Model auto-sleep: idle checker + activity subscription.
         self.auto_sleep.start(_sched)
+
+        # Per-app meeting auto-record (assistant round step 4): polls
+        # the mic consent store; inert unless meeting_auto_record.
+        self.meeting_watch.start(_sched, IO)
 
         # Suspend/resume awareness (hardware-resilience spec H1): both
         # transitions land in gpu-guard.jsonl for crash-time correlation,

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -42,5 +42,16 @@
     "base"
   ],
   "gpu_guard_probe": null,
-  "cpu_fallback_model": "base"
+  "cpu_fallback_model": "base",
+  "meeting_auto_record": false,
+  "meeting_watch_apps": [
+    "zoom.exe",
+    "slack.exe",
+    "teams.exe",
+    "ms-teams.exe",
+    "msteams",
+    "discord.exe"
+  ],
+  "meeting_watch_poll_seconds": 5,
+  "meeting_watch_stop_after_s": 30
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -34,6 +34,8 @@ _VALID_KEYS = {
     "gpu_guard", "gpu_guard_low_vram_mb", "gpu_guard_poll_seconds",
     "gpu_guard_ladder", "gpu_guard_probe",
     "cpu_fallback_model",
+    "meeting_auto_record", "meeting_watch_apps",
+    "meeting_watch_poll_seconds", "meeting_watch_stop_after_s",
 }
 
 

--- a/whisper_sync/meeting_watch.py
+++ b/whisper_sync/meeting_watch.py
@@ -34,6 +34,7 @@ disabled or off-Windows.
 
 from __future__ import annotations
 
+import math
 import os
 
 from .logger import logger
@@ -133,6 +134,7 @@ class MeetingWatch:
         self._read_entries = read_entries
         self._prev: dict[str, bool] = {}
         self._streak: dict[str, int] = {}  # entry -> active polls observed
+        self._handled: set[str] = set()    # entries whose call is dealt with
         self._auto_started_by: str | None = None
         self._release_polls = 0
         self._primed = False  # first enabled poll only seeds the baseline
@@ -173,6 +175,7 @@ class MeetingWatch:
                 # treating everything that changed meanwhile as fresh.
                 self._prev.clear()
                 self._streak.clear()
+                self._handled.clear()
                 self._auto_started_by = None
                 self._release_polls = 0
                 self._primed = False
@@ -181,42 +184,53 @@ class MeetingWatch:
         if entries is None:
             return
         apps = cfg.get("meeting_watch_apps") or []
-        watched = {eid: active for eid, active in entries.items()
-                   if entry_matches(eid, apps)}
         if not self._primed:
-            # Baseline: an entry already active now may be a stale
-            # leftover from a dead app version - only transitions the
-            # watcher OBSERVES count (module docstring).
-            self._prev = watched
+            # Baseline over ALL entries, not just watched ones: an entry
+            # already active now may be a stale leftover from a dead app
+            # version, and it must stay baseline even if the watch list
+            # is edited later to include it (review catch). An entry that
+            # APPEARS later is a real acquire - the consent store only
+            # creates entries on actual mic use.
+            self._prev = entries
             self._primed = True
             return
-        for eid, active in watched.items():
+        for eid, active in entries.items():
             if not active:
                 self._streak.pop(eid, None)
+                self._handled.discard(eid)
                 continue
             if not self._prev.get(eid, False) and eid not in self._streak:
-                self._streak[eid] = 1  # observed transition
+                self._streak[eid] = 1  # observed transition (or appearance)
             elif eid in self._streak and self._streak[eid] < TRIGGER_AFTER_POLLS:
                 self._streak[eid] += 1
-                if self._streak[eid] >= TRIGGER_AFTER_POLLS:
-                    self._maybe_start(eid)
-        self._prev = watched
-        self._maybe_stop(watched)
+            if (self._streak.get(eid, 0) >= TRIGGER_AFTER_POLLS
+                    and eid not in self._handled
+                    and entry_matches(eid, apps)):
+                # Retried every poll while the mic stays held (review
+                # catch): an app that is busy dictating at the debounce
+                # moment must not lose the whole meeting.
+                if self._maybe_start(eid):
+                    self._handled.add(eid)
+        self._prev = entries
+        self._maybe_stop(entries)
 
     # -- Start / stop decisions -------------------------------------------------
 
-    def _maybe_start(self, entry_id: str) -> None:
+    def _maybe_start(self, entry_id: str) -> bool:
+        """Try to auto-start. True = this call is dealt with (started,
+        or someone is already recording it); False = busy, retry next
+        poll while the mic stays held."""
         label = _label(entry_id)
         with self.app._lock:
             current = self.app.state.current if self.app.state else None
             mode = current.mode if current else None
             if mode == "meeting" or self.app.recorder.is_recording:
-                return  # already recording; that meeting is handled
+                return True  # already recording; that meeting is handled
             if not self.app._can_record():
                 logger.info(
                     f"meeting watch: {label} is in a call but the app is "
-                    "busy; not auto-starting")
-                return
+                    "busy; retrying while the mic stays held")
+                return False
             logger.info(
                 f"meeting watch: {label} started using the mic; "
                 "auto-starting the meeting recording")
@@ -228,6 +242,7 @@ class MeetingWatch:
         notify("Meeting recording started",
                f"{label} is in a call. Stop with the meeting hotkey "
                "or the tray if unwanted.")
+        return True
 
     def _maybe_stop(self, watched: dict) -> None:
         if self._auto_started_by is None:
@@ -244,7 +259,9 @@ class MeetingWatch:
             return
         poll = max(float(self.app.cfg.get("meeting_watch_poll_seconds", 5)), 1.0)
         stop_after = float(self.app.cfg.get("meeting_watch_stop_after_s", 30))
-        if self._release_polls + 1 < max(1, round(stop_after / poll)):
+        # Ceiling, never round: the release duration must be AT LEAST
+        # stop_after (review catch: poll=7/stop=30 rounded to 28s).
+        if self._release_polls + 1 < max(1, math.ceil(stop_after / poll)):
             self._release_polls += 1
             return
         entry = self._auto_started_by

--- a/whisper_sync/meeting_watch.py
+++ b/whisper_sync/meeting_watch.py
@@ -1,0 +1,262 @@
+"""Per-app meeting auto-record - assistant build round, step 4.
+
+When a configured communications app (Zoom, Slack, Teams, ...) starts
+using the microphone, a meeting recording auto-starts; when that app
+releases the mic and stays quiet, the auto-started recording stops
+(through the normal stop path, save dialog included). Manual hotkey
+control is untouched, and a manually started recording is never
+auto-stopped.
+
+Detection source: the Windows CapabilityAccessManager consent store
+(HKCU ConsentStore/microphone) - the registry tree behind the OS
+mic-in-use indicator. Desktop apps live under ``NonPackaged`` keyed by
+exe path ('#' separators); MSIX apps sit directly under ``microphone``
+keyed by package family name. Each entry carries LastUsedTimeStart /
+LastUsedTimeStop FILETIMEs, and ``LastUsedTimeStop == 0`` means the app
+holds the mic RIGHT NOW. Reading it is stdlib winreg - no COM, no new
+dependencies - and it is capture-specific: an app merely playing audio
+(a notification sound) can never look like a call. This deliberately
+replaces the WASAPI session enumeration sketched in the direction spec
+(which would have needed pycaw/comtypes and sees render sessions).
+
+Stale-entry hazard (observed on the dev machine): an app version that
+died mid-call leaves its entry active forever (old Slack app-x.y.z
+directories). The watcher therefore acts ONLY on transitions it
+observes between polls: an entry already active when watching begins
+never triggers, and per-ENTRY tracking means a stale sibling entry
+cannot mask the live app version's entry.
+
+Feature pattern (gpu_guard precedent): one owning module, flat config
+keys (meeting_auto_record, meeting_watch_apps,
+meeting_watch_poll_seconds, meeting_watch_stop_after_s), inert when
+disabled or off-Windows.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .logger import logger
+from .notifications import notify
+
+_CONSENT_ROOT = (
+    r"SOFTWARE\Microsoft\Windows\CurrentVersion"
+    r"\CapabilityAccessManager\ConsentStore\microphone"
+)
+
+# Consecutive active polls before an observed transition triggers a
+# recording - filters sub-poll blips like a mic permission check.
+TRIGGER_AFTER_POLLS = 2
+
+
+def read_mic_entries() -> dict[str, bool] | None:
+    """The consent store as {entry_id: holds_mic_now}.
+
+    entry_id is the NonPackaged exe path (with '#' separators, as
+    stored) or the package family name, lowercased. Entries that never
+    used the mic (no timestamps) are omitted. Returns None when the
+    store is unreadable (non-Windows or registry error) - callers must
+    treat that as "no information", never as "everything released".
+    """
+    if os.name != "nt":
+        return None
+    import winreg
+
+    entries: dict[str, bool] = {}
+    try:
+        _scan_tree(winreg, _CONSENT_ROOT, entries, skip={"nonpackaged"})
+        _scan_tree(winreg, _CONSENT_ROOT + r"\NonPackaged", entries, skip=set())
+    except OSError as exc:
+        logger.debug(f"meeting watch: consent store unreadable: {exc}")
+        return None
+    return entries
+
+
+def _scan_tree(winreg, path: str, out: dict, skip: set) -> None:
+    """Collect {entry_id: active} from one consent-store tree."""
+    try:
+        root = winreg.OpenKey(winreg.HKEY_CURRENT_USER, path)
+    except FileNotFoundError:
+        return
+    with root:
+        index = 0
+        while True:
+            try:
+                sub = winreg.EnumKey(root, index)
+            except OSError:
+                break  # end of enumeration
+            index += 1
+            if sub.lower() in skip:
+                continue
+            try:
+                with winreg.OpenKey(root, sub) as key:
+                    start, _ = winreg.QueryValueEx(key, "LastUsedTimeStart")
+                    stop, _ = winreg.QueryValueEx(key, "LastUsedTimeStop")
+            except OSError:
+                continue  # no usage values recorded for this app
+            if start:
+                out[sub.lower()] = stop == 0
+
+
+def entry_matches(entry_id: str, app_names) -> bool:
+    """True when a consent-store entry belongs to a watched app.
+
+    Desktop entries are full '#'-separated paths: a configured
+    ``*.exe`` token must match the path LEAF exactly (never a
+    substring - '#zoom.exe#helper.exe' belongs to helper.exe).
+    Packaged entries are package family names (MSTeams_8wekyb...): a
+    token without '.exe' matches as a case-insensitive prefix.
+    """
+    entry = entry_id.lower()
+    for name in app_names or ():
+        token = str(name).strip().lower()
+        if not token:
+            continue
+        if token.endswith(".exe"):
+            if entry.rsplit("#", 1)[-1] == token:
+                return True
+        elif entry.startswith(token):
+            return True
+    return False
+
+
+def _label(entry_id: str) -> str:
+    """Human-readable app name for toasts/logs (exe leaf or family)."""
+    return entry_id.rsplit("#", 1)[-1]
+
+
+class MeetingWatch:
+    """Owns per-app auto-record; reads services through ``app``."""
+
+    def __init__(self, app, read_entries=read_mic_entries):
+        self.app = app
+        self._read_entries = read_entries
+        self._prev: dict[str, bool] = {}
+        self._streak: dict[str, int] = {}  # entry -> active polls observed
+        self._auto_started_by: str | None = None
+        self._release_polls = 0
+        self._primed = False  # first enabled poll only seeds the baseline
+
+    # -- Wiring (called from run()) -------------------------------------------
+
+    def start(self, scheduler, io_executor) -> None:
+        """Register the poll tick. Runs even while disabled (the check
+        is a dict lookup); enabling from the tray needs no restart."""
+        poll = float(self.app.cfg.get("meeting_watch_poll_seconds", 5))
+        # Registry scans are milliseconds, but keep the scheduler tick
+        # to a pure enqueue (short-jobs contract, gpu-guard precedent).
+        scheduler.call_every(
+            poll,
+            lambda: io_executor.submit_native("meeting-watch", self.check_once),
+            label="meeting-watch",
+        )
+        enabled = bool(self.app.cfg.get("meeting_auto_record", False))
+        logger.info(
+            f"Meeting watch registered (poll={poll:.0f}s, "
+            f"auto-record {'ON' if enabled else 'off'})"
+        )
+
+    # -- Poll ------------------------------------------------------------------
+
+    def check_once(self) -> None:
+        """One consent-store poll. Runs on the IO executor."""
+        try:
+            self._check()
+        except Exception:
+            logger.debug("meeting watch check failed", exc_info=True)
+
+    def _check(self) -> None:
+        cfg = self.app.cfg
+        if not cfg.get("meeting_auto_record", False):
+            if self._primed:
+                # Reset so re-enabling re-seeds the baseline instead of
+                # treating everything that changed meanwhile as fresh.
+                self._prev.clear()
+                self._streak.clear()
+                self._auto_started_by = None
+                self._release_polls = 0
+                self._primed = False
+            return
+        entries = self._read_entries()
+        if entries is None:
+            return
+        apps = cfg.get("meeting_watch_apps") or []
+        watched = {eid: active for eid, active in entries.items()
+                   if entry_matches(eid, apps)}
+        if not self._primed:
+            # Baseline: an entry already active now may be a stale
+            # leftover from a dead app version - only transitions the
+            # watcher OBSERVES count (module docstring).
+            self._prev = watched
+            self._primed = True
+            return
+        for eid, active in watched.items():
+            if not active:
+                self._streak.pop(eid, None)
+                continue
+            if not self._prev.get(eid, False) and eid not in self._streak:
+                self._streak[eid] = 1  # observed transition
+            elif eid in self._streak and self._streak[eid] < TRIGGER_AFTER_POLLS:
+                self._streak[eid] += 1
+                if self._streak[eid] >= TRIGGER_AFTER_POLLS:
+                    self._maybe_start(eid)
+        self._prev = watched
+        self._maybe_stop(watched)
+
+    # -- Start / stop decisions -------------------------------------------------
+
+    def _maybe_start(self, entry_id: str) -> None:
+        label = _label(entry_id)
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            mode = current.mode if current else None
+            if mode == "meeting" or self.app.recorder.is_recording:
+                return  # already recording; that meeting is handled
+            if not self.app._can_record():
+                logger.info(
+                    f"meeting watch: {label} is in a call but the app is "
+                    "busy; not auto-starting")
+                return
+            logger.info(
+                f"meeting watch: {label} started using the mic; "
+                "auto-starting the meeting recording")
+            # toggle() re-enters the same RLock, wakes a sleeping model,
+            # and claims the mode atomically (try_transition).
+            self.app.meetings.toggle()
+            self._auto_started_by = entry_id
+            self._release_polls = 0
+        notify("Meeting recording started",
+               f"{label} is in a call. Stop with the meeting hotkey "
+               "or the tray if unwanted.")
+
+    def _maybe_stop(self, watched: dict) -> None:
+        if self._auto_started_by is None:
+            return
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            if (current.mode if current else None) != "meeting":
+                # Stopped manually (or errored) - no longer ours to manage.
+                self._auto_started_by = None
+                self._release_polls = 0
+                return
+        if watched.get(self._auto_started_by, False):
+            self._release_polls = 0
+            return
+        poll = max(float(self.app.cfg.get("meeting_watch_poll_seconds", 5)), 1.0)
+        stop_after = float(self.app.cfg.get("meeting_watch_stop_after_s", 30))
+        if self._release_polls + 1 < max(1, round(stop_after / poll)):
+            self._release_polls += 1
+            return
+        entry = self._auto_started_by
+        self._auto_started_by = None
+        self._release_polls = 0
+        label = _label(entry)
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            if (current.mode if current else None) != "meeting":
+                return  # raced with a manual stop
+            logger.info(
+                f"meeting watch: {label} released the mic; stopping the "
+                "auto-started recording")
+            self.app.meetings.toggle()
+        notify("Meeting recording stopped", f"{label} left the call.")


### PR DESCRIPTION
Assistant build round, step 4 PR 1 (plan: docs/plans/2026-07-04-assistant-build-round.md). Steps 2-3 wait on owner phrase choices; step 4 has no listener dependency, so it proceeds first under the standing authorization.

**Behavior** (off by default, `meeting_auto_record`):
- A watched app (`meeting_watch_apps`: Zoom, Slack, Teams, Discord defaults) starts **using the microphone** -> meeting recording auto-starts with a toast.
- The app releases the mic for `meeting_watch_stop_after_s` (30s) -> the auto-started recording stops through the normal save flow.
- Manual recordings are never auto-stopped; a manual stop relinquishes watcher ownership; a sleeping model wakes and records disk-first (existing toggle semantics).

**Detection - deliberate deviation from the spec sketch:** reads the Windows CapabilityAccessManager mic consent store (stdlib `winreg`, the registry behind the OS mic-in-use indicator) instead of WASAPI session enumeration. Capture-specific (a notification sound can never look like a call), zero new dependencies, poll-cheap. Verified live on the dev machine, which surfaced the stale-entry hazard: a dead Slack version's entry stuck `active` since June. The watcher therefore acts only on per-entry transitions it observes between polls - baseline-active entries never trigger, and a stale sibling cannot mask the live app version's entry.

Browsers are deliberately NOT in the default list (any tab's mic use would trigger); Meet detection is deferred to the listener's voice command or a later heuristic (noted in the plan doc).

Feature pattern (gpu_guard precedent): one owning module, flat config keys (defaults + `_VALID_KEYS` + features/defaults docs in this PR), inert when disabled or off-Windows.

Architecture note: no protected paths. Start/stop go through `meetings.toggle()` under the shared app RLock (atomic mode claim via try_transition).

Tests: 18 new (transition/debounce/stale-entry/blip/retrigger semantics, auto-stop ownership, disabled-state reseed, matching rules, real-store smoke). Suite 338, exit code verified directly.