### PR TITLE
feat: auto-record settings - Record/Ask/Ignore per app, detect, opt-in/out toasts

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -47,6 +47,12 @@ same PR that defers them.
   [docs/features/](features/) - a features screen, a
   shortcuts/interaction screen, and a defaults/configuration screen -
   so the installer stays current automatically.
+- **Streaming dictation ("fill as it goes")** - live word-by-word
+  insertion with rolling self-correction for paste-unfriendly apps.
+  Owner-floated, explicitly deferred (2026-07-04 third intake). A
+  different ASR architecture (streaming zipformer / whisper-streaming
+  partial hypotheses + edit-in-place delivery), not a config flip on
+  the batch pipeline (specs/2026-07-04-voice-assistant-direction.md).
 
 ## Hygiene
 

--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -43,7 +43,10 @@ fails if this table and the defaults file disagree on keys.
 | `gpu_guard_ladder` | `["large-v3", "medium", "small", "base"]` | Downgrade order as a JSON list (floor = last entry); non-list values are rejected and fall back to this default |
 | `gpu_guard_probe` | `null` | Force a probe backend (null = auto: pynvml, nvidia-smi) |
 | `cpu_fallback_model` | `base` | Model used when the GPU becomes unreachable (hybrid dGPU power-off) and transcription fails over to cpu |
-| `meeting_auto_record` | `false` | Auto-start a meeting recording when a watched app starts using the mic (per-app meeting auto-record) |
-| `meeting_watch_apps` | `["zoom.exe", "slack.exe", "teams.exe", "ms-teams.exe", "msteams", "discord.exe"]` | Watched apps: `*.exe` matches a desktop exe name exactly; a token without `.exe` matches an MSIX package family prefix. Browsers are deliberately absent (any tab audio would trigger) |
+| `meeting_auto_record` | `false` | Master toggle for per-app meeting auto-record |
+| `meeting_watch_apps` | zoom/slack/teams/ms-teams/msteams `record`, discord `ask` | Map of app token to state: `record` (auto-start + opt-in toast), `ask` (opt-out toast offers Record), `ignore` (silent). `*.exe` tokens match a desktop exe name exactly; a token without `.exe` matches an MSIX package family prefix. Browsers are deliberately absent (any tab audio would trigger). Legacy list form reads as all-`record` |
 | `meeting_watch_poll_seconds` | `5` | Mic consent-store poll interval |
 | `meeting_watch_stop_after_s` | `30` | Sustained mic release before an AUTO-started recording stops (manual recordings are never auto-stopped) |
+| `meeting_watch_toasts` | `true` | Master toggle for auto-record toasts |
+| `meeting_watch_toast_optin` | `true` | Toast when auto-recording starts ("Don't record" discards silently) |
+| `meeting_watch_toast_optout` | `true` | Toast when an ask-state app is in a call ("Record" starts one-click) |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -20,16 +20,20 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   diarization, speaker identification (Claude CLI with manual
   fallback), readable transcript, minutes generation, rename
   suggestion. Recording never waits on the pipeline.
-- **Per-app meeting auto-record** (off by default; toggle in tray
-  Settings > Meeting Auto-Record) - when a watched communications app
-  (Zoom, Slack, Teams, Discord; configurable) starts using the
-  microphone, recording auto-starts with a toast; when that app
-  releases the mic for `meeting_watch_stop_after_s`, the
-  auto-started recording stops through the normal save flow. Detection
-  reads the Windows mic-in-use consent store (capture-specific: an app
-  playing a notification sound never looks like a call) and only acts
-  on transitions it observes, so stale entries cannot false-trigger.
-  Manual recordings are never auto-stopped.
+- **Per-app meeting auto-record** (off by default; Settings > Meeting
+  Auto-Record) - each app is Record, Ask, or Ignore. Record apps
+  auto-start a recording when they begin using the microphone (opt-in
+  toast with a one-click "Don't record" that discards silently) and
+  auto-stop through the normal save flow after
+  `meeting_watch_stop_after_s` of mic release. Ask apps never record
+  but toast a one-click "Record" offer. Ignore apps are fully silent.
+  "Detect apps..." populates the list from every app that has ever
+  used the mic (new apps arrive as Ignore). Toasts have a master
+  toggle plus separate opt-in/opt-out toggles. Detection reads the
+  Windows mic-in-use consent store (capture-specific: an app playing
+  a notification sound never looks like a call) and only acts on
+  transitions it observes, so stale entries cannot false-trigger.
+  Manual recordings are never auto-stopped or dialog-skipped.
 - **Per-channel stereo diarization** - 3-tier cascade
   (balanced mix, per channel, raw audio) selectable per meeting from
   the save dialog.

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -99,6 +99,27 @@ tiers 0-2, which are deliberately tiny.
   phrases. (Feasibility notes below.)
 - **Power efficiency is a primary constraint** (laptop, library use).
 
