### PR TITLE
feat: always-on wake-word listener POC (step 2, tier 0+1)

### DIFF
--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -50,3 +50,6 @@ fails if this table and the defaults file disagree on keys.
 | `meeting_watch_toasts` | `true` | Master toggle for auto-record toasts |
 | `meeting_watch_toast_optin` | `true` | Toast when auto-recording starts ("Don't record" discards silently) |
 | `meeting_watch_toast_optout` | `true` | Toast when an ask-state app is in a call ("Record" starts one-click) |
+| `wake_listener` | `false` | Always-on wake-word listener (POC; needs openwakeword in the venv) |
+| `wake_phrase_model` | `hey_jarvis` | Pretrained openWakeWord phrase model (placeholder until custom phrases ship) |
+| `wake_threshold` | `0.5` | Wake-word detection score threshold (0-1) |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -41,6 +41,15 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   a second mic stream and the backup model (CPU or secondary GPU).
 - **Feature suggestions** - a dedicated hotkey records a voice note to
   the feature log and formats it via Claude CLI.
+- **Wake-word listener (POC**, off by default; Settings > Wake Word
+  Listener) - an always-on, shared (never exclusive) mic stream feeds
+  an openWakeWord model on the CPU; audio stays in RAM and nothing is
+  written before a wake. Detection currently wakes the model and
+  toasts; the splice into a dictation is the next step. Ships with the
+  pretrained "hey jarvis" phrase until custom phrases and the in-app
+  trainer arrive. Pauses during whisper mode and while recording.
+  Needs `openwakeword` in the venv (in requirements.txt); without it
+  the toggle simply reports unavailable.
 
 ## Model and VRAM lifecycle
 

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -41,8 +41,8 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   a second mic stream and the backup model (CPU or secondary GPU).
 - **Feature suggestions** - a dedicated hotkey records a voice note to
   the feature log and formats it via Claude CLI.
