### PR TITLE
feat: phrase-training environment + headless CLI (step 5, PR A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 
 # Local dev-machine marker, never shipped
 whisper_sync/.standalone
+
+# Phrase-training workspace (trainer venv + datasets, 12-18 GB)
+training/workspace/

--- a/docs/owner-test-checklist.md
+++ b/docs/owner-test-checklist.md
@@ -92,3 +92,18 @@ downloads the openWakeWord models - watch the log).
   tightening).
 - [ ] Clean exits, flat memory across meetings, `gpu-guard.jsonl`
   shows only expected events.
+
+## 7. Phrase training first run (step 5 PR A) - needs your go twice
+
+Both gates exist on purpose: the download is 12-18 GB of disk, and
+training occupies the dGPU for tens of minutes (do not start it while
+gaming).
+
+- [ ] `python training/setup_trainer.py --yes` completes (idempotent -
+  rerun after any interruption and it continues).
+- [ ] `python training/train_phrase.py "hey hal" --go` produces
+  `training/workspace/phrases/hey_hal.onnx` (this run also validates
+  the PROVISIONAL config values; a bad key fails fast and gets fixed).
+- [ ] Set `wake_phrase_model` to that .onnx path, toggle the listener
+  off/on - saying "hey hal" starts a dictation; "hey jarvis" no
+  longer does.

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -333,3 +333,24 @@ training job with menu status/ETA + completion toast.
   Remaining: step 5 phrase manager (plan above), step 6 NPU backend
   (fresh session). Owner reminder still outstanding: the tray app
   needs ONE restart to pick up everything from #167 onward.