+## Owner decisions - 2026-07-04 (third intake)
+
+- **Auto-record settings redesign**: Settings > Meeting Auto-Record
+  with Enabled, an Apps submenu ("Detect apps..." populates from the
+  mic consent store; each app is Record / Ask / Ignore - the 3-state
+  resolves the owner's Discord case, where opt-out toasts on every
+  call would be exhausting), and a Toasts submenu (master + opt-in +
+  opt-out). Opt-in toast: "Auto-recording this meeting" with a single
+  "Don't record" action that discards silently. Opt-out toast (ask
+  apps): "Not recording this call" with a single "Record" action.
+- **Listener POC: GO this session** with a pretrained openWakeWord
+  phrase as the placeholder; the owner's custom wake/outro phrases and
+  the in-app trainer come later. Whisper-mode default until decided:
+  the listener does not run while whisper mode is on.
+- **Streaming dictation ("fill as it goes")**: owner floated live
+  word-by-word insertion with rolling self-correction for
+  paste-unfriendly apps; explicitly deferred ("we can delay this").
+  Recorded in BACKLOG.md - it is a different ASR architecture
+  (streaming zipformer / whisper-streaming partial hypotheses), not a
+  config flip on the current batch pipeline.
+
 ## GPU power-state resilience (owner: "actually really important")
 
 The laptop (Core Ultra 9 285H + Arc 140T iGPU + RTX 5070 Ti, hybrid

--- a/tests/test_meeting_flow.py
+++ b/tests/test_meeting_flow.py
@@ -188,6 +188,21 @@ class StartStopTests(_FlowHarness):
         self.flow._start()
         self.assertFalse(self.app.recorder.is_recording)
 
+    def test_abort_recording_discards_without_dialog(self):
+        # The auto-record opt-in toast's "Don't record" action: no save
+        # dialog, temp streams discarded, straight back to idle.
+        self.flow.toggle()
+        self.assertEqual(self.app.state.current.mode, "meeting")
+        self.flow.abort_recording(reason="test")
+        self.assertIsNone(self.app.state.current.mode)
+        self.assertFalse(self.app.recorder.is_recording)
+        self.assertEqual(self.app.recorder.discarded, 1)
+        self.assertEqual(len(self.saved), 0, "nothing may be written")
+
+    def test_abort_when_not_recording_is_a_noop(self):
+        self.flow.abort_recording(reason="test")
+        self.assertEqual(self.app.recorder.discarded, 0)
+
     def test_stop_saves_and_enqueues_job(self):
         self.app.recorder.audio = {"mic": "MIC-AUDIO", "speaker": "SPK-AUDIO"}
         self.flow.toggle()

--- a/tests/test_meeting_watch.py
+++ b/tests/test_meeting_watch.py
@@ -12,7 +12,7 @@ import unittest
 from unittest import mock
 
 from whisper_sync import meeting_watch as mw
-from whisper_sync.meeting_watch import MeetingWatch, entry_matches
+from whisper_sync.meeting_watch import MeetingWatch, apps_map, match_token
 from whisper_sync.state_manager import StateManager, MEETING_STARTED, IDLE
 
 ZOOM = "c:#program files#zoom#bin#zoom.exe"
@@ -25,6 +25,7 @@ class _FakeMeetings:
     def __init__(self, app):
         self.app = app
         self.toggles = 0
+        self.aborts = 0
 
     def toggle(self):
         self.toggles += 1
@@ -34,12 +35,19 @@ class _FakeMeetings:
         else:
             self.app.state.emit(MEETING_STARTED, mode="meeting")
 
+    def abort_recording(self, reason="user"):
+        self.aborts += 1
+        if self.app.state.current.mode == "meeting":
+            self.app.state.emit(IDLE, mode=None)
+
 
 class _FakeApp:
     def __init__(self):
         self.cfg = {
             "meeting_auto_record": True,
-            "meeting_watch_apps": ["zoom.exe", "slack.exe", "msteams"],
+            "meeting_watch_apps": {"zoom.exe": "record",
+                                   "slack.exe": "record",
+                                   "msteams": "record"},
             "meeting_watch_poll_seconds": 5,
             "meeting_watch_stop_after_s": 30,
         }
@@ -87,8 +95,7 @@ class TriggerTests(_WatchHarness):
         ])
         self.assertEqual(self.app.meetings.toggles, 1)
         self.assertEqual(self.mode, "meeting")