-- **Wake-word listener (POC**, off by default; Settings > Wake Word
-  Listener) - an always-on, shared (never exclusive) mic stream feeds
+- **Wake-word listener (POC)** - off by default (Settings > Wake Word
+  Listener). An always-on, shared (never exclusive) mic stream feeds
   an openWakeWord model on the CPU; audio stays in RAM and nothing is
   written before a wake. Detection currently wakes the model and
   toasts; the splice into a dictation is the next step. Ships with the

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -14,7 +14,7 @@
 | # | Step | Spec anchor | Status |
 |---|------|-------------|--------|
 | 1 | GPU power-state failover (guard-owned, cpu_fallback_model) | GPU power-state resilience | MERGED (#180-#182) |
-| 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | NEEDS OWNER INPUT |
+| 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC IN PROGRESS (pretrained phrase) |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | QUEUED |
 | 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | MERGED (#183, #184) |
 | 5 | In-app wake-word trainer (verifier first, full training later) | Wake-word model landscape | QUEUED |
@@ -22,8 +22,10 @@
 | - | Installer refresh (screens generated from docs/features/) | BACKLOG.md | QUEUED |
 
 Standing authorization (owner, 2026-07-03/04): proceed step to step
-without asking unless a large unforeseen blocker. Before steps 2-3 the
-owner still owes: wake + outro phrase choices, whisper-mode interaction,
+without asking unless a large unforeseen blocker. Third intake
+(2026-07-04): the listener POC is GO with a pretrained phrase; the
+owner still owes the CUSTOM wake + outro phrase choices, the final
+whisper-mode decision (POC default: listener off in whisper mode),
 and the command allowlist shape.
 
 ## Step 1 plan - GPU power-state failover
@@ -192,3 +194,27 @@ PRs:
   behavior (asked again 2026-07-04). Owner reminder still outstanding:
   the tray app runs pre-#167 bytecode; a restart picks up everything
   from #167 through failover, auto-sleep, and meeting auto-record.
+
+- **2026-07-04 (third intake shipped, #186)**: auto-record settings
+  redesign per the owner's third intake - Record/Ask/Ignore per app
+  (the 3-state resolves the exhausting-Discord case), "Detect apps..."
+  populating from the consent store (new apps arrive as Ignore),
+  opt-in/opt-out toasts with master + sub-toggles, and
+  MeetingFlow.abort_recording for the silent "Don't record" discard.
+  Review caught a misleading menu label (said stop, does discard).
+  Owner's streaming-dictation idea recorded as a BACKLOG deferral.
+  Suite 357.
+
+- **2026-07-04 (step 2 POC)**: wake-word listener shipped as a POC per
+  the third-intake GO. listener.py: an always-on SHARED mic stream
+  (sounddevice/WASAPI, never exclusive) feeds 80ms frames to
+  openWakeWord (onnx, built-in silero VAD gate) on a daemon thread;
+  detection wakes the model (auto_sleep.wake) and toasts - the tier-2
+  dictation splice is next. Pretrained "hey_jarvis" placeholder until
+  the owner picks custom phrases; pauses in whisper mode (owner
+  default) and while recording; 3s refractory so one utterance fires
+  once; RAM-only until wake. openwakeword added to requirements
+  (lazy-imported; the module is inert without it - CI never sees it).
+  Verified live in the venv: model download + load + predict on the
+  dev machine. Config: wake_listener (off), wake_phrase_model,
+  wake_threshold; tray toggle under Settings.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ keyboard
 pyperclip
 pywin32
 windows-toasts
+
+# Wake-word listener POC (assistant round step 2). Lazy-imported:
+# the app runs without it, the listener just stays unavailable.
+openwakeword

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,0 +1,157 @@
+"""Tests for whisper_sync.listener - the wake-word POC.
+
+The decision logic (score threshold, refractory window, pause gating,
+thread lifecycle) runs against fakes: no audio, no openwakeword. The
+live audio loop is exercised manually for the POC and gets harness
+coverage with the tier-2 splice.
+"""
+
+import time
+import types
+import unittest
+from unittest import mock
+
+from whisper_sync import listener as listener_mod
+from whisper_sync.listener import WakeListener
+from whisper_sync.state_manager import StateManager, SLEEP_STARTED
+
+
+class _FakeApp:
+    def __init__(self):
+        self.cfg = {"wake_listener": True, "wake_threshold": 0.5}
+        self.state = StateManager(None, {})
+        self.recorder = types.SimpleNamespace(is_recording=False)
+        self.auto_sleep = types.SimpleNamespace(wake=mock.Mock())
+        self.flashes = 0
+
+    def _yellow_flash(self):
+        self.flashes += 1
+
+
+class WakeDecisionTests(unittest.TestCase):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.fired = []
+        self.listener = WakeListener(self.app,
+                                     on_wake=lambda: self.fired.append(1))
+
+    def test_score_below_threshold_does_not_fire(self):
+        self.assertFalse(self.listener.process_scores({"hey_jarvis": 0.3}))
+        self.assertEqual(self.fired, [])
+
+    def test_score_at_threshold_fires(self):
+        self.assertTrue(self.listener.process_scores({"hey_jarvis": 0.9}))
+        self.assertEqual(self.fired, [1])
+
+    def test_refractory_window_blocks_repeat_fires(self):
+        # Scores stay elevated for several consecutive frames of one
+        # utterance; one spoken phrase must fire exactly one wake.
+        self.listener.process_scores({"hey_jarvis": 0.9})
+        for _ in range(5):
+            self.assertFalse(
+                self.listener.process_scores({"hey_jarvis": 0.9}))
+        self.assertEqual(self.fired, [1])
+
+    def test_fires_again_after_the_refractory_window(self):
+        self.listener.process_scores({"hey_jarvis": 0.9})
+        self.listener._last_fire = time.monotonic() - 10
+        self.assertTrue(self.listener.process_scores({"hey_jarvis": 0.9}))
+        self.assertEqual(self.fired, [1, 1])
+
+    def test_empty_scores_are_safe(self):
+        self.assertFalse(self.listener.process_scores({}))
+        self.assertFalse(self.listener.process_scores(None))
+
+    def test_wake_action_exception_does_not_propagate(self):
+        boom = WakeListener(self.app,
+                            on_wake=mock.Mock(side_effect=RuntimeError))
+        self.assertTrue(boom.process_scores({"x": 1.0}))
+
+    def test_invalid_threshold_config_falls_back_to_half(self):
+        self.app.cfg["wake_threshold"] = "high"
+        self.assertTrue(self.listener.process_scores({"x": 0.6}))
+        self.assertEqual(self.fired, [1])
+
+
+class PauseGatingTests(unittest.TestCase):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.listener = WakeListener(self.app)
+
+    def test_idle_app_is_not_paused(self):
+        self.assertFalse(self.listener._paused())
+
+    def test_whisper_mode_pauses(self):
+        # Owner default until decided: no listening in whisper mode.
+        self.app.cfg["incognito"] = True
+        self.assertTrue(self.listener._paused())
+
+    def test_recording_pauses(self):
+        self.app.recorder.is_recording = True
+        self.assertTrue(self.listener._paused())
+
+    def test_active_mode_pauses(self):
+        self.app.state.emit("dictation_started", mode="dictation")
+        self.assertTrue(self.listener._paused())
+
+    def test_done_and_error_modes_do_not_pause(self):
+        self.app.state.emit("x", mode="done")
+        self.assertFalse(self.listener._paused())
+        self.app.state.emit("x", mode="error")
+        self.assertFalse(self.listener._paused())
+
+
+class LifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.listener = WakeListener(self.app)
+
+    def test_disabled_start_spawns_no_thread(self):
+        self.app.cfg["wake_listener"] = False
+        self.listener.start()
+        self.assertIsNone(self.listener._thread)
+
+    def test_enabled_start_spawns_one_thread_and_stop_ends_it(self):
+        with mock.patch.object(WakeListener, "_run",
+                               lambda s: s._stop_event.wait(5)):
+            self.listener.start()
+            first = self.listener._thread
+            self.assertIsNotNone(first)
+            self.listener.start()
+            self.assertIs(self.listener._thread, first,
+                          "second start must not spawn a duplicate")
+            self.listener.stop()
+            first.join(timeout=2)
+            self.assertFalse(first.is_alive())
+
+    def test_restart_if_toggled_reconciles_both_ways(self):
+        with mock.patch.object(WakeListener, "_run",
+                               lambda s: s._stop_event.wait(5)):
+            self.app.cfg["wake_listener"] = False
+            self.listener.restart_if_toggled()
+            self.assertIsNone(self.listener._thread)
+            self.app.cfg["wake_listener"] = True
+            self.listener.restart_if_toggled()
+            self.assertTrue(self.listener._thread.is_alive())
+            self.app.cfg["wake_listener"] = False
+            self.listener.restart_if_toggled()
+            self.listener._thread.join(timeout=2)
+            self.assertFalse(self.listener._thread.is_alive())
+
+    def test_default_wake_action_wakes_a_sleeping_model(self):
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        with mock.patch.object(listener_mod, "notify"):
+            self.listener._default_wake_action()
+        self.app.auto_sleep.wake.assert_called_once()
+        self.assertEqual(self.app.flashes, 0,
+                         "wake() owns the flash when asleep")
+
+    def test_default_wake_action_flashes_when_awake(self):
+        with mock.patch.object(listener_mod, "notify"):
+            self.listener._default_wake_action()
+        self.assertEqual(self.app.flashes, 1)
+        self.app.auto_sleep.wake.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -113,7 +113,7 @@ class LifecycleTests(unittest.TestCase):
 
     def test_enabled_start_spawns_one_thread_and_stop_ends_it(self):
         with mock.patch.object(WakeListener, "_run",
-                               lambda s: s._stop_event.wait(5)):
+                               lambda s, ev: ev.wait(5)):
             self.listener.start()
             first = self.listener._thread
             self.assertIsNotNone(first)
@@ -124,9 +124,27 @@ class LifecycleTests(unittest.TestCase):
             first.join(timeout=2)
             self.assertFalse(first.is_alive())
 
+    def test_rapid_off_on_toggle_starts_a_fresh_generation(self):
+        # Review catch: the stop event is bound per thread, so a quick
+        # off -> on toggle must start a new generation instead of
+        # short-circuiting on the old, stopping thread and leaving the
+        # listener enabled-but-inert.
+        with mock.patch.object(WakeListener, "_run",
+                               lambda s, ev: ev.wait(5)):
+            self.listener.start()
+            first = self.listener._thread
+            self.listener.stop()   # old generation begins exiting
+            self.listener.start()  # immediate re-enable
+            self.assertIsNot(self.listener._thread, first,
+                             "a stopping thread must not block a fresh start")
+            self.assertTrue(self.listener._thread.is_alive())
+            self.listener.stop()
+            self.listener._thread.join(timeout=2)
+            first.join(timeout=2)
+
     def test_restart_if_toggled_reconciles_both_ways(self):
         with mock.patch.object(WakeListener, "_run",
-                               lambda s: s._stop_event.wait(5)):
+                               lambda s, ev: ev.wait(5)):
             self.app.cfg["wake_listener"] = False
             self.listener.restart_if_toggled()
             self.assertIsNone(self.listener._thread)

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -183,6 +183,15 @@ class MenuBuildTests(unittest.TestCase):
             self.assertTrue(self.app.cfg["meeting_auto_record"])
             save.assert_called_once()
 
+    def test_toggle_wake_listener_flips_saves_and_reconciles(self):
+        self.app.wake_listener = types.SimpleNamespace(
+            restart_if_toggled=mock.Mock())
+        with mock.patch.object(config, "save") as save:
+            self.menu._toggle_wake_listener()
+        self.assertTrue(self.app.cfg["wake_listener"])
+        self.app.wake_listener.restart_if_toggled.assert_called_once()
+        save.assert_called_once()
+
     def test_menu_shows_meeting_auto_record_section(self):
         menu = self.menu.build()
         texts = " | ".join(_iter_texts(menu))

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -151,6 +151,10 @@ class WhisperSync:
         # store polling; auto-starts/stops recordings for watched apps.
         from .meeting_watch import MeetingWatch
         self.meeting_watch = MeetingWatch(self)
+        # Always-on wake-word listener POC (listener.py): inert unless
+        # wake_listener is on AND openwakeword is installed in the venv.
+        from .listener import WakeListener
+        self.wake_listener = WakeListener(self)
 
     @staticmethod
     def _migrate_data():
@@ -514,6 +518,10 @@ class WhisperSync:
         # Per-app meeting auto-record (assistant round step 4): polls
         # the mic consent store; inert unless meeting_auto_record.
         self.meeting_watch.start(_sched, IO)
+
+        # Wake-word listener POC (assistant round step 2): no-op while
+        # wake_listener is off; the tray toggle reconciles at runtime.
+        self.wake_listener.start()
 
         # Suspend/resume awareness (hardware-resilience spec H1): both
         # transitions land in gpu-guard.jsonl for crash-time correlation,

--- a/whisper_sync/app_control.py
+++ b/whisper_sync/app_control.py
@@ -242,6 +242,9 @@ class AppControl:
         except Exception:
             logger.debug("Post-queue shutdown signal failed", exc_info=True)
         try:
+            listener = getattr(self.app, "wake_listener", None)
+            if listener is not None:
+                listener.stop()
             if self.app.recorder.is_recording:
                 self.app.recorder.stop()
             self.app.worker.stop()

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -56,5 +56,8 @@
   "meeting_watch_stop_after_s": 30,
   "meeting_watch_toasts": true,
   "meeting_watch_toast_optin": true,
-  "meeting_watch_toast_optout": true
+  "meeting_watch_toast_optout": true,
+  "wake_listener": false,
+  "wake_phrase_model": "hey_jarvis",
+  "wake_threshold": 0.5
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -38,6 +38,7 @@ _VALID_KEYS = {
     "meeting_watch_poll_seconds", "meeting_watch_stop_after_s",
     "meeting_watch_toasts", "meeting_watch_toast_optin",
     "meeting_watch_toast_optout",
+    "wake_listener", "wake_phrase_model", "wake_threshold",
 }
 
 

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -80,15 +80,26 @@ class WakeListener:
 
     def start(self) -> None:
         """Start the listening thread if enabled. Safe to call again
-        after a config toggle; a running thread is left alone."""
+        after a config toggle; a healthy running thread is left alone.
+
+        The stop event is bound PER THREAD (worker _WorkerGeneration
+        precedent): a quick off -> on toggle starts a fresh generation
+        immediately instead of short-circuiting on the old, stopping
+        thread and leaving the listener enabled-but-inert (review
+        catch). A briefly overlapping old thread exits on ITS OWN
+        event; both streams are shared-mode, so the overlap is
+        harmless.
+        """
         with self._lock:
             if not self.enabled:
                 return
-            if self._thread is not None and self._thread.is_alive():
-                return
-            self._stop_event.clear()
+            if (self._thread is not None and self._thread.is_alive()
+                    and not self._stop_event.is_set()):
+                return  # already running and not stopping
+            self._stop_event = threading.Event()
             self._thread = threading.Thread(
-                target=self._run, daemon=True, name="wake-listener")
+                target=self._run, args=(self._stop_event,),
+                daemon=True, name="wake-listener")
             self._thread.start()
 
     def stop(self) -> None:
@@ -104,15 +115,25 @@ class WakeListener:
 
     # -- The listening loop -------------------------------------------------------
 
-    def _run(self) -> None:
+    def _run(self, stop_event: threading.Event) -> None:
         try:
             model = self._load_model()
-        except Exception as exc:
+        except ImportError as exc:
             logger.warning(
-                f"Wake listener unavailable: {exc} - install openwakeword "
-                "in whisper-env to enable it")
+                f"Wake listener unavailable: openwakeword is not "
+                f"installed ({exc}) - pip install openwakeword in "
+                "whisper-env to enable it")
             notify("Wake listener unavailable",
                    "openwakeword is not installed; see the log.")
+            return
+        except Exception:
+            # Distinct from the missing dependency (review catch):
+            # model download/load or onnxruntime failures need the
+            # real traceback, not an install hint.
+            logger.warning("Wake listener failed to load its model",
+                           exc_info=True)
+            notify("Wake listener failed",
+                   "Wake model could not load; see the log.")
             return
         if model is None:
             return
@@ -122,17 +143,24 @@ class WakeListener:
         logger.info(
             f"Wake listener active: phrase model '{self._phrase()}', "
             f"threshold {self._threshold():.2f}")
+        was_paused = False
         try:
             with sd.InputStream(samplerate=SAMPLE_RATE, channels=1,
                                 dtype="int16", blocksize=FRAME_SAMPLES) as stream:
-                while not self._stop_event.is_set():
+                while not stop_event.is_set():
                     frame, _overflowed = stream.read(FRAME_SAMPLES)
                     if self._paused():
                         # Keep draining the stream (cheap) but skip
-                        # inference and reset state so a phrase spoken
-                        # during a pause cannot fire on resume.
-                        model.reset()
+                        # inference. Reset ONCE on entering the pause
+                        # (review catch: not per 80ms frame) - clears
+                        # pre-pause audio so it cannot fire on resume;
+                        # nothing accumulates during the pause because
+                        # paused frames are never fed to the model.
+                        if not was_paused:
+                            model.reset()
+                            was_paused = True
                         continue
+                    was_paused = False
                     scores = model.predict(np.squeeze(frame))
                     self.process_scores(scores)
         except Exception:

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -1,0 +1,208 @@
+"""Always-on wake-word listener - assistant build round, step 2 (POC).
+
+Tier 0+1 of the voice-assistant architecture (direction spec): a
+shared, non-exclusive mic stream feeds 80ms frames into an openWakeWord
+model on the CPU. This POC ships with a PRETRAINED phrase as a
+placeholder (default "hey jarvis") - the owner's custom wake/outro
+phrases and the in-app trainer come later. On detection the POC wakes
+the transcription model (auto_sleep.wake) and toasts; the tier-2
+splice into a ring-buffer-prefixed dictation is the next step.
+
+Power and privacy posture (spec + owner decisions):
+- OFF by default (``wake_listener``); tray toggle under Settings.
+- All audio stays in RAM inside openWakeWord's internal buffer;
+  nothing is written to disk before a wake.
+- openWakeWord's built-in silero VAD gate (``vad_threshold``) keeps
+  the melspectrogram/model work near-zero while the room is silent.
+- The listener PAUSES while whisper/incognito mode is on (owner
+  default until decided otherwise) and while a recording or overlay
+  dictation is running (the mic is already being captured; a wake
+  mid-recording has nothing to do yet).
+- The stream is opened in shared mode (sounddevice/WASAPI default) and
+  never blocks other apps or the recorder from the mic.
+
+Dependency posture: openwakeword (+ onnxruntime) lives in the venv;
+this module imports it lazily and is fully inert - one log line, no
+thread - when the package or its models are missing, so the
+dependency-light system python (CI) never sees it.
+
+Feature pattern (gpu_guard precedent): one owning module, flat config
+keys (wake_listener, wake_phrase_model, wake_threshold), inert when
+disabled.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from .logger import logger
+from .notifications import notify
+
+# 80ms at 16kHz - openWakeWord's native frame size.
+SAMPLE_RATE = 16000
+FRAME_SAMPLES = 1280
+
+# After a detection, ignore further hits for this long: scores stay
+# elevated for several consecutive frames per utterance, and one
+# spoken wake phrase must fire exactly one wake.
+REFRACTORY_S = 3.0
+
+
+class WakeListener:
+    """Owns the always-on listening loop; services via ``app``."""
+
+    def __init__(self, app, on_wake=None):
+        self.app = app
+        # Seam for step 3: the splice replaces this default action.
+        self._on_wake = on_wake or self._default_wake_action
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._last_fire = 0.0
+        self._lock = threading.Lock()
+
+    # -- Config ----------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.app.cfg.get("wake_listener", False))
+
+    def _phrase(self) -> str:
+        return str(self.app.cfg.get("wake_phrase_model", "hey_jarvis"))
+
+    def _threshold(self) -> float:
+        try:
+            return float(self.app.cfg.get("wake_threshold", 0.5))
+        except (TypeError, ValueError):
+            return 0.5
+
+    # -- Lifecycle ---------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the listening thread if enabled. Safe to call again
+        after a config toggle; a running thread is left alone."""
+        with self._lock:
+            if not self.enabled:
+                return
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._run, daemon=True, name="wake-listener")
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the listening thread to exit (config toggle, quit)."""
+        self._stop_event.set()
+
+    def restart_if_toggled(self) -> None:
+        """Reconcile the thread with the config flag (tray setter)."""
+        if self.enabled:
+            self.start()
+        else:
+            self.stop()
+
+    # -- The listening loop -------------------------------------------------------
+
+    def _run(self) -> None:
+        try:
+            model = self._load_model()
+        except Exception as exc:
+            logger.warning(
+                f"Wake listener unavailable: {exc} - install openwakeword "
+                "in whisper-env to enable it")
+            notify("Wake listener unavailable",
+                   "openwakeword is not installed; see the log.")
+            return
+        if model is None:
+            return
+        import numpy as np
+        import sounddevice as sd
+
+        logger.info(
+            f"Wake listener active: phrase model '{self._phrase()}', "
+            f"threshold {self._threshold():.2f}")
+        try:
+            with sd.InputStream(samplerate=SAMPLE_RATE, channels=1,
+                                dtype="int16", blocksize=FRAME_SAMPLES) as stream:
+                while not self._stop_event.is_set():
+                    frame, _overflowed = stream.read(FRAME_SAMPLES)
+                    if self._paused():
+                        # Keep draining the stream (cheap) but skip
+                        # inference and reset state so a phrase spoken
+                        # during a pause cannot fire on resume.
+                        model.reset()
+                        continue
+                    scores = model.predict(np.squeeze(frame))
+                    self.process_scores(scores)
+        except Exception:
+            logger.warning("Wake listener stopped on stream error",
+                           exc_info=True)
+        finally:
+            logger.info("Wake listener stopped")
+
+    def _load_model(self):
+        """Load the openWakeWord model (lazy heavy import)."""
+        from openwakeword.model import Model
+        try:
+            return Model(wakeword_models=[self._phrase()],
+                         inference_framework="onnx",
+                         vad_threshold=0.5)
+        except Exception:
+            # Pretrained model files are a one-time download.
+            logger.info("Wake listener: downloading openWakeWord models...")
+            import openwakeword.utils
+            openwakeword.utils.download_models()
+            return Model(wakeword_models=[self._phrase()],
+                         inference_framework="onnx",
+                         vad_threshold=0.5)
+
+    # -- Decision logic (unit-tested without audio) --------------------------------
+
+    def _paused(self) -> bool:
+        """True while inference should not run.
+
+        Whisper mode: owner default - the listener does not listen.
+        Recording/overlay: the mic is already captured; nothing for a
+        wake to do until the tier-2 splice exists.
+        """
+        cfg = self.app.cfg
+        if cfg.get("incognito", False):
+            return True
+        state = self.app.state
+        current = state.current if state else None
+        if current is None:
+            return True
+        return (current.mode not in (None, "done", "error")
+                or self.app.recorder.is_recording)
+
+    def process_scores(self, scores: dict) -> bool:
+        """Evaluate one frame's model scores; fire at most one wake.
+
+        Returns True when a wake fired (refractory window applies).
+        """
+        threshold = self._threshold()
+        hit = any(score >= threshold for score in (scores or {}).values())
+        if not hit:
+            return False
+        now = time.monotonic()
+        if now - self._last_fire < REFRACTORY_S:
+            return False
+        self._last_fire = now
+        try:
+            self._on_wake()
+        except Exception:
+            logger.warning("Wake action failed", exc_info=True)
+        return True
+
+    def _default_wake_action(self) -> None:
+        """POC action: wake the model + announce. The tier-2 splice
+        (ring-buffer-prefixed dictation + outro phrase) replaces this."""
+        logger.info("Wake word detected")
+        state = self.app.state
+        if state is not None and state.current.sleeping:
+            self.app.auto_sleep.wake(reason="wake_word")
+        else:
+            self.app._yellow_flash()
+        notify("Wake word heard",
+               "POC: dictation splice arrives in the next step.")

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -509,6 +509,18 @@ class TrayMenu:
                                 "meeting_watch_toast_optout", True)),
                     )),
                 )),
