### PR TITLE
docs: fourth intake - self-serve phrase manager design (step 5)

### DIFF
--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -17,7 +17,7 @@
 | 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC IN PROGRESS (pretrained phrase) |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | QUEUED |
 | 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | MERGED (#183, #184) |
-| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Fourth intake | QUEUED |
+| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Owner decisions, fourth intake: the phrase manager | QUEUED |
 | 6 | NPU/OpenVINO backup-transcriber backend (committed scope) | NPU section | QUEUED |
 | - | Installer refresh (screens generated from docs/features/) | BACKLOG.md | QUEUED |
 

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -17,7 +17,7 @@
 | 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC IN PROGRESS (pretrained phrase) |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | QUEUED |
 | 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | MERGED (#183, #184) |
-| 5 | In-app wake-word trainer (verifier first, full training later) | Wake-word model landscape | QUEUED |
+| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Fourth intake | QUEUED |
 | 6 | NPU/OpenVINO backup-transcriber backend (committed scope) | NPU section | QUEUED |
 | - | Installer refresh (screens generated from docs/features/) | BACKLOG.md | QUEUED |
 

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -120,6 +120,29 @@ tiers 0-2, which are deliberately tiny.
   (streaming zipformer / whisper-streaming partial hypotheses), not a
   config flip on the current batch pipeline.
 
+## Owner decisions - 2026-07-04 (fourth intake): the phrase manager
+
+The in-app trainer (build-order step 5) is a SELF-SERVE phrase
+manager, not a record-your-voice wizard - openWakeWord custom phrases
+train synthetically from TYPED TEXT (Piper TTS generates the samples),
+so the owner never has to speak or hand over phrase strings:
+
+- Settings surface: "Set phrase..." takes typed text; training runs as
+  a BACKGROUND job on the dGPU (tens of minutes) with a visible status
+  in the menu (state + progress/ETA estimate). The current phrase(s)
+  display in the menu.
+- Saved phrases list with per-phrase ACTIVE checkmarks; reset/delete.
+  Multiple simultaneous phrases are cheap - openWakeWord runs several
+  models in parallel on the same frame stream (the POC's score dict is
+  already multi-model).
+- Different outcomes per phrase later ("hey Jarvis" -> dictation,
+  "take note" -> something else): the phrase -> action routing rides
+  the same score dict; design it with the tier-2 splice's command
+  routing, not before.
+- Until a custom phrase finishes training, the pretrained placeholder
+  keeps working; training happens alongside normal app use (GPU Guard
+  and auto-sleep already manage VRAM pressure).
+
 ## GPU power-state resilience (owner: "actually really important")
 
 The laptop (Core Ultra 9 285H + Arc 140T iGPU + RTX 5070 Ti, hybrid

--- a/docs/specs/2026-07-04-voice-assistant-direction.md
+++ b/docs/specs/2026-07-04-voice-assistant-direction.md
@@ -133,8 +133,9 @@ so the owner never has to speak or hand over phrase strings:
   display in the menu.
 - Saved phrases list with per-phrase ACTIVE checkmarks; reset/delete.
   Multiple simultaneous phrases are cheap - openWakeWord runs several
-  models in parallel on the same frame stream (the POC's score dict is
-  already multi-model).
+  models in parallel on the same frame stream, and predict() already
+  returns a per-model score dict (the POC loads a single model today;
+  the decision logic iterates the dict, so adding models is additive).
 - Different outcomes per phrase later ("hey Jarvis" -> dictation,
   "take note" -> something else): the phrase -> action routing rides
   the same score dict; design it with the tier-2 splice's command


### PR DESCRIPTION
Records the owner's fourth-intake design for step 5: custom openWakeWord phrases train synthetically from TYPED text (Piper TTS samples), so the trainer is a self-serve settings surface - 'Set phrase...' text input, background dGPU training job with visible menu status/ETA, saved-phrases list with per-phrase active checkmarks, reset, and cheap multi-phrase support (parallel models on one frame stream, the POC's score dict is already multi-model). Phrase-to-action routing ('hey Jarvis' vs 'take note' doing different things) rides the tier-2 command routing later. Docs only.