-        self.assertIn("Meeting recording started",
-                      self.notify.call_args[0][0])
+        self.assertIn("Auto-recording", self.notify.call_args[0][0])
 
     def test_entry_already_active_at_baseline_never_triggers(self):
         # The stale-entry hazard: a dead app version's entry can be
@@ -241,22 +248,98 @@ class LifecycleTests(_WatchHarness):
         self.assertEqual(calls, [(5.0, "meeting-watch")])
 
 
+class ThreeStateTests(_WatchHarness):
+    """Record / Ask / Ignore per app (owner design, third intake)."""
+
+    def _toast_buttons(self):
+        kwargs = self.notify.call_args[1]
+        return {b["label"]: b["action"] for b in kwargs.get("buttons", [])}
+
+    def test_ask_state_offers_but_never_records(self):
+        self.app.cfg["meeting_watch_apps"] = {"zoom.exe": "ask"}
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 0)
+        self.assertIn("Not recording", self.notify.call_args[0][0])
+        # One offer per call, not one per poll.
+        self._run_polls([{ZOOM: True}] * 3)
+        self.assertEqual(self.notify.call_count, 1)
+
+    def test_ask_toast_record_button_starts_recording(self):
+        self.app.cfg["meeting_watch_apps"] = {"zoom.exe": "ask"}
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self._toast_buttons()["Record"]()
+        self.assertEqual(self.mode, "meeting")
+        # The click-started recording is watcher-owned: it auto-stops
+        # after sustained release like any auto-started one.
+        self._run_polls([{ZOOM: False}] * 6)
+        self.assertEqual(self.mode, None)
+
+    def test_ignore_state_is_fully_silent(self):
+        self.app.cfg["meeting_watch_apps"] = {"zoom.exe": "ignore"}
+        self._run_polls([{ZOOM: False}] + [{ZOOM: True}] * 4)
+        self.assertEqual(self.app.meetings.toggles, 0)
+        self.notify.assert_not_called()
+
+    def test_optin_toast_dont_record_discards_silently(self):
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.mode, "meeting")
+        self._toast_buttons()["Don't record"]()
+        self.assertEqual(self.app.meetings.aborts, 1)
+        self.assertEqual(self.mode, None)
+        # Ownership released: no auto-stop fires later.
+        self._run_polls([{ZOOM: False}] * 8)
+        self.assertEqual(self.app.meetings.aborts, 1)
+
+    def test_toast_master_toggle_silences_but_still_records(self):
+        self.app.cfg["meeting_watch_toasts"] = False
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.mode, "meeting")
+        self.notify.assert_not_called()
+
+    def test_optout_toggle_silences_ask_apps(self):
+        self.app.cfg["meeting_watch_apps"] = {"zoom.exe": "ask"}
+        self.app.cfg["meeting_watch_toast_optout"] = False
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.app.meetings.toggles, 0)
+        self.notify.assert_not_called()
+
+    def test_legacy_list_config_reads_as_all_record(self):
+        self.app.cfg["meeting_watch_apps"] = ["zoom.exe"]
+        self._run_polls([{ZOOM: False}, {ZOOM: True}, {ZOOM: True}])
+        self.assertEqual(self.mode, "meeting")
+
+    def test_unknown_state_string_reads_as_ignore(self):
+        self.app.cfg["meeting_watch_apps"] = {"zoom.exe": "recrd"}  # typo
+        self._run_polls([{ZOOM: False}] + [{ZOOM: True}] * 3)
+        self.assertEqual(self.app.meetings.toggles, 0,
+                         "a config typo must never enable recording")
+
+
 class MatchingTests(unittest.TestCase):
     def test_exe_token_matches_leaf_only(self):