+                pystray.MenuItem("Wake Word Listener (POC)", pystray.Menu(
+                    pystray.MenuItem(
+                        "Enabled",
+                        lambda: self._toggle_wake_listener(),
+                        checked=lambda item: self.app.cfg.get(
+                            "wake_listener", False),
+                    ),
+                    pystray.MenuItem(
+                        f"  Phrase: "
+                        f"{self.app.cfg.get('wake_phrase_model', 'hey_jarvis')}",
+                        None, enabled=False),
+                )),
                 pystray.MenuItem(f"Diarization (Speaker Detection)\t{primary_label}",
                                  pystray.Menu(*diarize_sub_items)),
                 pystray.Menu.SEPARATOR,
@@ -942,6 +954,14 @@ class TrayMenu:
     def _toggle_watch_toast(self, key: str):
         self.app.cfg[key] = not self.app.cfg.get(key, True)
         logger.info(f"Auto-record toast setting {key}: {self.app.cfg[key]}")
+        self._save_and_refresh()
+
+    def _toggle_wake_listener(self):
+        cfg = self.app.cfg
+        cfg["wake_listener"] = not cfg.get("wake_listener", False)
+        logger.info(
+            f"Wake listener: {'on' if cfg['wake_listener'] else 'off'}")
+        self.app.wake_listener.restart_if_toggled()
         self._save_and_refresh()
 
     def _toggle_always_available_dictation(self):