+
+- **2026-07-05 (owner intake + checklist, #192)**: owner asked for a
+  running list of everything shipped but not yet hand-tested, kept
+  current with development. docs/owner-test-checklist.md shipped with
+  concrete steps/expected results (tray restart gates all), and the
+  CLAUDE.md same-PR rule now requires owner-facing PRs to append or
+  update an entry. Standing instruction: keep developing.
+
+- **2026-07-05 (step 5 PR A)**: trainer environment + headless CLI
+  per the step 5 plan. Dataset sources, piper checkpoint, package
+  list, and the three-stage invocation verified VERBATIM against the
+  upstream automatic_model_training notebook. whisper_sync/
+  phrase_training.py owns the pure logic (workspace layout, config
+  generation as JSON-is-YAML, command construction - CI-tested, no
+  yaml/torch imports); training/setup_trainer.py builds the separate
+  trainer venv + downloads (idempotent, 12-18 GB size gate behind
+  --yes); training/train_phrase.py trains one phrase and drops the
+  .onnx into workspace/phrases/ (GPU gate behind --go per the
+  warn-owner protocol). EXECUTION STAGED: the dataset download and
+  the first supervised training run wait for an explicit owner go -
+  PROVISIONAL config values are validated by that first run.

--- a/tests/test_phrase_training.py
+++ b/tests/test_phrase_training.py
@@ -1,0 +1,91 @@
+"""Tests for whisper_sync.phrase_training - step 5 PR A pure logic.
+
+The trainer itself (torch, openwakeword.train, datasets) never runs
+here; these pin the CI-safe parts: name sanitization, config content
+and serialization, and the three-stage command construction.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from whisper_sync.phrase_training import (
+    build_training_config, write_training_config, training_commands,
+    trained_model_path, sanitize_model_name,
+    ACAV_FEATURES, VALIDATION_FEATURES,
+)
+
+
+class SanitizeNameTests(unittest.TestCase):
+    def test_phrase_becomes_snake_case(self):
+        self.assertEqual(sanitize_model_name("Hey Hal!"), "hey_hal")
+        self.assertEqual(sanitize_model_name("that's all"), "that_s_all")
+
+    def test_unusable_phrase_raises(self):
+        with self.assertRaises(ValueError):
+            sanitize_model_name("!!!")
+
+
+class BuildConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path("C:/ws")
+        self.config = build_training_config("Hey Hal", self.root)
+
+    def test_notebook_values_present(self):
+        self.assertEqual(self.config["target_phrase"], ["hey hal"])
+        self.assertEqual(self.config["model_name"], "hey_hal")
+        self.assertEqual(self.config["n_samples"], 1000)
+        self.assertEqual(self.config["steps"], 10000)
+
+    def test_paths_land_under_the_workspace_root(self):
+        root = str(self.root)
+        self.assertTrue(self.config["output_dir"].startswith(root))
+        self.assertTrue(
+            self.config["piper_sample_generator_path"].startswith(root))
+        for p in (self.config["rir_paths"]
+                  + self.config["background_paths"]):
+            self.assertTrue(p.startswith(root))
+        self.assertIn(ACAV_FEATURES,
+                      self.config["feature_data_files"]["ACAV100M_sample"])
+        self.assertIn(VALIDATION_FEATURES,
+                      self.config["false_positive_validation_data_path"])
+
+    def test_overrides_win(self):
+        config = build_training_config("hey hal", self.root,
+                                       {"steps": 42, "n_samples": 7})
+        self.assertEqual(config["steps"], 42)
+        self.assertEqual(config["n_samples"], 7)
+
+    def test_trained_model_path_matches_trainer_output(self):
+        path = trained_model_path(self.config)
+        self.assertEqual(path.name, "hey_hal.onnx")
+        self.assertEqual(str(path.parent),
+                         str(Path(self.config["output_dir"])))
+
+
+class WriteConfigTests(unittest.TestCase):
+    def test_written_file_is_json_and_therefore_yaml(self):
+        # The trainer loads the config with yaml.load; JSON is a strict
+        # subset of YAML 1.2, so a JSON file needs no yaml dep here.
+        config = build_training_config("hey hal", "C:/ws")
+        with tempfile.TemporaryDirectory() as td:
+            path = write_training_config(config, Path(td) / "x" / "c.yml")
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(loaded, config)
+
+
+class CommandTests(unittest.TestCase):
+    def test_three_official_stages_in_order(self):
+        cmds = training_commands("C:/ws/c.yml", "C:/ws/py.exe")
+        self.assertEqual([c[-1] for c in cmds],
+                         ["--generate_clips", "--augment_clips",
+                          "--train_model"])
+        for cmd in cmds:
+            self.assertEqual(cmd[0], "C:/ws/py.exe")
+            self.assertIn("openwakeword.train", cmd)
+            self.assertIn("C:/ws/c.yml", cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/training/README.md
+++ b/training/README.md
@@ -1,0 +1,60 @@
+# Phrase training - trainer environment and headless CLI
+
+Step 5 (self-serve phrase manager) PR A: everything needed to train a
+custom openWakeWord phrase model from TYPED text, no speaking required.
+Sources and pipeline are verbatim from the upstream openWakeWord
+automatic_model_training notebook (verified 2026-07-05); the plan and
+PR sketch live in `docs/plans/2026-07-04-assistant-build-round.md`.
+
+## Why a separate environment
+
+The training stack (CUDA torch, torchinfo, torchmetrics, speechbrain,
+audiomentations, piper-sample-generator, HF datasets) is an order of
+magnitude heavier than the app runtime and must never bloat
+whisper-env. Everything lives in a self-contained workspace
+(`training/workspace/` by default, gitignored).
+
+## One-time setup
+
+```
+python training/setup_trainer.py --yes
+```
+
+- Creates `workspace/trainer-env` (separate venv, CUDA torch).
+- Clones piper-sample-generator + its libritts TTS checkpoint (the
+  synthetic voice that "speaks" your typed phrase thousands of times).
+- Downloads the datasets: MIT room impulse responses, AudioSet +
+  FMA background noise (converted to 16 kHz wavs), precomputed
+  negative features and validation features (.npy).
+
+**Disk warning: roughly 12-18 GB total.** Without `--yes` the script
+prints the plan and exits. Idempotent - rerun after any interruption
+and it continues (finished files are skipped).
+
+## Train a phrase
+
+```
+python training/train_phrase.py "hey hal" --go
+```
+
+Generates the training config (JSON, which the trainer's YAML loader
+accepts), then runs the three official stages in the trainer venv:
+`--generate_clips` (synthetic TTS samples), `--augment_clips` (RIR +
+noise augmentation), `--train_model`. The finished model lands at
+`workspace/phrases/hey_hal.onnx`; point `wake_phrase_model` or
+`wake_outro_model` at that path and toggle the listener off/on.
+
+**GPU protocol: training occupies the dGPU for tens of minutes.** The
+CLI refuses without `--go`, and the owner must be warned before any
+run. `--config-only` writes the config without training (used by the
+tests and for inspection). Config values the notebook did not pin are
+marked PROVISIONAL in `whisper_sync/phrase_training.py`; the first
+supervised run validates them (train.py fails fast on a bad key).
+
+## What the later PRs add
+
+- **PR B**: saved-phrase registry (name -> path + active + wake/outro
+  role), listener loading of all active models, tray Saved Phrases
+  surface with checkmarks.
+- **PR C**: Set Phrase dialog + background training job with tray
+  status/ETA and completion toast (app-side busy/asleep GPU checks).

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -89,7 +89,8 @@ else:
 ds = ds.cast_column("audio", Audio(sampling_rate=16000))
 n = 0
 for row in ds:
-    data = (np.asarray(row["audio"]["array"]) * 32767).astype(np.int16)
+    arr = np.clip(np.asarray(row["audio"]["array"]), -1.0, 1.0)
+    data = (arr * 32767).astype(np.int16)
     scipy.io.wavfile.write(out_dir / f"{n:06d}.wav", 16000, data)
     n += 1
 print(f"wrote {n} wavs to {out_dir}")
@@ -103,6 +104,17 @@ def log(msg: str) -> None:
 def run(cmd: list, **kw) -> None:
     log("run: " + " ".join(str(c) for c in cmd))
     subprocess.run([str(c) for c in cmd], check=True, **kw)
+
+
+def safe_extract(tar, dest: Path) -> None:
+    """extractall with member-path validation (remote tarballs can
+    carry traversal paths; every member must resolve under dest)."""
+    dest = dest.resolve()
+    for member in tar.getmembers():
+        target = (dest / member.name).resolve()
+        if not target.is_relative_to(dest):
+            raise RuntimeError(f"unsafe tar member: {member.name}")
+    tar.extractall(dest)
 
 
 def download(url: str, dest: Path) -> None:
@@ -175,7 +187,7 @@ def phase_datasets(root: Path) -> None:
             import tarfile
             log(f"extracting {tar.name}")
             with tarfile.open(tar) as tf:
-                tf.extractall(extracted)
+                safe_extract(tf, extracted)
         run([py, snippet, "local", extracted, "-", audioset])
     else:
         log("audioset_16k exists, skipping")

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -1,0 +1,220 @@
+"""One-time trainer environment setup for the phrase manager (step 5).
+
+Creates a SEPARATE venv with the openWakeWord training stack (torch
+CUDA and friends stay out of whisper-env), clones piper-sample-
+generator with its TTS checkpoint, and downloads the training datasets.
+Sources are verbatim from the upstream openWakeWord
+automatic_model_training notebook (verified 2026-07-05).
+
+Idempotent: every phase skips work whose output already exists, so
+rerunning after a failed or interrupted download continues instead of
+starting over (a file is only skipped once fully downloaded - partial
+downloads restart that one file).
+
+DISK WARNING: the datasets total roughly 12-18 GB. The script prints
+the plan and refuses to download without --yes.
+GPU note: setup itself never touches the GPU; training does (see
+train_phrase.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ROOT = Path(__file__).resolve().parent / "workspace"
+
+PIPER_REPO = "https://github.com/rhasspy/piper-sample-generator"
+PIPER_CHECKPOINT = ("https://github.com/rhasspy/piper-sample-generator/"
+                    "releases/download/v2.0.0/en_US-libritts_r-medium.pt")
+
+FEATURES_BASE = ("https://huggingface.co/datasets/davidscripka/"
+                 "openwakeword_features/resolve/main/")
+FEATURE_FILES = [
+    # (~10 GB) precomputed negative features, 2000 hrs
+    "openwakeword_features_ACAV100M_2000_hrs_16bit.npy",
+    # (~2 GB) false-positive validation features
+    "validation_set_features.npy",
+]
+
+AUDIOSET_TAR = ("https://huggingface.co/datasets/agkphysics/AudioSet/"
+                "resolve/main/data/bal_train09.tar")
+
+# Training deps per the upstream notebook, minus the tensorflow/tflite
+# export chain (the listener loads onnx; train.py's import scan shows
+# no unconditional tensorflow import). torch is installed separately
+# with the CUDA index.
+TRAINER_PACKAGES = [
+    "openwakeword",
+    "piper-phonemize",
+    "webrtcvad",
+    "mutagen==1.47.0",
+    "torchinfo==1.8.0",
+    "torchmetrics==1.2.0",
+    "speechbrain==0.5.14",
+    "audiomentations==0.33.0",
+    "torch-audiomentations==0.11.0",
+    "acoustics==0.2.6",
+    "pronouncing==0.2.0",
+    "datasets==2.14.6",
+    "deep-phonemizer==0.0.19",
+]
+
+# Runs inside the trainer venv (it has datasets/scipy): materialize a
+# HF dataset - or a local directory of audio files ("local" source) -
+# as 16 kHz mono int16 wavs, the layout train.py expects.
+# argv: <source> <config-or-dir> <split> <out_dir> ("local" uses
+# config-or-dir as the directory to glob; "-" config means None).
+HF_TO_WAVS_SNIPPET = r"""
+import sys
+from pathlib import Path
+import numpy as np
+import scipy.io.wavfile
+from datasets import load_dataset, Audio, Dataset
+
+source, config, split, out_dir = (sys.argv[1], sys.argv[2], sys.argv[3],
+                                  Path(sys.argv[4]))
+out_dir.mkdir(parents=True, exist_ok=True)
+if source == "local":
+    files = [str(p) for p in Path(config).glob("**/*")
+             if p.suffix.lower() in (".flac", ".wav", ".mp3", ".ogg")]
+    ds = Dataset.from_dict({"audio": files}).cast_column("audio", Audio())
+else:
+    ds = load_dataset(source, config if config != "-" else None,
+                      split=split, streaming=False)
+ds = ds.cast_column("audio", Audio(sampling_rate=16000))
+n = 0
+for row in ds:
+    data = (np.asarray(row["audio"]["array"]) * 32767).astype(np.int16)
+    scipy.io.wavfile.write(out_dir / f"{n:06d}.wav", 16000, data)
+    n += 1
+print(f"wrote {n} wavs to {out_dir}")
+"""
+
+
+def log(msg: str) -> None:
+    print(f"[setup] {msg}", flush=True)
+
+
+def run(cmd: list, **kw) -> None:
+    log("run: " + " ".join(str(c) for c in cmd))
+    subprocess.run([str(c) for c in cmd], check=True, **kw)
+
+
+def download(url: str, dest: Path) -> None:
+    """Streamed download; skip when the finished file already exists."""
+    if dest.exists():
+        log(f"exists, skipping: {dest.name}")
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    part = dest.with_suffix(dest.suffix + ".part")
+    log(f"downloading {url} -> {dest}")
+    with urllib.request.urlopen(url) as resp, open(part, "wb") as fh:
+        while True:
+            chunk = resp.read(1 << 20)
+            if not chunk:
+                break
+            fh.write(chunk)
+    part.rename(dest)
+
+
+def trainer_python(root: Path) -> Path:
+    return root / "trainer-env" / "Scripts" / "python.exe"
+
+
+def phase_venv(root: Path, base_python: str) -> None:
+    py = trainer_python(root)
+    if py.exists():
+        log("trainer venv exists, skipping create")
+    else:
+        run([base_python, "-m", "venv", root / "trainer-env"])
+    run([py, "-m", "pip", "install", "--upgrade", "pip"])
+    # CUDA torch first (its own index), then the notebook stack.
+    run([py, "-m", "pip", "install", "torch",
+         "--index-url", "https://download.pytorch.org/whl/cu121"])
+    run([py, "-m", "pip", "install"] + TRAINER_PACKAGES)
+
+
+def phase_piper(root: Path) -> None:
+    piper = root / "piper-sample-generator"
+    if not piper.exists():
+        run(["git", "clone", PIPER_REPO, piper])
+    else:
+        log("piper-sample-generator exists, skipping clone")
+    download(PIPER_CHECKPOINT, piper / "models" / "en_US-libritts_r-medium.pt")
+
+
+def phase_datasets(root: Path) -> None:
+    py = trainer_python(root)
+    features = root / "features"
+    for fname in FEATURE_FILES:
+        download(FEATURES_BASE + fname, features / fname)
+
+    data = root / "data"
+    snippet = root / "_hf_to_wavs.py"
+    snippet.write_text(HF_TO_WAVS_SNIPPET, encoding="utf-8")
+
+    rirs = data / "mit_rirs"
+    if not rirs.exists():
+        run([py, snippet,
+             "davidscripka/MIT_environmental_impulse_responses", "-",
+             "train", rirs])
+    else:
+        log("mit_rirs exists, skipping")
+
+    audioset = data / "audioset_16k"
+    if not audioset.exists():
+        tar = data / "bal_train09.tar"
+        download(AUDIOSET_TAR, tar)
+        extracted = data / "audioset_raw"
+        if not extracted.exists():
+            import tarfile
+            log(f"extracting {tar.name}")
+            with tarfile.open(tar) as tf:
+                tf.extractall(extracted)
+        run([py, snippet, "local", extracted, "-", audioset])
+    else:
+        log("audioset_16k exists, skipping")
+
+    fma = data / "fma"
+    if not fma.exists():
+        run([py, snippet, "rudraml/fma", "small", "train", fma])
+    else:
+        log("fma exists, skipping")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT,
+                        help="workspace root (default: training/workspace)")
+    parser.add_argument("--python", default=sys.executable,
+                        help="base python for the trainer venv")
+    parser.add_argument("--yes", action="store_true",
+                        help="confirm the 12-18 GB dataset download")
+    parser.add_argument("--skip-datasets", action="store_true",
+                        help="only set up the venv and piper generator")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    log(f"workspace: {root}")
+    phase_venv(root, args.python)
+    phase_piper(root)
+    if args.skip_datasets:
+        log("datasets skipped (--skip-datasets)")
+        return 0
+    if not args.yes:
+        log("DATASETS NOT DOWNLOADED. The feature/noise/RIR datasets "
+            "total roughly 12-18 GB on disk. Rerun with --yes to "
+            "proceed (idempotent; finished files are skipped).")
+        return 1
+    phase_datasets(root)
+    log("setup complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/training/train_phrase.py
+++ b/training/train_phrase.py
@@ -1,0 +1,95 @@
+"""Headless phrase training CLI - step 5, PR A.
+
+Trains ONE custom openWakeWord phrase model from typed text via the
+official trainer, using the workspace prepared by setup_trainer.py.
+The finished .onnx lands in <root>/phrases/, ready to be set as
+wake_phrase_model or wake_outro_model (the PR B registry and tray
+surface automate that).
+
+GPU PROTOCOL: training occupies the dGPU for tens of minutes. The
+command refuses to run without --go, and the owner must be warned
+before any run (see feedback_warn-before-gpu-heavy-tests in the PM
+memory; the PR C background job adds the app-side busy/asleep checks).
+
+Config generation lives in whisper_sync.phrase_training (CI-tested);
+this file is the thin subprocess wrapper around the trainer venv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ROOT = Path(__file__).resolve().parent / "workspace"
+sys.path.insert(0, str(REPO_ROOT))
+
+from whisper_sync.phrase_training import (  # noqa: E402
+    build_training_config, write_training_config, training_commands,
+    trained_model_path, sanitize_model_name,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("phrase", help='the phrase, e.g. "hey hal"')
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT,
+                        help="workspace root (default: training/workspace)")
+    parser.add_argument("--overrides", default="{}",
+                        help="JSON dict of training-config overrides")
+    parser.add_argument("--config-only", action="store_true",
+                        help="write the config and exit (no training)")
+    parser.add_argument("--go", action="store_true",
+                        help="confirm the GPU-heavy run (tens of minutes)")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    name = sanitize_model_name(args.phrase)
+    config = build_training_config(args.phrase, root,
+                                   json.loads(args.overrides))
+    config_path = write_training_config(
+        config, root / "output" / name / f"{name}.yml")
+    print(f"[train] config: {config_path}")
+    if args.config_only:
+        return 0
+
+    trainer_python = root / "trainer-env" / "Scripts" / "python.exe"
+    if not trainer_python.exists():
+        print("[train] trainer venv missing - run setup_trainer.py first")
+        return 1
+    if not args.go:
+        print("[train] NOT RUNNING. Training occupies the dGPU for tens "
+              "of minutes; make sure the owner has been warned, then "
+              "rerun with --go.")
+        return 1
+
+    for cmd in training_commands(config_path, trainer_python):
+        print("[train] run: " + " ".join(cmd), flush=True)
+        result = subprocess.run(cmd, cwd=root)
+        if result.returncode != 0:
+            print(f"[train] step failed (exit {result.returncode}); "
+                  "artifacts kept for inspection in "
+                  f"{config['output_dir']}")
+            return result.returncode
+
+    produced = trained_model_path(config)
+    if not produced.exists():
+        print(f"[train] trainer reported success but {produced} is "
+              "missing - check the output dir")
+        return 1
+    phrases_dir = root / "phrases"
+    phrases_dir.mkdir(parents=True, exist_ok=True)
+    final = phrases_dir / produced.name
+    shutil.copy2(produced, final)
+    print(f"[train] done: {final}")
+    print("[train] set it as wake_phrase_model or wake_outro_model "
+          "(full path) and restart the listener toggle to load it.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/training/train_phrase.py
+++ b/training/train_phrase.py
@@ -6,10 +6,11 @@ The finished .onnx lands in <root>/phrases/, ready to be set as
 wake_phrase_model or wake_outro_model (the PR B registry and tray
 surface automate that).
 
-GPU PROTOCOL: training occupies the dGPU for tens of minutes. The
-command refuses to run without --go, and the owner must be warned
-before any run (see feedback_warn-before-gpu-heavy-tests in the PM
-memory; the PR C background job adds the app-side busy/asleep checks).
+GPU PROTOCOL: training occupies the dGPU for tens of minutes and the
+owner may be using it (gaming). The command refuses to run without
+--go, and whoever drives it warns the owner first - the protocol and
+first-run validation steps live in docs/owner-test-checklist.md (the
+PR C background job adds the app-side busy/asleep checks).
 
 Config generation lives in whisper_sync.phrase_training (CI-tested);
 this file is the thin subprocess wrapper around the trainer venv.
@@ -49,8 +50,15 @@ def main() -> int:
 
     root = args.root.resolve()
     name = sanitize_model_name(args.phrase)
-    config = build_training_config(args.phrase, root,
-                                   json.loads(args.overrides))
+    try:
+        overrides = json.loads(args.overrides)
+        if not isinstance(overrides, dict):
+            raise ValueError("must be a JSON object")
+    except ValueError as exc:
+        print(f"[train] bad --overrides ({exc}); expected a JSON "
+              'object like {"steps": 20000}')
+        return 2
+    config = build_training_config(args.phrase, root, overrides)
     config_path = write_training_config(
         config, root / "output" / name / f"{name}.yml")
     print(f"[train] config: {config_path}")

--- a/whisper_sync/phrase_training.py
+++ b/whisper_sync/phrase_training.py
@@ -1,0 +1,115 @@
+"""Phrase-training config and command construction - step 5, PR A.
+
+The self-serve phrase manager (spec, fourth intake) trains custom
+openWakeWord models from TYPED phrases via the official trainer
+(``openwakeword.train`` driven by a YAML config; pipeline verified
+against the upstream automatic_model_training notebook 2026-07-05).
+This module owns the pure logic - workspace layout, config generation,
+command lines - so it is unit-testable on the dependency-light system
+python and reusable by the PR C background job. The heavyweight
+execution lives in ``training/`` scripts and a separate trainer venv;
+nothing here imports torch or openwakeword.
+
+The config is written as JSON, which every YAML 1.2 parser (including
+the trainer's ``yaml.load``) accepts - no yaml dependency here.
+
+Values marked NOTEBOOK below are verbatim from the upstream notebook;
+values marked PROVISIONAL are best-effort defaults for keys train.py
+reads but the notebook summary did not pin - the first supervised
+training run validates them (train.py fails fast on a missing or
+malformed key, and the run is staged behind an explicit owner go).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Workspace layout, all relative to one root (gitignored by default):
+#   trainer-env/              separate venv (torch CUDA etc.)
+#   piper-sample-generator/   TTS sample generator checkout + checkpoint
+#   data/mit_rirs/            room impulse responses
+#   data/audioset_16k/        background noise (AudioSet subset)
+#   data/fma/                 background noise (FMA small subset)
+#   features/*.npy            precomputed negative/validation features
+#   output/<name>/            per-phrase training artifacts
+#   phrases/<name>.onnx       finished models the listener loads
+ACAV_FEATURES = "openwakeword_features_ACAV100M_2000_hrs_16bit.npy"
+VALIDATION_FEATURES = "validation_set_features.npy"
+
+
+def sanitize_model_name(phrase: str) -> str:
+    """Typed phrase -> model/file name ("Hey Hal!" -> "hey_hal")."""
+    name = re.sub(r"[^a-z0-9]+", "_", phrase.lower()).strip("_")
+    if not name:
+        raise ValueError(f"phrase {phrase!r} has no usable characters")
+    return name
+
+
+def build_training_config(phrase: str, root: Path | str,
+                          overrides: dict | None = None) -> dict:
+    """Full config dict for ``openwakeword.train`` for one phrase."""
+    root = Path(root)
+    name = sanitize_model_name(phrase)
+    config = {
+        # Verbatim NOTEBOOK values.
+        "target_phrase": [phrase.lower()],
+        "model_name": name,
+        "n_samples": 1000,
+        "n_samples_val": 1000,
+        "steps": 10000,
+        "target_accuracy": 0.6,
+        "target_recall": 0.25,
+        "background_paths": [str(root / "data" / "audioset_16k"),
+                             str(root / "data" / "fma")],
+        "false_positive_validation_data_path":
+            str(root / "features" / VALIDATION_FEATURES),
+        "feature_data_files":
+            {"ACAV100M_sample": str(root / "features" / ACAV_FEATURES)},
+        # Workspace paths.
+        "rir_paths": [str(root / "data" / "mit_rirs")],
+        "piper_sample_generator_path":
+            str(root / "piper-sample-generator"),
+        "output_dir": str(root / "output" / name),
+        # PROVISIONAL defaults for the remaining keys train.py reads.
+        "model_type": "dnn",
+        "layer_size": 32,
+        "total_length": 32000,
+        "tts_batch_size": 50,
+        "augmentation_batch_size": 16,
+        "augmentation_rounds": 1,
+        "custom_negative_phrases": [],
+        "background_paths_duplication_rate": [1],
+        "batch_n_per_class": {"ACAV100M_sample": 1024,
+                              "adversarial_negative": 50,
+                              "positive": 50},
+        "max_negative_weight": 1500,
+        "target_false_positives_per_hour": 0.2,
+    }
+    config.update(overrides or {})
+    return config
+
+
+def write_training_config(config: dict, path: Path | str) -> Path:
+    """Write the config as JSON (valid YAML) for the trainer."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    return path
+
+
+def training_commands(config_path: Path | str,
+                      trainer_python: Path | str) -> list[list[str]]:
+    """The three trainer invocations, in order (notebook-verbatim
+    staging: clip generation, augmentation, then model training)."""
+    base = [str(trainer_python), "-m", "openwakeword.train",
+            "--training_config", str(config_path)]
+    return [base + ["--generate_clips"],
+            base + ["--augment_clips"],
+            base + ["--train_model"]]
+
+
+def trained_model_path(config: dict) -> Path:
+    """Where train.py leaves the .onnx for this config."""
+    return Path(config["output_dir"]) / f"{config['model_name']}.onnx"


### PR DESCRIPTION
## What

Step 5 (self-serve phrase manager) PR A of 3, per the plan doc. Everything needed to train a custom openWakeWord phrase model from **typed text** - no speaking required. Sources verified **verbatim** against the upstream automatic_model_training notebook (piper-sample-generator + libritts checkpoint, package list, MIT RIRs / AudioSet / FMA, ACAV100M features, three-stage invocation).

- **whisper_sync/phrase_training.py**: pure logic - workspace layout, name sanitization, config generation, command construction. CI-tested. The config is written as JSON, a strict subset of YAML 1.2, so the trainer's `yaml.load` reads it and the app side needs no yaml import. Values the notebook did not pin are marked PROVISIONAL and are validated by the first supervised run (train.py fails fast on a bad key).
- **training/setup_trainer.py**: one-time setup of a SEPARATE trainer venv (CUDA torch and the rest of the heavy stack stay out of whisper-env), piper checkout + TTS checkpoint, dataset downloads. Idempotent (finished files skip); refuses the **12-18 GB** download without `--yes`.
- **training/train_phrase.py**: trains one phrase end to end, drops the .onnx into `workspace/phrases/` ready for `wake_phrase_model` / `wake_outro_model`. Refuses without `--go` - training occupies the dGPU for tens of minutes and the owner must be warned first (GPU protocol).
- `training/workspace/` gitignored.

## Execution staged

The dataset download and the first supervised training run wait for an explicit owner go. This PR ships the tooling; PR B adds the saved-phrase registry + tray Saved Phrases surface, PR C the Set Phrase dialog + background job with status/ETA.

## Tests

System suite 426 passed, 2 skipped (test_phrase_training covers sanitization, notebook config values, workspace-rooted paths, override precedence, JSON-as-YAML serialization, and the three-stage command order).