-        self.assertTrue(entry_matches(ZOOM, ["zoom.exe"]))
-        self.assertFalse(
-            entry_matches("c:#tools#zoom.exe#helper.exe", ["zoom.exe"]),
+        self.assertEqual(match_token(ZOOM, ["zoom.exe"]), "zoom.exe")
+        self.assertIsNone(
+            match_token("c:#tools#zoom.exe#helper.exe", ["zoom.exe"]),
             "an exe token must match the path leaf, never a segment")
 
     def test_packaged_token_matches_family_prefix(self):
-        self.assertTrue(entry_matches(
-            "msteams_8wekyb3d8bbwe", ["msteams"]))
-        self.assertFalse(entry_matches(
+        self.assertEqual(match_token(
+            "msteams_8wekyb3d8bbwe", ["msteams"]), "msteams")
+        self.assertIsNone(match_token(
             "microsoft.windowscamera_8wekyb3d8bbwe", ["msteams"]))
 
     def test_matching_is_case_insensitive_and_skips_blanks(self):
-        self.assertTrue(entry_matches(ZOOM, ["ZOOM.EXE"]))
-        self.assertFalse(entry_matches(ZOOM, ["", "  "]))
+        self.assertEqual(match_token(ZOOM, ["ZOOM.EXE"]), "zoom.exe")
+        self.assertIsNone(match_token(ZOOM, ["", "  "]))
+
+    def test_apps_map_normalizes_forms(self):
+        self.assertEqual(apps_map({"meeting_watch_apps": ["Zoom.EXE", ""]}),
+                         {"zoom.exe": "record"})
+        self.assertEqual(
+            apps_map({"meeting_watch_apps": {"zoom.exe": "ASK",
+                                             "x.exe": "bogus"}}),
+            {"zoom.exe": "ask", "x.exe": "ignore"})
+        self.assertEqual(apps_map({"meeting_watch_apps": None}), {})
 
 
 class RealStoreTests(unittest.TestCase):

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -187,7 +187,38 @@ class MenuBuildTests(unittest.TestCase):
         menu = self.menu.build()
         texts = " | ".join(_iter_texts(menu))
         self.assertIn("Meeting Auto-Record", texts)
-        self.assertIn("Watches: zoom", texts)
+        self.assertIn("Detect apps...", texts)
+        self.assertIn("zoom\trecord", texts)
+        self.assertIn("discord\task", texts)
+        self.assertIn("Show toasts", texts)
+
+    def test_set_app_record_state_saves_the_map(self):
+        from whisper_sync.meeting_watch import apps_map
+        with mock.patch.object(config, "save") as save:
+            self.menu._set_app_record_state("discord.exe", "ignore")
+        self.assertEqual(apps_map(self.app.cfg)["discord.exe"], "ignore")
+        save.assert_called_once()
+
+    def test_detect_adds_new_apps_as_ignore_only(self):
+        from whisper_sync import tray_menu as tray_menu_mod
+        from whisper_sync.meeting_watch import apps_map
+        entries = {
+            "c:#program files#zoom#bin#zoom.exe": False,   # already covered
+            "c:#program files#obs#obs64.exe": True,        # new
+            "microsoft.windowssoundrecorder_8wek": False,  # new (packaged)
+        }
+        with mock.patch("whisper_sync.meeting_watch.read_mic_entries",
+                        return_value=entries), \
+                mock.patch.object(config, "save"), \
+                mock.patch.object(tray_menu_mod, "notify"):
+            self.menu._detect_auto_record_apps()
+        apps = apps_map(self.app.cfg)
+        self.assertEqual(apps["obs64.exe"], "ignore")
+        self.assertEqual(apps["microsoft.windowssoundrecorder_8wek"],
+                         "ignore")
+        # The existing zoom token still covers its entry: no duplicate.
+        self.assertEqual(apps["zoom.exe"], "record")
+        self.assertNotIn("c:#program files#zoom#bin#zoom.exe", apps)
 
     def test_menu_callback_swallows_pystray_args(self):
         calls = []

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -44,14 +44,17 @@
   "gpu_guard_probe": null,
   "cpu_fallback_model": "base",
   "meeting_auto_record": false,
-  "meeting_watch_apps": [
-    "zoom.exe",
-    "slack.exe",
-    "teams.exe",
-    "ms-teams.exe",
-    "msteams",
-    "discord.exe"
-  ],
+  "meeting_watch_apps": {
+    "zoom.exe": "record",
+    "slack.exe": "record",
+    "teams.exe": "record",
+    "ms-teams.exe": "record",
+    "msteams": "record",
+    "discord.exe": "ask"
+  },
   "meeting_watch_poll_seconds": 5,
-  "meeting_watch_stop_after_s": 30
+  "meeting_watch_stop_after_s": 30,
+  "meeting_watch_toasts": true,
+  "meeting_watch_toast_optin": true,
+  "meeting_watch_toast_optout": true
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -36,6 +36,8 @@ _VALID_KEYS = {
     "cpu_fallback_model",
     "meeting_auto_record", "meeting_watch_apps",
     "meeting_watch_poll_seconds", "meeting_watch_stop_after_s",
+    "meeting_watch_toasts", "meeting_watch_toast_optin",
+    "meeting_watch_toast_optout",
 }
 
 

--- a/whisper_sync/meeting_flow.py
+++ b/whisper_sync/meeting_flow.py
@@ -141,6 +141,22 @@ class MeetingFlow:
         if self.app.cfg.get("always_available_dictation", True):
             self.app._backup.preload()
 
+    def abort_recording(self, reason: str = "user"):
+        """Silently discard an in-progress meeting recording.
+
+        No save dialog, nothing written: the auto-record opt-in toast's
+        "Don't record" action lands here. The manual stop path keeps
+        its dialog (which has its own discard choice).
+        """
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            if (current.mode if current else None) != "meeting":
+                return
+            self.app.recorder.stop()
+            self.app.recorder.discard_streaming()
+            logger.info(f"Meeting recording aborted ({reason}); nothing saved")
+            self.app.state.emit(IDLE, mode=None)
+
     def _stop(self):
         audio = self.app.recorder.stop()
 

--- a/whisper_sync/meeting_watch.py
+++ b/whisper_sync/meeting_watch.py
@@ -1,11 +1,22 @@
 """Per-app meeting auto-record - assistant build round, step 4.
 
-When a configured communications app (Zoom, Slack, Teams, ...) starts
-using the microphone, a meeting recording auto-starts; when that app
-releases the mic and stays quiet, the auto-started recording stops
-(through the normal stop path, save dialog included). Manual hotkey
-control is untouched, and a manually started recording is never
-auto-stopped.
+Each configured app has one of three states (owner design, 2026-07-04
+third intake):
+
+- **record**: when the app starts using the microphone, a meeting
+  recording auto-starts; an opt-in toast announces it with a single
+  "Don't record" action (which silently discards). When the app
+  releases the mic and stays quiet, the auto-started recording stops
+  through the normal stop path, save dialog included.
+- **ask**: never auto-starts; an opt-out toast offers a one-click
+  "Record" action instead.
+- **ignore**: fully silent (the exhausting-Discord case) - no
+  recording, no toasts.
+
+Toasts are gated by meeting_watch_toasts (master) and the
+meeting_watch_toast_optin / meeting_watch_toast_optout sub-toggles.
+Manual hotkey control is untouched, and a manually started recording
+is never auto-stopped.
 
 Detection source: the Windows CapabilityAccessManager consent store
 (HKCU ConsentStore/microphone) - the registry tree behind the OS
@@ -99,8 +110,32 @@ def _scan_tree(winreg, path: str, out: dict, skip: set) -> None:
                 out[sub.lower()] = stop == 0
 
 
-def entry_matches(entry_id: str, app_names) -> bool:
-    """True when a consent-store entry belongs to a watched app.
+_APP_STATES = ("record", "ask", "ignore")
+
+
+def apps_map(cfg) -> dict[str, str]:
+    """Normalized {app token: state} from meeting_watch_apps.
+
+    Accepts the legacy list form (#183 shipped a plain list) as
+    all-'record'; unknown state strings read as 'ignore' so a config
+    typo can never silently enable recording.
+    """
+    raw = cfg.get("meeting_watch_apps") or {}
+    if isinstance(raw, (list, tuple)):
+        return {str(t).strip().lower(): "record"
+                for t in raw if str(t).strip()}
+    out: dict[str, str] = {}
+    if isinstance(raw, dict):
+        for token, state in raw.items():
+            token = str(token).strip().lower()
+            state = str(state).strip().lower()
+            if token:
+                out[token] = state if state in _APP_STATES else "ignore"
+    return out
+
+
+def match_token(entry_id: str, tokens) -> str | None:
+    """The configured token a consent-store entry belongs to, or None.
 
     Desktop entries are full '#'-separated paths: a configured
     ``*.exe`` token must match the path LEAF exactly (never a
@@ -109,16 +144,16 @@ def entry_matches(entry_id: str, app_names) -> bool:
     token without '.exe' matches as a case-insensitive prefix.
     """
     entry = entry_id.lower()
-    for name in app_names or ():
+    for name in tokens or ():
         token = str(name).strip().lower()
         if not token:
             continue
         if token.endswith(".exe"):
             if entry.rsplit("#", 1)[-1] == token:
-                return True
+                return token
         elif entry.startswith(token):
-            return True
-    return False
+            return token
+    return None
 
 
 def _label(entry_id: str) -> str:
@@ -183,7 +218,7 @@ class MeetingWatch:
         entries = self._read_entries()
         if entries is None:
             return
-        apps = cfg.get("meeting_watch_apps") or []
+        apps = apps_map(cfg)
         if not self._primed:
             # Baseline over ALL entries, not just watched ones: an entry
             # already active now may be a stale leftover from a dead app
@@ -204,19 +239,37 @@ class MeetingWatch:
             elif eid in self._streak and self._streak[eid] < TRIGGER_AFTER_POLLS:
                 self._streak[eid] += 1
             if (self._streak.get(eid, 0) >= TRIGGER_AFTER_POLLS
-                    and eid not in self._handled
-                    and entry_matches(eid, apps)):
-                # Retried every poll while the mic stays held (review
-                # catch): an app that is busy dictating at the debounce
-                # moment must not lose the whole meeting.
-                if self._maybe_start(eid):
+                    and eid not in self._handled):
+                token = match_token(eid, apps)
+                state = apps.get(token) if token else None
+                if state == "record":
+                    # Retried every poll while the mic stays held
+                    # (review catch on #183): an app that is busy
+                    # dictating at the debounce moment must not lose
+                    # the whole meeting.
+                    if self._maybe_start(eid):
+                        self._handled.add(eid)
+                elif state == "ask":
+                    self._offer_recording(eid)
+                    self._handled.add(eid)  # one offer per call
+                else:
+                    # ignore / not configured: nothing this call. A
+                    # state edited mid-call applies from the NEXT call.
                     self._handled.add(eid)
         self._prev = entries
         self._maybe_stop(entries)
 
     # -- Start / stop decisions -------------------------------------------------
 
-    def _maybe_start(self, entry_id: str) -> bool:
+    def _toast_enabled(self, kind: str) -> bool:
+        cfg = self.app.cfg
+        if not cfg.get("meeting_watch_toasts", True):
+            return False
+        key = ("meeting_watch_toast_optin" if kind == "optin"
+               else "meeting_watch_toast_optout")
+        return bool(cfg.get(key, True))
+
+    def _maybe_start(self, entry_id: str, announce: bool = True) -> bool:
         """Try to auto-start. True = this call is dealt with (started,
         or someone is already recording it); False = busy, retry next
         poll while the mic stays held."""
@@ -239,10 +292,39 @@ class MeetingWatch:
             self.app.meetings.toggle()
             self._auto_started_by = entry_id
             self._release_polls = 0
-        notify("Meeting recording started",
-               f"{label} is in a call. Stop with the meeting hotkey "
-               "or the tray if unwanted.")
+        if announce and self._toast_enabled("optin"):
+            notify("Auto-recording this meeting",
+                   f"{label} is in a call.",
+                   buttons=[{"label": "Don't record",
+                             "action": self._cancel_auto_recording}])
         return True
+
+    def _cancel_auto_recording(self) -> None:
+        """Opt-in toast action: silently discard the auto-started
+        recording (no save dialog). No-op if it already ended or the
+        user took over with a manual stop."""
+        entry = self._auto_started_by
+        if entry is None:
+            return
+        self._auto_started_by = None
+        self._release_polls = 0
+        logger.info(
+            f"meeting watch: opt-out clicked for {_label(entry)}; "
+            "discarding the auto-started recording")
+        self.app.meetings.abort_recording(reason="auto_record_optout")
+
+    def _offer_recording(self, entry_id: str) -> None:
+        """Ask-state path: never record, offer a one-click start."""
+        if not self._toast_enabled("optout"):
+            return
+        label = _label(entry_id)
+        logger.info(
+            f"meeting watch: {label} is in a call (ask); offering to record")
+        notify("Not recording this call",
+               f"{label} is in a call.",
+               buttons=[{"label": "Record",
+                         "action": lambda eid=entry_id:
+                             self._maybe_start(eid, announce=False)}])
 
     def _maybe_stop(self, watched: dict) -> None:
         if self._auto_started_by is None:

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -496,7 +496,7 @@ class TrayMenu:
                             checked=lambda item: self.app.cfg.get(
                                 "meeting_watch_toasts", True)),
                         pystray.MenuItem(
-                            "Opt-in (auto-recording, click to stop)",
+                            "Opt-in (auto-recording, click to discard)",
                             menu_callback(self._toggle_watch_toast,
                                           "meeting_watch_toast_optin"),
                             checked=lambda item: self.app.cfg.get(

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -486,8 +486,28 @@ class TrayMenu:
                         checked=lambda item: self.app.cfg.get("meeting_auto_record", False),
                     ),
                     pystray.MenuItem(
-                        f"  Watches: {self._meeting_watch_apps_label()}",
-                        None, enabled=False),
+                        "Apps",
+                        pystray.Menu(*self._build_auto_record_apps_items())),
+                    pystray.MenuItem("Toasts", pystray.Menu(
+                        pystray.MenuItem(
+                            "Show toasts",
+                            menu_callback(self._toggle_watch_toast,
+                                          "meeting_watch_toasts"),
+                            checked=lambda item: self.app.cfg.get(
+                                "meeting_watch_toasts", True)),
+                        pystray.MenuItem(
+                            "Opt-in (auto-recording, click to stop)",
+                            menu_callback(self._toggle_watch_toast,
+                                          "meeting_watch_toast_optin"),
+                            checked=lambda item: self.app.cfg.get(
+                                "meeting_watch_toast_optin", True)),
+                        pystray.MenuItem(
+                            "Opt-out (not recording, click to record)",
+                            menu_callback(self._toggle_watch_toast,
+                                          "meeting_watch_toast_optout"),
+                            checked=lambda item: self.app.cfg.get(
+                                "meeting_watch_toast_optout", True)),
+                    )),
                 )),
                 pystray.MenuItem(f"Diarization (Speaker Detection)\t{primary_label}",
                                  pystray.Menu(*diarize_sub_items)),
