### PR TITLE
feat: hands-free stop for wake dictations - outro phrase + silence (step 3, PR 2)

### DIFF
--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -53,3 +53,5 @@ fails if this table and the defaults file disagree on keys.
 | `wake_listener` | `false` | Always-on wake-word listener (POC; needs openwakeword in the venv) |
 | `wake_phrase_model` | `hey_jarvis` | Pretrained openWakeWord phrase model (placeholder until custom phrases ship) |
 | `wake_threshold` | `0.5` | Wake-word detection score threshold (0-1) |
+| `wake_outro_model` | (empty) | Outro phrase model that ends a wake dictation hands-free (empty = disabled) |
+| `wake_silence_stop_s` | `8` | Sustained silence (silero VAD) that ends a wake dictation; 0 disables |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -49,11 +49,15 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   the syllables spoken around the wake phrase are not lost; the spoken
   phrase itself is stripped from the transcribed text. A sleeping
   model is woken and recording proceeds while it loads; busy states
-  (dictation, meeting, saving) get a yellow flash instead. Stop with
-  the dictation hotkey (voice outro phrase and silence auto-stop are
-  the next step). Ships with the pretrained "hey jarvis" phrase until
-  custom phrases and the in-app trainer arrive. Pauses during whisper
-  mode and while recording. Needs `openwakeword` in the venv (in
+  (dictation, meeting, saving) get a yellow flash instead. The
+  dictation ends hands-free on the outro phrase (`wake_outro_model`, a
+  second openWakeWord model; also stripped from the text tail) or
+  after `wake_silence_stop_s` of silence (silero VAD; 0 disables) -
+  the dictation hotkey still works at any time. Ships with the
+  pretrained "hey jarvis" phrase until custom phrases and the in-app
+  trainer arrive. Pauses during whisper mode and while recording
+  (except during its own wake dictations, which it watches for the
+  stop signals). Needs `openwakeword` in the venv (in
   requirements.txt); without it the toggle simply reports unavailable.
 
 ## Model and VRAM lifecycle

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -261,3 +261,17 @@ spliced; wakes during meetings refuse politely.
   with regression tests. The listener frame loop was refactored into
   handle_frame() so ring gating and pause-latch behavior are
   unit-tested without audio.
+
+- **2026-07-04 (step 3 PR 2)**: hands-free stop per the step 3 plan.
+  During a wake-initiated dictation the listener keeps running
+  (handle_frame routes on the session flag before the pause gate) and
+  ends the dictation on the outro phrase (wake_outro_model loads into
+  the SAME openWakeWord model; its score key never fires a wake, and a
+  2s grace window keeps a wake-alike outro from ending the session it
+  started) or on sustained silence (wake_silence_stop_s, default 8s,
+  read from the silero VAD scores the model already computes; a
+  missing VAD buffer counts every frame as voice, failing safe). The
+  spoken outro is stripped from the text tail (strip_trailing_phrase,
+  anchored to the end so a mid-sentence outro is preserved). Hotkey
+  stop, discard, the minutes cap, and incognito all hand the listener
+  back to normal listening cleanly.

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -454,6 +454,16 @@ class WakeSpliceTests(_FlowHarness):
         self.assertEqual(self.paste.call_args[0][0],
                          "Take a note about the demo.")
 
+    def test_wake_session_strips_trailing_outro_when_configured(self):
+        self.app.cfg["wake_outro_model"] = "thats_all"
+        self.app.worker.transcribe_fast = (
+            lambda audio, model_override=None, timeout=None:
+            "Hey Jarvis, take a note about the demo. That's all.")
+        self.flow.begin_via_wake(None)
+        self.flow.toggle()
+        self.assertEqual(self.paste.call_args[0][0],
+                         "take a note about the demo.")
+
     def test_normal_dictation_never_strips(self):
         self.app.worker.transcribe_fast = (
             lambda audio, model_override=None, timeout=None:

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -40,14 +40,15 @@ class _FakeApp:
 class _FakeModel:
     """Stands in for the openWakeWord model in frame-handling tests."""
 
-    def __init__(self, score=0.0):
-        self.score = score
+    def __init__(self, scores=None, vad_score=1.0):
+        self.scores = scores if scores is not None else {"hey_jarvis": 0.0}
         self.resets = 0
         self.predicted = []
+        self.vad = types.SimpleNamespace(prediction_buffer=[vad_score])
 
     def predict(self, mono):
         self.predicted.append(mono)
-        return {"hey_jarvis": self.score}
+        return dict(self.scores)
 
     def reset(self):
         self.resets += 1
@@ -272,6 +273,148 @@ class WakeActionSpliceTests(unittest.TestCase):
         self.listener._default_wake_action()
         self.app.dictation.begin_via_wake.assert_called_once_with(None)
         self.assertEqual(len(self.listener._ring), 0)
+
+
+class WakeSessionTests(unittest.TestCase):
+    """During a wake-initiated dictation the listener keeps running and
+    watches for the outro phrase and sustained silence."""
+
+    def setUp(self):
+        self.app = _FakeApp()
+        self.app.dictation.toggle = mock.Mock()
+        self.listener = WakeListener(self.app)
+        self.app.state.emit("x", mode="dictation")
+        self.listener._wake_session_active = True
+        # Well past the grace window, voice heard just now.
+        self.listener._session_started = time.monotonic() - 10
+        self.listener._last_voice = time.monotonic()
+
+    def test_wake_action_arms_the_session(self):
+        listener = WakeListener(self.app)
+        with mock.patch.object(listener, "_assemble_prefix",
+                               return_value=None):
+            listener._default_wake_action()
+        self.assertTrue(listener._wake_session_active)
+
+    def test_refused_wake_does_not_arm_the_session(self):
+        self.app.dictation.begin_via_wake.return_value = False
+        listener = WakeListener(self.app)
+        with mock.patch.object(listener, "_assemble_prefix",
+                               return_value=None):
+            listener._default_wake_action()
+        self.assertFalse(listener._wake_session_active)
+
+    def test_outro_phrase_stops_the_dictation(self):
+        self.app.cfg["wake_outro_model"] = "thats_all"
+        model = _FakeModel(scores={"hey_jarvis": 0.0, "thats_all": 0.9})
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_called_once()
+        self.assertFalse(self.listener._wake_session_active)
+        self.assertEqual(model.resets, 1)
+
+    def test_outro_within_grace_window_is_ignored(self):
+        # An outro model acoustically close to the wake phrase must not
+        # end the dictation on the same utterance that started it.
+        self.app.cfg["wake_outro_model"] = "thats_all"
+        self.listener._session_started = time.monotonic()
+        model = _FakeModel(scores={"thats_all": 0.9})
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_not_called()
+        self.assertTrue(self.listener._wake_session_active)
+
+    def test_without_outro_config_high_foreign_score_is_ignored(self):
+        model = _FakeModel(scores={"thats_all": 0.9})
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_not_called()
+
+    def test_silence_stops_after_the_configured_limit(self):
+        model = _FakeModel(vad_score=0.0)
+        self.listener._last_voice = time.monotonic() - 9  # default 8s
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_called_once()
+        self.assertFalse(self.listener._wake_session_active)
+
+    def test_voice_refreshes_the_silence_clock(self):
+        model = _FakeModel(vad_score=0.9)
+        self.listener._last_voice = time.monotonic() - 9
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_not_called()
+        self.assertTrue(self.listener._wake_session_active)
+
+    def test_silence_stop_disabled_by_zero(self):
+        self.app.cfg["wake_silence_stop_s"] = 0
+        model = _FakeModel(vad_score=0.0)
+        self.listener._last_voice = time.monotonic() - 100
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_not_called()
+
+    def test_missing_vad_counts_as_voice_and_never_silence_stops(self):
+        model = _FakeModel(vad_score=0.0)
+        del model.vad
+        self.listener._last_voice = time.monotonic() - 100
+        self.listener.handle_frame("f", model)
+        self.app.dictation.toggle.assert_not_called()
+
+    def test_session_ends_when_the_dictation_ended_elsewhere(self):
+        # Hotkey stop, discard, or the max-minutes cap: back to normal
+        # listening without touching the (already ended) dictation.
+        self.app.state.emit("x", mode=None)
+        model = _FakeModel()
+        self.listener.handle_frame("f", model)
+        self.assertFalse(self.listener._wake_session_active)
+        self.assertEqual(model.resets, 1)
+        self.assertEqual(model.predicted, [],
+                         "no inference on the cleanup frame")
+        self.app.dictation.toggle.assert_not_called()
+
+    def test_incognito_ends_the_session_without_stopping_dictation(self):
+        self.app.cfg["incognito"] = True
+        self.listener.handle_frame("f", _FakeModel())
+        self.assertFalse(self.listener._wake_session_active)
+        self.app.dictation.toggle.assert_not_called()
+
+    def test_outro_key_never_fires_a_wake_when_idle(self):
+        # Saying the outro phrase while nothing is recording must not
+        # START a dictation.
+        self.app.cfg["wake_outro_model"] = "thats_all"
+        listener = WakeListener(self.app, on_wake=mock.Mock())
+        self.assertFalse(listener.process_scores({"thats_all": 0.9}))
+        self.assertTrue(listener.process_scores({"hey_jarvis": 0.9}))
+
+
+class StripTrailingPhraseTests(unittest.TestCase):
+    def test_strips_outro_and_trailing_punctuation(self):
+        from whisper_sync.listener import strip_trailing_phrase
+        self.assertEqual(
+            strip_trailing_phrase("Take a note. That's all.", "thats_all"),
+            "Take a note.")
+        self.assertEqual(
+            strip_trailing_phrase("Take a note, thats all", "thats_all"),
+            "Take a note,")
+
+    def test_outro_mid_sentence_is_preserved(self):
+        from whisper_sync.listener import strip_trailing_phrase
+        text = "That's all I know about the demo, plus one more thing"
+        self.assertEqual(strip_trailing_phrase(text, "thats_all"), text)
+
+    def test_only_the_last_occurrence_is_stripped(self):
+        from whisper_sync.listener import strip_trailing_phrase
+        self.assertEqual(
+            strip_trailing_phrase("That's all that matters. That's all.",
+                                  "thats_all"),
+            "That's all that matters.")
+
+    def test_no_match_returns_text_unchanged(self):
+        from whisper_sync.listener import strip_trailing_phrase
+        self.assertEqual(
+            strip_trailing_phrase("Take a note about the demo.",
+                                  "thats_all"),
+            "Take a note about the demo.")
+
+    def test_only_the_phrase_yields_empty_string(self):
+        from whisper_sync.listener import strip_trailing_phrase
+        self.assertEqual(strip_trailing_phrase("That's all.", "thats_all"),
+                         "")
 
 
 class StripLeadingPhraseTests(unittest.TestCase):

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -348,6 +348,18 @@ class WakeSessionTests(unittest.TestCase):
         self.listener.handle_frame("f", model)
         self.app.dictation.toggle.assert_not_called()
 
+    def test_invalid_silence_config_falls_back_to_default_not_disabled(self):
+        # Review catch: `or 0` treated None/"" as an explicit disable.
+        # Only 0 disables; junk falls back to the 8s default.
+        for bad in (None, "", "soon"):
+            self.app.cfg["wake_silence_stop_s"] = bad
+            self.listener._wake_session_active = True
+            self.app.dictation.toggle.reset_mock()
+            model = _FakeModel(vad_score=0.0)
+            self.listener._last_voice = time.monotonic() - 9
+            self.listener.handle_frame("f", model)
+            self.app.dictation.toggle.assert_called_once()
+
     def test_missing_vad_counts_as_voice_and_never_silence_stops(self):
         model = _FakeModel(vad_score=0.0)
         del model.vad

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -59,5 +59,7 @@
   "meeting_watch_toast_optout": true,
   "wake_listener": false,
   "wake_phrase_model": "hey_jarvis",
-  "wake_threshold": 0.5
+  "wake_threshold": 0.5,
+  "wake_outro_model": "",
+  "wake_silence_stop_s": 8
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -39,6 +39,7 @@ _VALID_KEYS = {
     "meeting_watch_toasts", "meeting_watch_toast_optin",
     "meeting_watch_toast_optout",
     "wake_listener", "wake_phrase_model", "wake_threshold",
+    "wake_outro_model", "wake_silence_stop_s",
 }
 
 

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -446,11 +446,17 @@ class DictationFlow:
                 t2 = _time.perf_counter()
                 if was_wake and text:
                     # The ring-buffer prefix contains the spoken wake
-                    # phrase; without this the pasted text starts with
-                    # "Hey, Jarvis." (listener.py owns the strip logic).
-                    from .listener import strip_leading_phrase
+                    # phrase, and the dictation mic hears the outro
+                    # phrase before the listener can stop the session;
+                    # both are summons, not dictation (listener.py owns
+                    # the strip logic).
+                    from .listener import (strip_leading_phrase,
+                                           strip_trailing_phrase)
                     text = strip_leading_phrase(
                         text, app.cfg.get("wake_phrase_model", "hey_jarvis"))
+                    outro = app.cfg.get("wake_outro_model", "")
+                    if outro and text:
+                        text = strip_trailing_phrase(text, outro)
                 char_count = len(text) if text else 0
 
                 if is_feature:

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -204,10 +204,14 @@ class WakeListener:
         return str(self.app.cfg.get("wake_outro_model", "") or "")
 
     def _silence_stop_s(self) -> float:
-        """Seconds of sustained silence that end a wake dictation
-        (0 disables the silence stop)."""
+        """Seconds of sustained silence that end a wake dictation.
+
+        Only an explicit 0 disables the silence stop; invalid values
+        (None, empty string, junk) fall back to the 8s default, same
+        discipline as _threshold() (review catch).
+        """
         try:
-            return float(self.app.cfg.get("wake_silence_stop_s", 8) or 0)
+            return float(self.app.cfg.get("wake_silence_stop_s", 8))
         except (TypeError, ValueError):
             return 8.0
 

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -16,6 +16,16 @@ audio; the stop path strips it from the transcription text
 between detection and the dictation mic opening (~0.1-0.3s, usually
 the natural pause after the phrase) is not captured.
 
+During a wake-initiated dictation the listener KEEPS running (its
+stream is shared) and watches for two hands-free stop signals: the
+outro phrase (``wake_outro_model``, a second openWakeWord model in the
+same score dict - multi-model is native) and sustained silence
+(``wake_silence_stop_s``, read from the silero VAD scores the model
+already computes for its own gate). Either one stops the dictation
+exactly like the hotkey would; the spoken outro is stripped from the
+tail of the transcription (strip_trailing_phrase). Hotkey-initiated
+dictations are untouched: the listener still pauses for those.
+
 Power and privacy posture (spec + owner decisions):
 - OFF by default (``wake_listener``); tray toggle under Settings.
 - All audio stays in RAM inside openWakeWord's internal buffer;
@@ -70,6 +80,16 @@ RING_FRAMES = int(RING_SECONDS * SAMPLE_RATE / FRAME_SAMPLES)
 # is the user SAYING the phrase mid-sentence and must be preserved.
 STRIP_SEARCH_CHARS = 48
 
+# For the first moments of a wake session, outro and silence checks are
+# suppressed: an outro model acoustically close to the wake phrase must
+# not end the dictation on the same utterance that started it.
+SESSION_GRACE_S = 2.0
+
+# A silero VAD score at or above this counts as voice and refreshes the
+# silence clock. Deliberately below the model's own 0.5 gate: a false
+# "voice" merely extends the dictation, a false "silence" cuts it off.
+VAD_VOICE_THRESHOLD = 0.3
+
 
 def _phrase_tokens(phrase_name: str) -> list[str]:
     """Model name -> spoken words ("hey_jarvis_v0.1" -> ["hey", "jarvis"]).
@@ -81,6 +101,20 @@ def _phrase_tokens(phrase_name: str) -> list[str]:
     stem = stem.split(".", 1)[0]
     tokens = [t for t in re.split(r"[_\-\s]+", stem.lower()) if t]
     return [t for t in tokens if not re.fullmatch(r"v\d+", t)]
+
+
+def _phrase_pattern(tokens: list[str]) -> str:
+    """Regex matching the spoken phrase inside transcribed text.
+
+    Whisper renders "hey jarvis" as "Hey, Jarvis." and friends - allow
+    punctuation and whitespace between tokens, and apostrophes inside
+    them ("thats" must match "that's"). Word boundaries keep
+    single-token phrases from matching inside a longer word ("alexa"
+    must not strip through "Alexander").
+    """
+    sep = r"[\s,.!?;:-]+"
+    words = (r"'?".join(re.escape(ch) for ch in t) for t in tokens)
+    return r"\b" + sep.join(words) + r"\b"
 
 
 def strip_leading_phrase(text: str, phrase_name: str) -> str:
@@ -97,17 +131,32 @@ def strip_leading_phrase(text: str, phrase_name: str) -> str:
     tokens = _phrase_tokens(phrase_name)
     if not tokens:
         return text
-    # Whisper renders "hey jarvis" as "Hey, Jarvis." and friends -
-    # allow punctuation and whitespace between and after the tokens.
-    # Word boundaries keep single-token phrases from matching inside a
-    # longer word ("alexa" must not strip through "Alexander").
-    sep = r"[\s,.!?;:-]+"
-    pattern = (r"\b" + sep.join(re.escape(t) for t in tokens)
-               + r"\b[\s,.!?;:-]*")
+    pattern = _phrase_pattern(tokens) + r"[\s,.!?;:-]*"
     match = re.search(pattern, text, re.IGNORECASE)
     if match is None or match.start() > STRIP_SEARCH_CHARS:
         return text
     return text[match.end():].lstrip()
+
+
+def strip_trailing_phrase(text: str, phrase_name: str) -> str:
+    """Remove the spoken outro phrase from the tail of a wake-spliced
+    transcription.
+
+    The outro is heard by the dictation mic before the listener can
+    stop it, so it lands at the end of the text. Conservative: only
+    strips when nothing but punctuation or whitespace follows the
+    phrase - an outro spoken mid-sentence is preserved.
+    """
+    if not text:
+        return text
+    tokens = _phrase_tokens(phrase_name)
+    if not tokens:
+        return text
+    pattern = _phrase_pattern(tokens) + r"[\s,.!?;:-]*$"
+    match = re.search(pattern, text, re.IGNORECASE)
+    if match is None:
+        return text
+    return text[:match.start()].rstrip()
 
 
 class WakeListener:
@@ -128,6 +177,12 @@ class WakeListener:
         # entry so pre-pause audio never crosses a privacy boundary.
         self._ring: deque = deque(maxlen=RING_FRAMES)
         self._was_paused = False
+        # Wake-session tracking (all touched only on the listener
+        # thread): while active, handle_frame watches for the outro
+        # phrase and sustained silence instead of pausing.
+        self._wake_session_active = False
+        self._session_started = 0.0
+        self._last_voice = 0.0
 
     # -- Config ----------------------------------------------------------------
 
@@ -143,6 +198,29 @@ class WakeListener:
             return float(self.app.cfg.get("wake_threshold", 0.5))
         except (TypeError, ValueError):
             return 0.5
+
+    def _outro(self) -> str:
+        """Outro phrase model name; empty string = no outro configured."""
+        return str(self.app.cfg.get("wake_outro_model", "") or "")
+
+    def _silence_stop_s(self) -> float:
+        """Seconds of sustained silence that end a wake dictation
+        (0 disables the silence stop)."""
+        try:
+            return float(self.app.cfg.get("wake_silence_stop_s", 8) or 0)
+        except (TypeError, ValueError):
+            return 8.0
+
+    @staticmethod
+    def _is_outro_key(score_key: str, outro: str) -> bool:
+        """openWakeWord keys scores by the model file's basename minus
+        its extension; the config value may be a bare pretrained name or
+        a path to a custom .onnx."""
+        if not outro:
+            return False
+        stem = re.sub(r"\.(onnx|tflite)$", "",
+                      re.split(r"[\\/]", outro)[-1], flags=re.IGNORECASE)
+        return score_key.lower() in (outro.lower(), stem.lower())
 
     # -- Lifecycle ---------------------------------------------------------------
 
@@ -213,6 +291,7 @@ class WakeListener:
             f"threshold {self._threshold():.2f}")
         self._was_paused = False
         self._ring.clear()
+        self._wake_session_active = False
         try:
             with sd.InputStream(samplerate=SAMPLE_RATE, channels=1,
                                 dtype="int16", blocksize=FRAME_SAMPLES) as stream:
@@ -226,10 +305,19 @@ class WakeListener:
             logger.info("Wake listener stopped")
 
     def _load_model(self):
-        """Load the openWakeWord model (lazy heavy import)."""
+        """Load the openWakeWord model (lazy heavy import).
+
+        The outro phrase, when configured, loads into the SAME model:
+        predict() returns one score per loaded model and the decision
+        logic routes wake keys and the outro key separately.
+        """
         from openwakeword.model import Model
+        models = [self._phrase()]
+        outro = self._outro()
+        if outro:
+            models.append(outro)
         try:
-            return Model(wakeword_models=[self._phrase()],
+            return Model(wakeword_models=models,
                          inference_framework="onnx",
                          vad_threshold=0.5)
         except Exception:
@@ -237,7 +325,7 @@ class WakeListener:
             logger.info("Wake listener: downloading openWakeWord models...")
             import openwakeword.utils
             openwakeword.utils.download_models()
-            return Model(wakeword_models=[self._phrase()],
+            return Model(wakeword_models=models,
                          inference_framework="onnx",
                          vad_threshold=0.5)
 
@@ -247,14 +335,20 @@ class WakeListener:
         """One frame's worth of decisions (unit-tested without audio).
 
         ``mono`` is one 80ms int16 frame (already squeezed to 1-D by the
-        loop); ``model`` is the loaded openWakeWord model. While paused,
-        inference is skipped and the model is reset ONCE on entering the
-        pause (review catch on the POC: not per 80ms frame) - it clears
-        pre-pause audio so it cannot fire on resume, and the ring buffer
-        is cleared for the same reason (paused audio is someone's
-        recording or whisper-mode speech; the splice must never inherit
-        it).
+        loop); ``model`` is the loaded openWakeWord model. A wake
+        session (a dictation THIS listener started) routes to the
+        outro/silence watcher; the pause gate would otherwise stop
+        inference the moment the dictation recorder opened. While
+        paused, inference is skipped and the model is reset ONCE on
+        entering the pause (review catch on the POC: not per 80ms
+        frame) - it clears pre-pause audio so it cannot fire on resume,
+        and the ring buffer is cleared for the same reason (paused
+        audio is someone's recording or whisper-mode speech; the splice
+        must never inherit it).
         """
+        if self._wake_session_active:
+            self._handle_wake_session_frame(mono, model)
+            return
         if self._paused():
             if not self._was_paused:
                 model.reset()
@@ -264,6 +358,68 @@ class WakeListener:
         self._was_paused = False
         self._ring.append(mono)
         self.process_scores(model.predict(mono))
+
+    def _handle_wake_session_frame(self, mono, model) -> None:
+        """Watch a wake-initiated dictation for its hands-free stops."""
+        current = self.app.state.current if self.app.state else None
+        mode = current.mode if current else None
+        if mode != "dictation" or self.app.cfg.get("incognito", False):
+            # The dictation ended some other way (hotkey stop, discard,
+            # auto-stop cap) or a privacy boundary appeared - return to
+            # normal listening.
+            self._end_wake_session(model)
+            return
+        scores = model.predict(mono)
+        now = time.monotonic()
+        if self._frame_has_voice(model):
+            self._last_voice = now
+        if now - self._session_started < SESSION_GRACE_S:
+            return
+        outro = self._outro()
+        if outro:
+            threshold = self._threshold()
+            hit = any(score >= threshold
+                      for name, score in (scores or {}).items()
+                      if self._is_outro_key(name, outro))
+            if hit:
+                self._stop_wake_dictation(model, "outro phrase")
+                return
+        limit = self._silence_stop_s()
+        if limit > 0 and now - self._last_voice >= limit:
+            self._stop_wake_dictation(model, f"{limit:.0f}s of silence")
+
+    def _frame_has_voice(self, model) -> bool:
+        """Latest silero VAD score from the model's own gate.
+
+        When the VAD buffer is unavailable (no vad_threshold, exotic
+        model object), every frame counts as voice: the silence stop
+        simply never fires, which fails safe (the hotkey still works).
+        """
+        try:
+            buffer = model.vad.prediction_buffer
+            if not buffer:
+                return True
+            return float(buffer[-1]) >= VAD_VOICE_THRESHOLD
+        except Exception:
+            return True
+
+    def _end_wake_session(self, model) -> None:
+        """Back to normal listening; nothing from the session lingers."""
+        self._wake_session_active = False
+        self._ring.clear()
+        try:
+            model.reset()
+        except Exception:
+            pass
+
+    def _stop_wake_dictation(self, model, why: str) -> None:
+        """Stop the wake dictation exactly like the hotkey would."""
+        logger.info(f"Wake dictation stopping: {why}")
+        self._end_wake_session(model)
+        try:
+            self.app.dictation.toggle()
+        except Exception:
+            logger.warning("Wake dictation stop failed", exc_info=True)
 
     def _assemble_prefix(self):
         """Ring frames -> the mono float32 column the recorder expects.
@@ -301,9 +457,14 @@ class WakeListener:
         """Evaluate one frame's model scores; fire at most one wake.
 
         Returns True when a wake fired (refractory window applies).
+        The outro model shares the score dict but never wakes: saying
+        the outro phrase while idle must not start a dictation.
         """
         threshold = self._threshold()
-        hit = any(score >= threshold for score in (scores or {}).values())
+        outro = self._outro()
+        hit = any(score >= threshold
+                  for name, score in (scores or {}).items()
+                  if not self._is_outro_key(name, outro))
         if not hit:
             return False
         now = time.monotonic()
@@ -342,3 +503,10 @@ class WakeListener:
             logger.info("Wake word heard but dictation could not start "
                         "(another workflow is active)")
             self.app._yellow_flash()
+            return
+        # Arm the outro/silence watcher (handle_frame routes on this
+        # from the next frame). The listener thread is the only writer.
+        now = time.monotonic()
+        self._wake_session_active = True
+        self._session_started = now
+        self._last_voice = now


### PR DESCRIPTION
## What

Step 3 (tier-2 splice) PR 2 of 2, per docs/plans/2026-07-04-assistant-build-round.md. Completes the hands-free loop: wake -> prefixed dictation (#189) -> **voice/silence stop** (this PR).

- **Keep listening during wake sessions**: `handle_frame` routes on the session flag before the pause gate. Hotkey-initiated dictations are untouched - the listener still pauses for those.
- **Outro phrase** (`wake_outro_model`, default empty = disabled): loads into the SAME openWakeWord model (multi-model score dict is native). The outro key never fires a wake (saying the outro while idle must not start a dictation), and a 2s grace window keeps a wake-alike outro from ending the utterance that started it. The spoken outro is stripped from the text tail; the strip is anchored to the end of the text so a mid-sentence outro is preserved.
- **Silence stop** (`wake_silence_stop_s`, default 8s, 0 disables): reads the silero VAD scores the model already computes for its own gate (`model.vad.prediction_buffer`). A missing VAD buffer counts every frame as voice - fails safe to hotkey-only stop.
- **Clean teardown**: hotkey stop, discard, the minutes cap, and incognito all hand the listener back to normal listening (model reset + ring clear, dictation untouched).
- `_phrase_pattern` shared by both strips, apostrophe-tolerant (config token `thats` matches transcribed "that's").

## Verified live (venv, CPU-only)

Multi-model load returns per-model score keys ('alexa', 'hey_jarvis') and `vad.prediction_buffer` reads 0.05 on silence - below the 0.3 voice threshold, as designed.

## Tests

- System suite: 417 passed, 2 skipped in 14s.
- Venv: test_capture_recorder + test_listener + test_dictation_flow, 98 passed (session routing, grace window, outro/wake key separation, silence clock, VAD-missing failsafe, trailing strip suite, teardown paths).