### PR DESCRIPTION
Step 2 POC per the owner's third-intake GO (plan + spec updated in this PR). Ships with the pretrained `hey_jarvis` phrase as a placeholder until the owner picks custom wake/outro phrases (in-app trainer is build-order step 5).

**What it does** (`listener.py`, feature pattern):
- A **shared, never-exclusive** mic stream (sounddevice/WASAPI) feeds 80ms int16 frames to an openWakeWord model (onnx framework, built-in silero VAD gate) on a daemon thread.
- On detection: wakes the transcription model (`auto_sleep.wake`) and toasts. The `on_wake` seam is where the tier-2 ring-buffer splice lands next.
- **Privacy/power posture** (spec): off by default; audio stays in RAM (nothing on disk before a wake); VAD keeps idle inference near-zero; **pauses in whisper mode** (owner default until decided) and while recording, with `model.reset()` on pause so a phrase spoken during a pause can't fire on resume; 3s refractory so one utterance fires exactly one wake.
- **Dependency posture**: `openwakeword` added to requirements, lazy-imported; without it the module logs once + toasts unavailable and stays inert - the dependency-light CI python never imports it. Verified live in the venv on the dev machine (model download + load + predict).

Config: `wake_listener` (false), `wake_phrase_model` (`hey_jarvis`), `wake_threshold` (0.5). Tray: Settings > Wake Word Listener (POC) with runtime reconciliation; stopped in AppControl cleanup.

Architecture note: no protected paths; the listener opens its own shared stream and never touches capture.py's recorder.

Tests: 17 new (decision logic, pause gating, thread lifecycle). Suite 374, exit verified directly.