@@ -852,10 +872,77 @@ class TrayMenu:
         # tick and re-seeds its baseline on re-enable (meeting_watch).
         self._save_and_refresh()
 
-    def _meeting_watch_apps_label(self) -> str:
-        apps = self.app.cfg.get("meeting_watch_apps") or []
-        names = [str(a).replace(".exe", "") for a in apps]
-        return ", ".join(dict.fromkeys(names)) or "none"
+    def _build_auto_record_apps_items(self):
+        """Per-app Record / Ask / Ignore radios + the Detect action."""
+        import pystray  # lazy: not installed on the CI system python
+        from .meeting_watch import apps_map
+
+        def _state_radio(token, state, label):
+            return pystray.MenuItem(
+                label,
+                menu_callback(self._set_app_record_state, token, state),
+                checked=lambda item, t=token, s=state:
+                    apps_map(self.app.cfg).get(t) == s,
+                radio=True,
+            )
+
+        items = [
+            pystray.MenuItem("Detect apps...",
+                             menu_callback(self._detect_auto_record_apps)),
+            pystray.Menu.SEPARATOR,
+        ]
+        apps = apps_map(self.app.cfg)
+        for token in sorted(apps):
+            items.append(pystray.MenuItem(
+                f"{token.replace('.exe', '')}\t{apps[token]}",
+                pystray.Menu(
+                    _state_radio(token, "record", "Record"),
+                    _state_radio(token, "ask", "Ask (toast to record)"),
+                    _state_radio(token, "ignore", "Ignore"),
+                )))
+        return items
+
+    def _set_app_record_state(self, token: str, state: str):
+        from .meeting_watch import apps_map
+        apps = apps_map(self.app.cfg)
+        apps[token] = state
+        self.app.cfg["meeting_watch_apps"] = apps
+        logger.info(f"Auto-record app {token}: {state}")
+        self._save_and_refresh()
+
+    def _detect_auto_record_apps(self):
+        """Populate the Apps submenu from the mic consent store.
+
+        Every app that has ever used the microphone becomes selectable;
+        new apps arrive as Ignore, so detection never changes behavior
+        by itself - the user promotes the ones they want to Record/Ask.
+        """
+        from .meeting_watch import apps_map, match_token, read_mic_entries
+        entries = read_mic_entries()
+        if entries is None:
+            notify("Detect failed",
+                   "Could not read the Windows microphone usage list.")
+            return
+        apps = apps_map(self.app.cfg)
+        added = 0
+        for eid in sorted(entries):
+            if match_token(eid, apps.keys()):
+                continue  # an existing token already covers this entry
+            token = eid.rsplit("#", 1)[-1] if "#" in eid else eid
+            if token not in apps:
+                apps[token] = "ignore"
+                added += 1
+        self.app.cfg["meeting_watch_apps"] = apps
+        logger.info(f"Auto-record detect: {added} new app(s) added as ignore")
+        self._save_and_refresh()
+        notify("Apps detected",
+               f"{added} new app(s) added as Ignore. Set the ones you "
+               "want to Record or Ask in Settings > Meeting Auto-Record.")
+
+    def _toggle_watch_toast(self, key: str):
+        self.app.cfg[key] = not self.app.cfg.get(key, True)
+        logger.info(f"Auto-record toast setting {key}: {self.app.cfg[key]}")
+        self._save_and_refresh()
 
     def _toggle_always_available_dictation(self):
         self.app.cfg["always_available_dictation"] = not self.app.cfg.get("always_available_dictation", True)


