### PR TITLE
feat: tray toggle for meeting auto-record (step 4, PR 2)

### DIFF
--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -20,10 +20,11 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   diarization, speaker identification (Claude CLI with manual
   fallback), readable transcript, minutes generation, rename
   suggestion. Recording never waits on the pipeline.
-- **Per-app meeting auto-record** (off by default) - when a watched
-  communications app (Zoom, Slack, Teams, Discord; configurable) starts
-  using the microphone, recording auto-starts with a toast; when that
-  app releases the mic for `meeting_watch_stop_after_s`, the
+- **Per-app meeting auto-record** (off by default; toggle in tray
+  Settings > Meeting Auto-Record) - when a watched communications app
+  (Zoom, Slack, Teams, Discord; configurable) starts using the
+  microphone, recording auto-starts with a toast; when that app
+  releases the mic for `meeting_watch_stop_after_s`, the
   auto-started recording stops through the normal save flow. Detection
   reads the Windows mic-in-use consent store (capture-specific: an app
   playing a notification sound never looks like a call) and only acts

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -160,3 +160,25 @@ PRs:
   auto_sleep._busy extracted to module-level app_busy() and shared.
   BACKLOG: CPU-floor entry removed (shipped); WM_DEVICECHANGE instant
   detection recorded as the deliberate deferral.
+
+- **2026-07-04 (step 4 PR 1 merged, #183)**: meeting_watch.py shipped
+  per the step 4 plan. Review caught three real issues, all fixed with
+  regression tests: round() could stop an auto-started recording
+  before the configured release window (now math.ceil); the baseline
+  only covered watch-listed entries, so editing meeting_watch_apps
+  mid-session could promote a stale always-active entry into a fake
+  transition (baseline now covers ALL entries, filter applies at the
+  trigger decision); and a busy app at the debounce moment lost the
+  meeting permanently (start now retries every poll while the mic
+  stays held, via a handled-set). Suite 342. Session lesson recorded:
+  verify suite exit codes DIRECTLY, never through a tail pipe (a
+  test-harness infinite loop hid behind tail's exit 0 for a while).
+
+- **2026-07-04 (step 4 PR 2)**: tray surface. Settings > Meeting
+  Auto-Record submenu: Enabled checkbox (_toggle_meeting_auto_record;
+  the always-registered poll reads the flag per tick and re-seeds its
+  baseline on re-enable) plus a disabled info line listing the watched
+  apps. Two pre-existing pyflakes nits fixed in the touched files.
+  Manual validation for the owner: enable the toggle, join any Zoom or
+  Slack call, expect the start toast within ~10s (two 5s polls) and
+  the stop + save dialog ~30s after leaving.

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -65,7 +65,6 @@ def _iter_texts(menu):
         item = stack.pop()
         if isinstance(item, _MenuItem):
             out.append(item.text)
-            sub = item.kw.get("submenu") or (item.action if isinstance(item.action, _Menu) else None)
             if isinstance(item.action, _Menu):
                 stack.extend(item.action.items)
         elif isinstance(item, _Menu):
@@ -177,6 +176,18 @@ class MenuBuildTests(unittest.TestCase):
             before = self.app.cfg.get("incognito", False)
             self.menu._toggle_incognito()
             self.assertNotEqual(self.app.cfg["incognito"], before)
+
+    def test_toggle_meeting_auto_record_flips_and_saves(self):
+        with mock.patch.object(config, "save") as save:
+            self.menu._toggle_meeting_auto_record()
+            self.assertTrue(self.app.cfg["meeting_auto_record"])
+            save.assert_called_once()
+
+    def test_menu_shows_meeting_auto_record_section(self):
+        menu = self.menu.build()
+        texts = " | ".join(_iter_texts(menu))
+        self.assertIn("Meeting Auto-Record", texts)
+        self.assertIn("Watches: zoom", texts)
 
     def test_menu_callback_swallows_pystray_args(self):
         calls = []

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -479,6 +479,16 @@ class TrayMenu:
                     pystray.MenuItem(f"Backup Model\t{backup_model_cfg}",
                                      pystray.Menu(*backup_model_items)),
                 )),
+                pystray.MenuItem("Meeting Auto-Record", pystray.Menu(
+                    pystray.MenuItem(
+                        "Enabled",
+                        lambda: self._toggle_meeting_auto_record(),
+                        checked=lambda item: self.app.cfg.get("meeting_auto_record", False),
+                    ),
+                    pystray.MenuItem(
+                        f"  Watches: {self._meeting_watch_apps_label()}",
+                        None, enabled=False),
+                )),
                 pystray.MenuItem(f"Diarization (Speaker Detection)\t{primary_label}",
                                  pystray.Menu(*diarize_sub_items)),
                 pystray.Menu.SEPARATOR,
@@ -625,7 +635,7 @@ class TrayMenu:
 
                 tk.Label(dlg, text="Move Existing Recordings?",
                          font=("Segoe UI", 11, "bold"), bg=bg, fg=fg).pack(pady=(14, 4))
-                tk.Label(dlg, text=f"Move files from current folder to new location?",
+                tk.Label(dlg, text="Move files from current folder to new location?",
                          font=("Segoe UI", 9), bg=bg, fg=fg_dim).pack(pady=(0, 4))
                 tk.Label(dlg, text=f"{current}",
                          font=("Segoe UI", 8), bg=bg, fg=fg_dim).pack()
@@ -832,6 +842,20 @@ class TrayMenu:
             if gpu:
                 return f"Auto ({gpu})"
             return "Auto (CPU)"
+
+    def _toggle_meeting_auto_record(self):
+        cfg = self.app.cfg
+        cfg["meeting_auto_record"] = not cfg.get("meeting_auto_record", False)
+        state = "on" if cfg["meeting_auto_record"] else "off"
+        logger.info(f"Meeting auto-record: {state}")
+        # The watcher poll is always registered; it reads this flag per
+        # tick and re-seeds its baseline on re-enable (meeting_watch).
+        self._save_and_refresh()
+
+    def _meeting_watch_apps_label(self) -> str:
+        apps = self.app.cfg.get("meeting_watch_apps") or []
+        names = [str(a).replace(".exe", "") for a in apps]
+        return ", ".join(dict.fromkeys(names)) or "none"
 
     def _toggle_always_available_dictation(self):
         self.app.cfg["always_available_dictation"] = not self.app.cfg.get("always_available_dictation", True)


### PR DESCRIPTION
Step 4, PR 2 (final) of the meeting auto-record feature. Builds on #183.

- **Settings > Meeting Auto-Record**: Enabled checkbox toggling `meeting_auto_record`, plus a disabled info line listing the watched apps. The watcher's poll is always registered and reads the flag per tick, re-seeding its transition baseline on re-enable - so the toggle needs no restart.
- features.md now points at the toggle.
- Hygiene in touched files (pyflakes): dead f-string prefix in the output-folder dialog, unused local in the test menu-text flattener.

Manual validation for the owner (noted in the plan doc): enable the toggle, join any Zoom/Slack call, expect the start toast within ~10s (two 5s polls) and the auto-stop + save dialog ~30s after leaving the call.

Tests: toggle flips + saves config; full-menu build asserts the new section and watched-apps line against real shipped defaults. Suite 344.