### PR TITLE
feat: tier-2 splice core - wake starts a ring-buffer-prefixed dictation (step 3, PR 1)

### DIFF
--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -44,12 +44,17 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
 - **Wake-word listener (POC)** - off by default (Settings > Wake Word
   Listener). An always-on, shared (never exclusive) mic stream feeds
   an openWakeWord model on the CPU; audio stays in RAM and nothing is
-  written before a wake. Detection currently wakes the model and
-  toasts; the splice into a dictation is the next step. Ships with the
-  pretrained "hey jarvis" phrase until custom phrases and the in-app
-  trainer arrive. Pauses during whisper mode and while recording.
-  Needs `openwakeword` in the venv (in requirements.txt); without it
-  the toggle simply reports unavailable.
+  written before a wake. Detection starts a normal disk-first
+  dictation, prefixed with the listener's rolling ~2.5s ring buffer so
+  the syllables spoken around the wake phrase are not lost; the spoken
+  phrase itself is stripped from the transcribed text. A sleeping
+  model is woken and recording proceeds while it loads; busy states
+  (dictation, meeting, saving) get a yellow flash instead. Stop with
+  the dictation hotkey (voice outro phrase and silence auto-stop are
+  the next step). Ships with the pretrained "hey jarvis" phrase until
+  custom phrases and the in-app trainer arrive. Pauses during whisper
+  mode and while recording. Needs `openwakeword` in the venv (in
+  requirements.txt); without it the toggle simply reports unavailable.
 
 ## Model and VRAM lifecycle
 

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -14,8 +14,8 @@
 | # | Step | Spec anchor | Status |
 |---|------|-------------|--------|
 | 1 | GPU power-state failover (guard-owned, cpu_fallback_model) | GPU power-state resilience | MERGED (#180-#182) |
-| 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC IN PROGRESS (pretrained phrase) |
-| 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | QUEUED |
+| 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC MERGED (#187, pretrained phrase) |
+| 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | IN PROGRESS (PR 1: splice core) |
 | 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | MERGED (#183, #184) |
 | 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Owner decisions, fourth intake: the phrase manager | QUEUED |
 | 6 | NPU/OpenVINO backup-transcriber backend (committed scope) | NPU section | QUEUED |
@@ -119,6 +119,39 @@ PRs:
   listener's voice command ("record the meeting") or a window-title
   heuristic later.
 
+## Step 3 plan - tier-2 splice
+
+Requirement (spec + handoff design anchors): a wake detection must
+become a hands-free dictation with no syllables lost, ended by an
+outro phrase or silence.
+
+- **PR 1 - splice core**: the listener keeps a rolling ~2.5s ring
+  buffer of int16 frames (fed only while inference runs; cleared on
+  pause entry so recordings and whisper-mode speech never cross into
+  it). On wake it hands the assembled float32 prefix to
+  DictationFlow.begin_via_wake, which starts a NORMAL disk-first
+  dictation with the prefix seeded ahead of live capture in both sinks
+  (RAM accumulator and crash-safety WAV - both seams are ordered
+  before the callback can write, so no locking against the audio
+  thread). The spoken wake phrase rides along in the prefix;
+  strip_leading_phrase removes it (and any ring lead-in before it)
+  from the transcription. Busy states refuse with a yellow flash; a
+  sleeping model is woken and recording proceeds while it loads.
+  Opportunistic fix: AudioRecorder.start() now resets a stale
+  _disk_only flag left by a disk-streamed meeting (an incognito
+  dictation after such a meeting used to capture nothing).
+- **PR 2 - outro + silence stop**: keep listening during a
+  wake-initiated dictation; end it on an outro phrase (second
+  openWakeWord model in the same score dict) or a sustained-silence
+  fallback, whichever is configured.
+
+Known POC gaps (deliberate): audio between detection and the dictation
+mic opening (~0.1-0.3s, usually the natural pause after the phrase) is
+not captured - a seamless handoff needs a listener-to-recorder stream
+handover and is not worth it before the custom-phrase trainer. The
+overlay path (dictation during meeting recording/transcription) is not
+spliced; wakes during meetings refuse politely.
+
 ## Progress log
 
 - **2026-07-04 (round start)**: Handoff consumed; #178 verified merged;
@@ -218,3 +251,13 @@ PRs:
   Verified live in the venv: model download + load + predict on the
   dev machine. Config: wake_listener (off), wake_phrase_model,
   wake_threshold; tray toggle under Settings.
+
+- **2026-07-04 (step 3 PR 1)**: tier-2 splice core per the step 3 plan.
+  A wake now starts a real dictation: ring-buffer prefix into both
+  recorder sinks, wake-phrase strip on the stop path (window-bounded,
+  wake sessions only - a mid-sentence mention of the phrase in a
+  normal dictation is never touched), begin_via_wake busy/sleep
+  semantics mirroring the hotkey toggle, and the stale _disk_only fix
+  with regression tests. The listener frame loop was refactored into
+  handle_frame() so ring gating and pause-latch behavior are
+  unit-tested without audio.

--- a/tests/test_capture_recorder.py
+++ b/tests/test_capture_recorder.py
@@ -80,6 +80,66 @@ class StartStreamingTransactionalTests(unittest.TestCase):
         self.assertIsNone(recorder._mic_writer)
 
 
+class WakeSplicePrefixTests(unittest.TestCase):
+    """Tier-2 splice: prefix audio must be ordered ahead of live capture
+    in BOTH sinks (RAM accumulator and crash-safety WAV), and a stale
+    disk-only flag from a previous meeting must not leak into a new
+    session (an incognito dictation after a disk-streamed meeting used
+    to capture nothing)."""
+
+    def test_start_seeds_ram_with_prefix(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        prefix = np.full((100, 1), 0.5, dtype=np.float32)
+        recorder.start(mic_device=7, prefix_audio=prefix)
+        self.assertEqual(len(recorder._mic_data), 1)
+        self.assertIs(recorder._mic_data[0], prefix)
+
+    def test_start_without_prefix_starts_empty(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        recorder.start(mic_device=7)
+        self.assertEqual(recorder._mic_data, [])
+
+    def test_start_resets_stale_disk_only_flag(self):
+        recorder, capture = _make_recorder()
+        self.addCleanup(lambda: setattr(capture, "sd",
+                                        __import__("sounddevice")))
+        recorder._disk_only = True  # left behind by a disk-streamed meeting
+        recorder.start(mic_device=7)
+        self.assertFalse(recorder._disk_only,
+                         "a session without a writer must accumulate RAM")
+
+    def test_streaming_prefix_is_written_before_writer_is_published(self):
+        recorder, capture = _make_recorder(install_fake_sd=False)
+        prefix = np.full((100, 1), 0.5, dtype=np.float32)
+        writer = mock.Mock()
+        published_at_write = []
+        writer.write.side_effect = (
+            lambda chunk: published_at_write.append(recorder._mic_writer))
+
+        with mock.patch.object(capture, "StreamingWavWriter",
+                               return_value=writer):
+            recorder.start_streaming(mic_path="/tmp/x.wav",
+                                     prefix_audio=prefix)
+
+        writer.write.assert_called_once()
+        self.assertIs(writer.write.call_args[0][0], prefix)
+        self.assertEqual(published_at_write, [None],
+                         "prefix must land before the callback can write")
+        self.assertIs(recorder._mic_writer, writer)
+
+    def test_streaming_without_prefix_writes_nothing_upfront(self):
+        recorder, capture = _make_recorder(install_fake_sd=False)
+        writer = mock.Mock()
+        with mock.patch.object(capture, "StreamingWavWriter",
+                               return_value=writer):
+            recorder.start_streaming(mic_path="/tmp/x.wav")
+        writer.write.assert_not_called()
+
+
 class MicCallbackNormalizationTests(unittest.TestCase):
     def test_int16_samples_are_scaled_to_minus_one_to_one(self):
         from whisper_sync.capture import AudioRecorder

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -29,14 +29,18 @@ class _FakeRecorder:
         self.audio = {"mic": "AUDIO"}
         self.stop_streaming_calls = 0
         self.fail_start = False
+        self.start_prefix = None
+        self.streaming_prefix = None
 
-    def start(self, mic_device=None):
+    def start(self, mic_device=None, prefix_audio=None):
         if self.fail_start:
             raise RuntimeError("no mic")
+        self.start_prefix = prefix_audio
         self.is_recording = True
 
-    def start_streaming(self, path):
+    def start_streaming(self, path, prefix_audio=None):
         self.streaming_path = path
+        self.streaming_prefix = prefix_audio
 
     def stop(self):
         self.is_recording = False
@@ -426,6 +430,92 @@ class OverlayDictationTests(_FlowHarness):
         self.assertFalse(self.flow.overlay_active)
         self.assertFalse(self.app.state.current.feature_suggest)
         self.paste.assert_not_called()
+
+
+class WakeSpliceTests(_FlowHarness):
+    """Tier-2 splice entry point: begin_via_wake starts a NORMAL
+    disk-first dictation with the listener's ring buffer as an audio
+    prefix, and the stop path strips the spoken wake phrase."""
+
+    def test_begin_via_wake_threads_prefix_to_ram_and_disk(self):
+        self.assertTrue(self.flow.begin_via_wake("PREFIX"))
+        self.assertEqual(self.app.state.current.mode, "dictation")
+        self.assertEqual(self.app.recorder.start_prefix, "PREFIX")
+        self.assertEqual(self.app.recorder.streaming_prefix, "PREFIX",
+                         "crash-safety WAV must contain the prefix too")
+
+    def test_wake_session_strips_leading_phrase_on_stop(self):
+        self.app.worker.transcribe_fast = (
+            lambda audio, model_override=None, timeout=None:
+            "Hey, Jarvis. Take a note about the demo.")
+        self.assertTrue(self.flow.begin_via_wake(None))
+        self.flow.toggle()
+        self.paste.assert_called_once()
+        self.assertEqual(self.paste.call_args[0][0],
+                         "Take a note about the demo.")
+
+    def test_normal_dictation_never_strips(self):
+        self.app.worker.transcribe_fast = (
+            lambda audio, model_override=None, timeout=None:
+            "Hey, Jarvis. Take a note.")
+        self.flow.toggle()
+        self.flow.toggle()
+        self.assertEqual(self.paste.call_args[0][0],
+                         "Hey, Jarvis. Take a note.")
+
+    def test_wake_session_with_only_the_phrase_pastes_nothing(self):
+        self.app.worker.transcribe_fast = (
+            lambda audio, model_override=None, timeout=None: "Hey Jarvis.")
+        self.flow.begin_via_wake(None)
+        self.flow.toggle()
+        self.paste.assert_not_called()
+        self.assertEqual(self.app.state.current.mode, "done")
+
+    def test_discarded_wake_session_does_not_strip_the_next_dictation(self):
+        self.app.worker.transcribe_fast = (
+            lambda audio, model_override=None, timeout=None:
+            "Hey Jarvis is my wake phrase.")
+        self.flow.begin_via_wake(None)
+        self.flow.discard()
+        self.flow.toggle()
+        self.flow.toggle()
+        self.assertEqual(self.paste.call_args[0][0],
+                         "Hey Jarvis is my wake phrase.")
+
+    def test_refuses_while_a_dictation_is_running(self):
+        self.flow.toggle()
+        self.assertFalse(self.flow.begin_via_wake(None))
+        self.assertEqual(self.app.state.current.mode, "dictation",
+                         "running dictation must be untouched")
+
+    def test_refuses_during_meeting_and_saving(self):
+        self.app.state.emit(MEETING_STARTED, mode="meeting")
+        self.assertFalse(self.flow.begin_via_wake(None))
+        self.app.state.emit("x", mode="saving")
+        self.assertFalse(self.flow.begin_via_wake(None))
+
+    def test_refuses_during_overlay_and_meeting_transcription(self):
+        self.app.state.emit("x", dictation_overlay=True)
+        self.assertFalse(self.flow.begin_via_wake(None))
+        self.app.state.emit("x", dictation_overlay=False,
+                            meeting_transcribing=True)
+        self.assertFalse(self.flow.begin_via_wake(None),
+                         "overlay path is not spliced; must refuse")
+
+    def test_wakes_a_sleeping_model_and_records_disk_first(self):
+        from whisper_sync.state_manager import SLEEP_STARTED
+        self.app.auto_sleep = mock.Mock()
+        self.app.worker.ready = False
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        self.assertTrue(self.flow.begin_via_wake(None))
+        self.app.auto_sleep.wake.assert_called_once_with(reason="wake_word")
+        self.assertTrue(self.app.recorder.is_recording)
+
+    def test_mic_failure_reports_false_and_clears_wake_intent(self):
+        self.app.recorder.fail_start = True
+        self.assertFalse(self.flow.begin_via_wake(None))
+        self.assertIsNone(self.app.state.current.mode)
+        self.assertFalse(self.flow._wake_session)
 
 
 class HistoryTests(_FlowHarness):

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -11,21 +11,46 @@ import types
 import unittest
 from unittest import mock
 
-from whisper_sync import listener as listener_mod
-from whisper_sync.listener import WakeListener
-from whisper_sync.state_manager import StateManager, SLEEP_STARTED
+try:
+    import numpy as np
+except ImportError:  # dependency-light system python (CI)
+    np = None
+
+from whisper_sync.listener import (
+    WakeListener, strip_leading_phrase, RING_FRAMES,
+)
+from whisper_sync.state_manager import StateManager
 
 
 class _FakeApp:
     def __init__(self):
-        self.cfg = {"wake_listener": True, "wake_threshold": 0.5}
+        self.cfg = {"wake_listener": True, "wake_threshold": 0.5,
+                    "sample_rate": 16000}
         self.state = StateManager(None, {})
         self.recorder = types.SimpleNamespace(is_recording=False)
         self.auto_sleep = types.SimpleNamespace(wake=mock.Mock())
+        self.dictation = types.SimpleNamespace(
+            begin_via_wake=mock.Mock(return_value=True))
         self.flashes = 0
 
     def _yellow_flash(self):
         self.flashes += 1
+
+
+class _FakeModel:
+    """Stands in for the openWakeWord model in frame-handling tests."""
+
+    def __init__(self, score=0.0):
+        self.score = score
+        self.resets = 0
+        self.predicted = []
+
+    def predict(self, mono):
+        self.predicted.append(mono)
+        return {"hey_jarvis": self.score}
+
+    def reset(self):
+        self.resets += 1
 
 
 class WakeDecisionTests(unittest.TestCase):
@@ -156,19 +181,144 @@ class LifecycleTests(unittest.TestCase):
             self.listener._thread.join(timeout=2)
             self.assertFalse(self.listener._thread.is_alive())
 
-    def test_default_wake_action_wakes_a_sleeping_model(self):
-        self.app.state.emit(SLEEP_STARTED, sleeping=True)
-        with mock.patch.object(listener_mod, "notify"):
-            self.listener._default_wake_action()
-        self.app.auto_sleep.wake.assert_called_once()
-        self.assertEqual(self.app.flashes, 0,
-                         "wake() owns the flash when asleep")
+class FrameHandlingTests(unittest.TestCase):
+    """handle_frame drives the ring buffer and the pause latch."""
 
-    def test_default_wake_action_flashes_when_awake(self):
-        with mock.patch.object(listener_mod, "notify"):
+    def setUp(self):
+        self.app = _FakeApp()
+        self.listener = WakeListener(self.app, on_wake=lambda: None)
+        self.model = _FakeModel()
+
+    def test_frames_feed_ring_and_model(self):
+        self.listener.handle_frame("f1", self.model)
+        self.listener.handle_frame("f2", self.model)
+        self.assertEqual(list(self.listener._ring), ["f1", "f2"])
+        self.assertEqual(self.model.predicted, ["f1", "f2"])
+
+    def test_ring_is_bounded(self):
+        for i in range(RING_FRAMES + 5):
+            self.listener.handle_frame(i, self.model)
+        self.assertEqual(len(self.listener._ring), RING_FRAMES)
+        self.assertEqual(self.listener._ring[0], 5,
+                         "oldest frames must roll off")
+
+    def test_pause_resets_model_once_and_clears_ring(self):
+        self.listener.handle_frame("pre", self.model)
+        self.app.cfg["incognito"] = True
+        self.listener.handle_frame("p1", self.model)
+        self.listener.handle_frame("p2", self.model)
+        self.assertEqual(self.model.resets, 1,
+                         "reset fires once on pause ENTRY, not per frame")
+        self.assertEqual(len(self.listener._ring), 0,
+                         "pre-pause audio must not survive the pause")
+        self.assertEqual(self.model.predicted, ["pre"],
+                         "no inference while paused")
+
+    def test_resume_after_pause_feeds_again(self):
+        self.app.cfg["incognito"] = True
+        self.listener.handle_frame("p1", self.model)
+        self.app.cfg["incognito"] = False
+        self.listener.handle_frame("f1", self.model)
+        self.assertEqual(list(self.listener._ring), ["f1"])
+        self.assertEqual(self.model.predicted, ["f1"])
+
+
+@unittest.skipIf(np is None, "numpy not installed (CI system python)")
+class AssemblePrefixTests(unittest.TestCase):
+    def setUp(self):
+        self.listener = WakeListener(_FakeApp(), on_wake=lambda: None)
+
+    def test_int16_frames_become_float32_column(self):
+        frame = np.full(1280, 16384, dtype=np.int16)
+        self.listener._ring.append(frame)
+        self.listener._ring.append(frame)
+        prefix = self.listener._assemble_prefix()
+        self.assertEqual(prefix.shape, (2560, 1))
+        self.assertEqual(prefix.dtype, np.float32)
+        self.assertAlmostEqual(float(prefix[0][0]), 0.5, places=3)
+        self.assertEqual(len(self.listener._ring), 0,
+                         "assembly consumes the ring")
+
+    def test_empty_ring_returns_none(self):
+        self.assertIsNone(self.listener._assemble_prefix())
+
+
+class WakeActionSpliceTests(unittest.TestCase):
+    """The default wake action is the tier-2 splice now."""
+
+    def setUp(self):
+        self.app = _FakeApp()
+        self.listener = WakeListener(self.app)
+
+    def test_wake_hands_prefix_to_dictation(self):
+        with mock.patch.object(self.listener, "_assemble_prefix",
+                               return_value="PREFIX"):
+            self.listener._default_wake_action()
+        self.app.dictation.begin_via_wake.assert_called_once_with("PREFIX")
+        self.assertEqual(self.app.flashes, 0)
+
+    def test_busy_dictation_flashes(self):
+        self.app.dictation.begin_via_wake.return_value = False
+        with mock.patch.object(self.listener, "_assemble_prefix",
+                               return_value=None):
             self.listener._default_wake_action()
         self.assertEqual(self.app.flashes, 1)
-        self.app.auto_sleep.wake.assert_not_called()
+
+    def test_foreign_sample_rate_skips_prefix_and_clears_ring(self):
+        # The ring is 16 kHz; splicing it into a recorder configured for
+        # another rate would time-stretch the prefix audio.
+        self.app.cfg["sample_rate"] = 48000
+        self.listener._ring.append("stale")
+        self.listener._default_wake_action()
+        self.app.dictation.begin_via_wake.assert_called_once_with(None)
+        self.assertEqual(len(self.listener._ring), 0)
+
+
+class StripLeadingPhraseTests(unittest.TestCase):
+    def test_strips_phrase_and_punctuation(self):
+        self.assertEqual(
+            strip_leading_phrase("Hey, Jarvis. Take a note.", "hey_jarvis"),
+            "Take a note.")
+        self.assertEqual(
+            strip_leading_phrase("Hey Jarvis take a note", "hey_jarvis"),
+            "take a note")
+
+    def test_strips_room_audio_lead_in_before_the_phrase(self):
+        # The 2.5s ring can start mid-sentence of ambient speech; the
+        # summons and everything before it belong to the wake, not the
+        # dictation.
+        self.assertEqual(
+            strip_leading_phrase("so anyway hey jarvis note this",
+                                 "hey_jarvis"),
+            "note this")
+
+    def test_no_phrase_returns_text_unchanged(self):
+        self.assertEqual(
+            strip_leading_phrase("Take a note about the demo.",
+                                 "hey_jarvis"),
+            "Take a note about the demo.")
+
+    def test_phrase_beyond_search_window_is_preserved(self):
+        text = ("The quick brown fox jumps over the lazy sleeping dog "
+                "and then says hey jarvis at the end")
+        self.assertEqual(strip_leading_phrase(text, "hey_jarvis"), text)
+
+    def test_only_the_phrase_yields_empty_string(self):
+        self.assertEqual(strip_leading_phrase("Hey Jarvis.", "hey_jarvis"),
+                         "")
+
+    def test_versioned_model_name_tokens(self):
+        self.assertEqual(
+            strip_leading_phrase("Hey Jarvis, okay.", "hey_jarvis_v0.1"),
+            "okay.")
+
+    def test_single_token_phrase_respects_word_boundaries(self):
+        self.assertEqual(
+            strip_leading_phrase("Alexander wrote this down.", "alexa"),
+            "Alexander wrote this down.")
+
+    def test_empty_text_is_safe(self):
+        self.assertEqual(strip_leading_phrase("", "hey_jarvis"), "")
 
 
 if __name__ == "__main__":

--- a/whisper_sync/capture.py
+++ b/whisper_sync/capture.py
@@ -303,12 +303,28 @@ class AudioRecorder:
                 self._speaker_error_logged = True
                 logger.warning(f"speaker callback error (suppressed): {e}")
 
-    def start(self, mic_device: int | None = None, speaker_device: int | None = None):
+    def start(self, mic_device: int | None = None, speaker_device: int | None = None,
+              prefix_audio: np.ndarray | None = None):
         with self._lock:
             self._mic_data = []
             self._speaker_data = []
             self._mic_error_logged = False
             self._speaker_error_logged = False
+            # Wake-splice prefix (tier-2): mono float32 audio the wake
+            # listener ring-buffered BEFORE this recorder existed, at
+            # self.sample_rate. Seeded before the stream opens, so it is
+            # ordered ahead of every callback buffer without any locking
+            # against the callback thread. The disk writer gets the same
+            # prefix in start_streaming() (RAM and disk are parallel
+            # sinks; each needs its own copy).
+            if prefix_audio is not None and len(prefix_audio):
+                self._mic_data.append(prefix_audio)
+            # Disk-only is a per-session property of start_streaming().
+            # A previous disk-streamed meeting must not leave the
+            # RAM-skipping flag armed for a session that never opens a
+            # writer: an incognito dictation after such a meeting used to
+            # capture NOTHING (callback skipped RAM and had no writer).
+            self._disk_only = False
 
             # Transactional: the recorder only becomes "recording" AFTER
             # the mic stream is fully open and started. On any failure we
@@ -552,7 +568,8 @@ class AudioRecorder:
             return None
         return _monotonic() - last
 
-    def start_streaming(self, mic_path, speaker_path=None, disk_only=False):
+    def start_streaming(self, mic_path, speaker_path=None, disk_only=False,
+                        prefix_audio=None):
         """Open streaming WAV writers for crash safety during meeting recording.
 
         Args:
@@ -562,12 +579,19 @@ class AudioRecorder:
                 the loopback stream is active and ``disk_only`` is set.
             disk_only: If True, skip RAM accumulation -- audio lives only on disk.
                 Use for long meetings to prevent MemoryError.
+            prefix_audio: Optional mono float32 audio (wake-splice ring
+                buffer) written ahead of the live capture.
 
         Transactional: if ``StreamingWavWriter`` raises (e.g. unwritable
         disk), the ``_disk_only`` flag is NOT flipped, so the callback
         continues to accumulate into RAM and the meeting is still usable.
         """
         writer = StreamingWavWriter(mic_path, channels=1, rate=self.sample_rate)
+        # The prefix is written BEFORE the writer is published to the
+        # callback thread, so it lands ahead of every live buffer in the
+        # WAV without locking.
+        if prefix_audio is not None and len(prefix_audio):
+            writer.write(prefix_audio)
         # Only commit state after the writer is successfully opened. The
         # old ordering flipped _disk_only first; a writer-open failure
         # then left the callback skipping BOTH RAM and disk and the

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -75,6 +75,11 @@ class DictationFlow:
         self._cap_handle = None
         self._history = dictation_log.load_recent(HISTORY_LIMIT)
         self._history_lock = threading.Lock()
+        # True while the CURRENT dictation was started by the wake
+        # listener (tier-2 splice). Mutated only under app._lock; the
+        # stop path captures-and-clears it exactly like feature intent
+        # and uses it to strip the spoken wake phrase from the result.
+        self._wake_session = False
 
     # -- Public API (hotkeys, clicks, menu, startup recovery) ---------------
 
@@ -149,6 +154,40 @@ class DictationFlow:
             elif self.app._can_record():
                 self._start(feature=True)
 
+    def begin_via_wake(self, prefix_audio=None) -> bool:
+        """Start a normal dictation on behalf of the wake listener.
+
+        Tier-2 splice entry point: ``prefix_audio`` is the listener's
+        ring buffer (mono float32 at the recorder's sample rate), seeded
+        ahead of the live capture so the syllables spoken around the
+        wake phrase are not lost. Mirrors toggle()'s start arm: a
+        sleeping model is woken and recording proceeds disk-first while
+        it loads. Busy states (dictation, meeting, saving, overlay,
+        meeting transcription) refuse instead of queueing - the wake
+        splice never interrupts other work. Returns True when a
+        dictation recording actually started.
+        """
+        with self.app._lock:
+            current = self.app.state.current if self.app.state else None
+            if current and (current.dictation_overlay
+                            or current.meeting_transcribing):
+                # The overlay path (separate recorder + backup model)
+                # is not spliced yet; refuse rather than start a normal
+                # dictation that would queue behind the meeting job.
+                return False
+            mode = current.mode if current else None
+            if mode == "dictation" or not self.app._can_record():
+                return False
+            if current and current.sleeping:
+                self.app.auto_sleep.wake(reason="wake_word")
+            self._start(feature=False, prefix_audio=prefix_audio)
+            # _start can fail before DICTATION_STARTED sticks (mic open
+            # failure emits IDLE); report what actually happened.
+            started = ((self.app.state.current.mode
+                        if self.app.state else None) == "dictation")
+            self._wake_session = started
+            return started
+
     def discard(self):
         """Discard current dictation - stop recording, throw away audio, return to idle."""
         with self.app._lock:
@@ -168,6 +207,7 @@ class DictationFlow:
 
             if (self.app.state.current.mode if self.app.state else None) != "dictation":
                 return
+            self._wake_session = False
             self.app.recorder.stop()  # stop recording, discard the audio
             self.app.recorder.stop_streaming()
             if self._wav_path and self._wav_path.exists():
@@ -203,13 +243,18 @@ class DictationFlow:
                         "(always_available_dictation disabled)", extra={"secondary": True})
             notify(f"{label} unavailable", "Enable always-available dictation in settings")
 
-    def _start(self, feature: bool):
+    def _start(self, feature: bool, prefix_audio=None):
         # Lazy: capture/backup_worker import numpy; keep this module
         # importable on the dependency-light system python (CI suite).
         from .backup_worker import BackupTranscriber
         from .capture import get_default_devices
 
         app = self.app
+        # Any fresh start is a normal session until begin_via_wake says
+        # otherwise (it sets the flag AFTER a successful start). Keeps a
+        # discarded or failed wake session from leaking its strip
+        # behavior into the next hotkey dictation.
+        self._wake_session = False
         _meeting_tx = app.state.current.meeting_transcribing if app.state else False
         if not app.worker.is_ready():
             has_backup = _meeting_tx and BackupTranscriber.is_enabled(app.cfg)
@@ -241,7 +286,7 @@ class DictationFlow:
             # device and often rejects float32 @ 16 kHz with MME error 32.
             mic = get_default_devices().get("input")
         try:
-            app.recorder.start(mic_device=mic)
+            app.recorder.start(mic_device=mic, prefix_audio=prefix_audio)
         except Exception as e:
             logger.error("Failed to start mic for dictation: %s", e, exc_info=True)
             notify("Dictation unavailable", f"Mic could not be opened: {e}")
@@ -257,7 +302,8 @@ class DictationFlow:
             prefix = "feature_" if feature else ""
             self._wav_path = log_dir / f"{prefix}{ts}.wav"
             try:
-                app.recorder.start_streaming(self._wav_path)
+                app.recorder.start_streaming(self._wav_path,
+                                             prefix_audio=prefix_audio)
             except Exception as e:
                 logger.warning("Dictation disk streaming disabled: %s", e)
                 self._wav_path = None
@@ -331,8 +377,11 @@ class DictationFlow:
         # transition that leaves dictation mode. All mutators of
         # feature_suggest run under app._lock (which every caller of _stop
         # holds), so the read-then-emit pair is atomic exactly like the old
-        # locked flag capture.
+        # locked flag capture. Wake-session intent follows the same
+        # discipline: captured here, consumed by the strip below.
         is_feature = app.state.current.feature_suggest
+        was_wake = self._wake_session
+        self._wake_session = False
         app.state.emit(TRANSCRIPTION_STARTED, mode="transcribing", feature_suggest=False)
 
         dictation_model = app._gpu_guard.effective_model(
@@ -395,6 +444,13 @@ class DictationFlow:
                     t1 = _time.perf_counter()
                     logger.debug(f"transcribe_fast: {t1 - t0:.2f}s")
                 t2 = _time.perf_counter()
+                if was_wake and text:
+                    # The ring-buffer prefix contains the spoken wake
+                    # phrase; without this the pasted text starts with
+                    # "Hey, Jarvis." (listener.py owns the strip logic).
+                    from .listener import strip_leading_phrase
+                    text = strip_leading_phrase(
+                        text, app.cfg.get("wake_phrase_model", "hey_jarvis"))
                 char_count = len(text) if text else 0
 
                 if is_feature:

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -1,12 +1,20 @@
-"""Always-on wake-word listener - assistant build round, step 2 (POC).
+"""Always-on wake-word listener - assistant build round, steps 2+3.
 
 Tier 0+1 of the voice-assistant architecture (direction spec): a
 shared, non-exclusive mic stream feeds 80ms frames into an openWakeWord
-model on the CPU. This POC ships with a PRETRAINED phrase as a
-placeholder (default "hey jarvis") - the owner's custom wake/outro
-phrases and the in-app trainer come later. On detection the POC wakes
-the transcription model (auto_sleep.wake) and toasts; the tier-2
-splice into a ring-buffer-prefixed dictation is the next step.
+model on the CPU, with a PRETRAINED phrase as a placeholder (default
+"hey jarvis") until the owner's custom wake/outro phrases and the
+in-app trainer arrive (step 5).
+
+Tier 2 splice (step 3): the listener keeps a rolling RAM ring buffer of
+the last ~2.5s of frames. On detection it hands that buffer to a normal
+disk-first dictation start (DictationFlow.begin_via_wake), so the
+syllables spoken around the wake phrase are not lost while the
+dictation mic opens. The spoken wake phrase rides along in the prefix
+audio; the stop path strips it from the transcription text
+(strip_leading_phrase). Known POC gap, recorded in the plan doc: audio
+between detection and the dictation mic opening (~0.1-0.3s, usually
+the natural pause after the phrase) is not captured.
 
 Power and privacy posture (spec + owner decisions):
 - OFF by default (``wake_listener``); tray toggle under Settings.
@@ -33,8 +41,10 @@ disabled.
 
 from __future__ import annotations
 
+import re
 import threading
 import time
+from collections import deque
 
 from .logger import logger
 from .notifications import notify
@@ -48,18 +58,76 @@ FRAME_SAMPLES = 1280
 # spoken wake phrase must fire exactly one wake.
 REFRACTORY_S = 3.0
 
+# Rolling pre-wake buffer handed to the dictation splice. Long enough
+# to cover the spoken wake phrase plus lead-in; short enough that the
+# transcriber barely notices the prefix. RAM cost: ~80 KB of int16.
+RING_SECONDS = 2.5
+RING_FRAMES = int(RING_SECONDS * SAMPLE_RATE / FRAME_SAMPLES)
+
+# strip_leading_phrase only strips when the wake phrase appears within
+# this many characters of the start of the transcription: the ring is
+# ~2.5s, so a genuine spoken phrase always lands early. Anything later
+# is the user SAYING the phrase mid-sentence and must be preserved.
+STRIP_SEARCH_CHARS = 48
+
+
+def _phrase_tokens(phrase_name: str) -> list[str]:
+    """Model name -> spoken words ("hey_jarvis_v0.1" -> ["hey", "jarvis"]).
+
+    Drops path components, the file extension, and bare version tokens
+    (v0, v1, ...) that appear in openWakeWord model file names.
+    """
+    stem = re.split(r"[\\/]", phrase_name)[-1]
+    stem = stem.split(".", 1)[0]
+    tokens = [t for t in re.split(r"[_\-\s]+", stem.lower()) if t]
+    return [t for t in tokens if not re.fullmatch(r"v\d+", t)]
+
+
+def strip_leading_phrase(text: str, phrase_name: str) -> str:
+    """Remove the spoken wake phrase (and any lead-in before it) from
+    the head of a wake-spliced transcription.
+
+    The ring-buffer prefix contains the wake phrase and up to ~1.5s of
+    room audio before it; both belong to the summons, not the
+    dictation. Conservative: when the phrase is not found near the
+    start, the text is returned unchanged.
+    """
+    if not text:
+        return text
+    tokens = _phrase_tokens(phrase_name)
+    if not tokens:
+        return text
+    # Whisper renders "hey jarvis" as "Hey, Jarvis." and friends -
+    # allow punctuation and whitespace between and after the tokens.
+    # Word boundaries keep single-token phrases from matching inside a
+    # longer word ("alexa" must not strip through "Alexander").
+    sep = r"[\s,.!?;:-]+"
+    pattern = (r"\b" + sep.join(re.escape(t) for t in tokens)
+               + r"\b[\s,.!?;:-]*")
+    match = re.search(pattern, text, re.IGNORECASE)
+    if match is None or match.start() > STRIP_SEARCH_CHARS:
+        return text
+    return text[match.end():].lstrip()
+
 
 class WakeListener:
     """Owns the always-on listening loop; services via ``app``."""
 
     def __init__(self, app, on_wake=None):
         self.app = app
-        # Seam for step 3: the splice replaces this default action.
+        # The step-3 seam: the default action IS the tier-2 splice now;
+        # tests (and future command routing) can still inject on_wake.
         self._on_wake = on_wake or self._default_wake_action
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
         self._last_fire = 0.0
         self._lock = threading.Lock()
+        # Rolling pre-wake audio (int16 mono frames). Only fed while
+        # inference runs: paused periods (whisper mode, recordings)
+        # leave nothing behind, and the buffer is cleared on pause
+        # entry so pre-pause audio never crosses a privacy boundary.
+        self._ring: deque = deque(maxlen=RING_FRAMES)
+        self._was_paused = False
 
     # -- Config ----------------------------------------------------------------
 
@@ -143,26 +211,14 @@ class WakeListener:
         logger.info(
             f"Wake listener active: phrase model '{self._phrase()}', "
             f"threshold {self._threshold():.2f}")
-        was_paused = False
+        self._was_paused = False
+        self._ring.clear()
         try:
             with sd.InputStream(samplerate=SAMPLE_RATE, channels=1,
                                 dtype="int16", blocksize=FRAME_SAMPLES) as stream:
                 while not stop_event.is_set():
                     frame, _overflowed = stream.read(FRAME_SAMPLES)
-                    if self._paused():
-                        # Keep draining the stream (cheap) but skip
-                        # inference. Reset ONCE on entering the pause
-                        # (review catch: not per 80ms frame) - clears
-                        # pre-pause audio so it cannot fire on resume;
-                        # nothing accumulates during the pause because
-                        # paused frames are never fed to the model.
-                        if not was_paused:
-                            model.reset()
-                            was_paused = True
-                        continue
-                    was_paused = False
-                    scores = model.predict(np.squeeze(frame))
-                    self.process_scores(scores)
+                    self.handle_frame(np.squeeze(frame), model)
         except Exception:
             logger.warning("Wake listener stopped on stream error",
                            exc_info=True)
@@ -186,6 +242,43 @@ class WakeListener:
                          vad_threshold=0.5)
 
     # -- Decision logic (unit-tested without audio) --------------------------------
+
+    def handle_frame(self, mono, model) -> None:
+        """One frame's worth of decisions (unit-tested without audio).
+
+        ``mono`` is one 80ms int16 frame (already squeezed to 1-D by the
+        loop); ``model`` is the loaded openWakeWord model. While paused,
+        inference is skipped and the model is reset ONCE on entering the
+        pause (review catch on the POC: not per 80ms frame) - it clears
+        pre-pause audio so it cannot fire on resume, and the ring buffer
+        is cleared for the same reason (paused audio is someone's
+        recording or whisper-mode speech; the splice must never inherit
+        it).
+        """
+        if self._paused():
+            if not self._was_paused:
+                model.reset()
+                self._ring.clear()
+                self._was_paused = True
+            return
+        self._was_paused = False
+        self._ring.append(mono)
+        self.process_scores(model.predict(mono))
+
+    def _assemble_prefix(self):
+        """Ring frames -> the mono float32 column the recorder expects.
+
+        Consumes (and clears) the ring. Returns None when the ring is
+        empty. numpy is imported lazily: this only runs on the wake
+        path, where the audio stack is present by definition.
+        """
+        if not self._ring:
+            return None
+        import numpy as np
+        frames = list(self._ring)
+        self._ring.clear()
+        audio = np.concatenate(frames).astype(np.float32) / 32768.0
+        return audio.reshape(-1, 1)
 
     def _paused(self) -> bool:
         """True while inference should not run.
@@ -224,13 +317,28 @@ class WakeListener:
         return True
 
     def _default_wake_action(self) -> None:
-        """POC action: wake the model + announce. The tier-2 splice
-        (ring-buffer-prefixed dictation + outro phrase) replaces this."""
-        logger.info("Wake word detected")
-        state = self.app.state
-        if state is not None and state.current.sleeping:
-            self.app.auto_sleep.wake(reason="wake_word")
+        """Tier-2 splice: hand the ring buffer to a dictation start.
+
+        begin_via_wake owns the busy checks and wakes a sleeping model
+        itself (recording is disk-first, so it starts immediately and
+        transcription waits for the load). The prefix is skipped when
+        the recorder runs at a non-16k sample rate: the ring is 16k and
+        must not be spliced into a stream at another rate.
+        """
+        logger.info("Wake word detected - starting dictation")
+        prefix = None
+        try:
+            recorder_rate = int(self.app.cfg.get("sample_rate", SAMPLE_RATE))
+        except (TypeError, ValueError):
+            recorder_rate = SAMPLE_RATE
+        if recorder_rate == SAMPLE_RATE:
+            prefix = self._assemble_prefix()
         else:
+            self._ring.clear()
+            logger.debug("wake prefix skipped: recorder sample_rate is "
+                         f"{recorder_rate}, ring is {SAMPLE_RATE}")
+        started = self.app.dictation.begin_via_wake(prefix)
+        if not started:
+            logger.info("Wake word heard but dictation could not start "
+                        "(another workflow is active)")
             self.app._yellow_flash()
-        notify("Wake word heard",
-               "POC: dictation splice arrives in the next step.")


### PR DESCRIPTION
## What

Step 3 (tier-2 splice) PR 1 of 2, per docs/plans/2026-07-04-assistant-build-round.md. A wake detection now starts a normal disk-first dictation instead of just toasting.

- **Listener ring buffer**: rolling ~2.5s of int16 frames, fed only while inference runs; cleared on pause entry (recordings and whisper-mode speech never cross into it) and consumed on wake. Frame loop refactored into `handle_frame()` so ring gating and the pause latch are unit-tested without audio.
- **Recorder prefix seams**: `AudioRecorder.start(prefix_audio=...)` seeds the RAM accumulator before the stream opens; `start_streaming(prefix_audio=...)` writes the prefix before the writer is published to the callback. Both orderings are race-free without locking against the audio thread.
- **`DictationFlow.begin_via_wake`**: mirrors the hotkey toggle's start arm (wakes a sleeping model, records disk-first while it loads); refuses busy states instead of queueing. Wake-session intent follows the feature-suggest capture-and-clear discipline.
- **Wake-phrase strip**: `strip_leading_phrase` removes the spoken phrase (and ring lead-in before it) from the transcription. Window-bounded and wake-session-only; a normal dictation mentioning the phrase is never touched.
- **Opportunistic fix** (regression-tested): `start()` resets a stale `_disk_only` flag left by a disk-streamed meeting; an incognito dictation after such a meeting used to capture nothing.

## Known POC gaps (recorded in the plan doc)

- ~0.1-0.3s detection-to-mic-open gap (usually the natural pause after the phrase).
- Overlay path (dictation during meetings) is not spliced; wakes refuse politely.
- Outro phrase + silence auto-stop land in PR 2.

## Tests

- System suite: 399 passed, 2 skipped (numpy-gated prefix-assembly tests) in 16s.
- Venv: test_capture_recorder + test_listener + test_dictation_flow, 80 passed (prefix ordering, disk_only reset, ring gating, strip suite, begin_via_wake semantics).