### PR DESCRIPTION
Owner third-intake redesign of the meeting auto-record surface (decisions recorded in the direction spec).

**Per-app 3-state** (`meeting_watch_apps` is now `{token: state}`):
- **record**: auto-start + opt-in toast with a single **Don't record** action that silently discards (new `MeetingFlow.abort_recording` - no save dialog).
- **ask**: never records; opt-out toast offers a one-click **Record**. A click-started recording becomes watcher-owned (auto-stops after the call like any auto-start).
- **ignore**: fully silent - resolves the owner's Discord case where opt-out toasts on every call would be exhausting.
- Legacy list form (shipped in #183) reads as all-record; unknown state strings read as ignore, so a config typo can never enable recording.

**Toasts**: `meeting_watch_toasts` master + `_optin`/`_optout` sub-toggles.

**Tray** (Settings > Meeting Auto-Record): Enabled; Apps with **Detect apps...** (populates from every app that has ever used the mic via the consent store - new apps arrive as Ignore, so detection never changes behavior by itself) plus per-app Record/Ask/Ignore radios; Toasts submenu.

Defaults: zoom/slack/teams = record, discord = ask.

Docs: features/defaults rows, spec third-intake section, BACKLOG entry for the owner's deferred streaming-dictation idea.

Architecture note: no protected paths. abort_recording stops + discards under the app lock and emits IDLE; the manual stop path keeps its dialog.

Tests: 8 ThreeStateTests, apps_map normalization, tray set-state/detect, 2 abort tests. Suite 357, exit verified directly.