### PR TITLE
feat: saved-phrase registry + tray Saved Phrases surface (step 5, PR B)

### DIFF
--- a/docs/features/defaults.md
+++ b/docs/features/defaults.md
@@ -55,3 +55,4 @@ fails if this table and the defaults file disagree on keys.
 | `wake_threshold` | `0.5` | Wake-word detection score threshold (0-1) |
 | `wake_outro_model` | (empty) | Outro phrase model that ends a wake dictation hands-free (empty = disabled) |
 | `wake_silence_stop_s` | `8` | Sustained silence (silero VAD) that ends a wake dictation; 0 disables |
+| `wake_phrases` | `{}` | Saved-phrase registry: name -> {path, role (wake/outro), active}. Active entries load into the listener; empty = pretrained fallback |

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -54,8 +54,10 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   second openWakeWord model; also stripped from the text tail) or
   after `wake_silence_stop_s` of silence (silero VAD; 0 disables) -
   the dictation hotkey still works at any time. Ships with the
-  pretrained "hey jarvis" phrase until custom phrases and the in-app
-  trainer arrive. Pauses during whisper mode and while recording
+  pretrained "hey jarvis" phrase until custom phrases are trained
+  (training/README.md); trained phrases register in `wake_phrases`
+  and toggle via Settings > Wake Word Listener > Saved Phrases
+  (active checkmarks; multiple wake and outro phrases load at once). Pauses during whisper mode and while recording
   (except during its own wake dictations, which it watches for the
   stop signals). Needs `openwakeword` in the venv (in
   requirements.txt); without it the toggle simply reports unavailable.

--- a/docs/owner-test-checklist.md
+++ b/docs/owner-test-checklist.md
@@ -104,6 +104,8 @@ gaming).
 - [ ] `python training/train_phrase.py "hey hal" --go` produces
   `training/workspace/phrases/hey_hal.onnx` (this run also validates
   the PROVISIONAL config values; a bad key fails fast and gets fixed).
-- [ ] Set `wake_phrase_model` to that .onnx path, toggle the listener
-  off/on - saying "hey hal" starts a dictation; "hey jarvis" no
-  longer does.
+- [ ] Register it in `wake_phrases` (name `hey_hal`, the .onnx path,
+  role `wake`, active `true`), then check it under Settings > Wake
+  Word Listener > Saved Phrases - saying "hey hal" starts a
+  dictation; "hey jarvis" no longer does (custom phrases replace the
+  pretrained fallback while any is active).

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -354,3 +354,18 @@ training job with menu status/ETA + completion toast.
   warn-owner protocol). EXECUTION STAGED: the dataset download and
   the first supervised training run wait for an explicit owner go -
   PROVISIONAL config values are validated by that first run.
+
+- **2026-07-05 (step 5 PR B)**: saved-phrase registry. New config key
+  wake_phrases (name -> {path, role wake/outro, active}); the
+  listener loads ALL active models into one openWakeWord Model
+  (wake_model_paths falls back to the pretrained wake_phrase_model
+  when nothing is active, so the listener never goes deaf; outro
+  routing generalized from one key to the _outro_keys set, legacy
+  wake_outro_model still honored). Text strips try every active
+  phrase name plus the legacy keys - the strips are conservative, so
+  only the spoken one matches. Tray: Settings > Wake Word Listener >
+  Saved Phrases with active checkmarks; toggling bounces the listener
+  thread (model list binds at thread start). Malformed registry
+  entries are skipped, never crash. Remaining for step 5: PR C (Set
+  Phrase dialog + background training job + tray status/ETA +
+  registry auto-registration on training success).

--- a/tests/test_dictation_flow.py
+++ b/tests/test_dictation_flow.py
@@ -464,6 +464,19 @@ class WakeSpliceTests(_FlowHarness):
         self.assertEqual(self.paste.call_args[0][0],
                          "take a note about the demo.")
 
+    def test_registry_phrase_names_drive_the_strips(self):
+        self.app.cfg["wake_phrases"] = {
+            "hey_hal": {"path": "C:/p/hey_hal.onnx", "role": "wake",
+                        "active": True},
+            "thats_all": {"path": "C:/p/thats_all.onnx", "role": "outro",
+                          "active": True}}
+        self.app.worker.transcribe_fast = (
+            lambda audio, model_override=None, timeout=None:
+            "Hey Hal, note the demo. That's all.")
+        self.flow.begin_via_wake(None)
+        self.flow.toggle()
+        self.assertEqual(self.paste.call_args[0][0], "note the demo.")
+
     def test_normal_dictation_never_strips(self):
         self.app.worker.transcribe_fast = (
             lambda audio, model_override=None, timeout=None:

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -18,6 +18,8 @@ except ImportError:  # dependency-light system python (CI)
 
 from whisper_sync.listener import (
     WakeListener, strip_leading_phrase, RING_FRAMES,
+    wake_model_paths, outro_model_paths, wake_strip_names,
+    outro_strip_names,
 )
 from whisper_sync.state_manager import StateManager
 
@@ -392,6 +394,86 @@ class WakeSessionTests(unittest.TestCase):
         listener = WakeListener(self.app, on_wake=mock.Mock())
         self.assertFalse(listener.process_scores({"thats_all": 0.9}))
         self.assertTrue(listener.process_scores({"hey_jarvis": 0.9}))
+
+
+class PhraseRegistryTests(unittest.TestCase):
+    """wake_phrases registry -> model lists, routing, strip names."""
+
+    def setUp(self):
+        self.cfg = {"wake_phrase_model": "hey_jarvis",
+                    "wake_outro_model": "",
+                    "wake_phrases": {}}
+
+    def test_empty_registry_falls_back_to_pretrained(self):
+        self.assertEqual(wake_model_paths(self.cfg), ["hey_jarvis"])
+        self.assertEqual(outro_model_paths(self.cfg), [])
+
+    def test_active_wake_entries_replace_the_fallback(self):
+        self.cfg["wake_phrases"] = {
+            "hey_hal": {"path": "C:/p/hey_hal.onnx", "role": "wake",
+                        "active": True},
+            "take_note": {"path": "C:/p/take_note.onnx", "role": "wake",
+                          "active": False},
+        }
+        self.assertEqual(wake_model_paths(self.cfg),
+                         ["C:/p/hey_hal.onnx"],
+                         "inactive entries and the fallback stay out")
+
+    def test_outro_entries_plus_legacy_key(self):
+        self.cfg["wake_outro_model"] = "alexa"
+        self.cfg["wake_phrases"] = {
+            "thats_all": {"path": "C:/p/thats_all.onnx", "role": "outro",
+                          "active": True}}
+        self.assertEqual(outro_model_paths(self.cfg),
+                         ["C:/p/thats_all.onnx", "alexa"])
+
+    def test_malformed_entries_never_crash_and_are_skipped(self):
+        self.cfg["wake_phrases"] = {
+            "junk": "not-a-dict",
+            "no_path": {"role": "wake", "active": True},
+            "ok": {"path": "C:/p/ok.onnx", "role": "wake", "active": True},
+        }
+        self.assertEqual(wake_model_paths(self.cfg), ["C:/p/ok.onnx"])
+        self.cfg["wake_phrases"] = ["not", "a", "dict"]
+        self.assertEqual(wake_model_paths(self.cfg), ["hey_jarvis"])
+
+    def test_strip_name_candidates(self):
+        self.cfg["wake_phrases"] = {
+            "hey_hal": {"path": "C:/p/hey_hal.onnx", "role": "wake",
+                        "active": True},
+            "thats_all": {"path": "C:/p/t.onnx", "role": "outro",
+                          "active": True}}
+        self.assertEqual(wake_strip_names(self.cfg),
+                         ["hey_hal", "hey_jarvis"])
+        self.assertEqual(outro_strip_names(self.cfg), ["thats_all"])
+
+    def test_listener_model_list_dedups_preserving_order(self):
+        app = _FakeApp()
+        app.cfg["wake_phrases"] = {
+            "hey_hal": {"path": "hey_hal.onnx", "role": "wake",
+                        "active": True},
+            "same_file": {"path": "hey_hal.onnx", "role": "outro",
+                          "active": True}}
+        self.assertEqual(WakeListener(app)._model_list(),
+                         ["hey_hal.onnx"])
+
+    def test_registry_outro_stops_sessions_and_never_wakes(self):
+        app = _FakeApp()
+        app.dictation.toggle = mock.Mock()
+        app.cfg["wake_phrases"] = {
+            "thats_all": {"path": "C:/p/thats_all.onnx", "role": "outro",
+                          "active": True}}
+        listener = WakeListener(app)
+        # The custom outro's score key (openWakeWord stems the path)
+        # must not fire a wake while idle...
+        self.assertFalse(listener.process_scores({"thats_all": 0.9}))
+        # ...but must end a wake session.
+        app.state.emit("x", mode="dictation")
+        listener._wake_session_active = True
+        listener._session_started = time.monotonic() - 10
+        listener._last_voice = time.monotonic()
+        listener.handle_frame("f", _FakeModel(scores={"thats_all": 0.9}))
+        app.dictation.toggle.assert_called_once()
 
 
 class StripTrailingPhraseTests(unittest.TestCase):

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -192,6 +192,37 @@ class MenuBuildTests(unittest.TestCase):
         self.app.wake_listener.restart_if_toggled.assert_called_once()
         save.assert_called_once()
 
+    def test_saved_phrases_empty_registry_shows_info_line(self):
+        items = self.menu._build_saved_phrase_items()
+        self.assertEqual(len(items), 1)
+        self.assertIn("No saved phrases", items[0].text)
+        self.assertFalse(items[0].kw.get("enabled", True))
+
+    def test_saved_phrases_entries_render_with_roles(self):
+        self.app.cfg["wake_phrases"] = {
+            "hey_hal": {"path": "C:/p/hey_hal.onnx", "role": "wake",
+                        "active": True},
+            "thats_all": {"path": "C:/p/t.onnx", "role": "outro",
+                          "active": False}}
+        items = self.menu._build_saved_phrase_items()
+        texts = [i.text for i in items]
+        self.assertEqual(texts, ["hey_hal (wake)", "thats_all (outro)"])
+        checked = [i.kw["checked"](i) for i in items]
+        self.assertEqual(checked, [True, False])
+
+    def test_toggle_saved_phrase_flips_saves_and_bounces_listener(self):
+        self.app.cfg["wake_phrases"] = {
+            "hey_hal": {"path": "C:/p/hey_hal.onnx", "role": "wake",
+                        "active": False}}
+        self.app.wake_listener = types.SimpleNamespace(
+            stop=mock.Mock(), start=mock.Mock())
+        with mock.patch.object(config, "save") as save:
+            self.menu._toggle_saved_phrase("hey_hal")
+        self.assertTrue(self.app.cfg["wake_phrases"]["hey_hal"]["active"])
+        self.app.wake_listener.stop.assert_called_once()
+        self.app.wake_listener.start.assert_called_once()
+        save.assert_called_once()
+
     def test_menu_shows_meeting_auto_record_section(self):
         menu = self.menu.build()
         texts = " | ".join(_iter_texts(menu))

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -223,6 +223,21 @@ class MenuBuildTests(unittest.TestCase):
         self.app.wake_listener.start.assert_called_once()
         save.assert_called_once()
 
+    def test_toggle_saved_phrase_tolerates_malformed_registry(self):
+        # Review catch: a corrupted config (non-dict registry or a
+        # string entry) must never crash the tray toggle - it repairs
+        # the entry instead, same tolerance as listener.py.
+        self.app.wake_listener = types.SimpleNamespace(
+            stop=mock.Mock(), start=mock.Mock())
+        self.app.cfg["wake_phrases"] = ["not", "a", "dict"]
+        with mock.patch.object(config, "save"):
+            self.menu._toggle_saved_phrase("hey_hal")
+        self.assertTrue(self.app.cfg["wake_phrases"]["hey_hal"]["active"])
+        self.app.cfg["wake_phrases"] = {"hey_hal": "corrupted-string"}
+        with mock.patch.object(config, "save"):
+            self.menu._toggle_saved_phrase("hey_hal")
+        self.assertTrue(self.app.cfg["wake_phrases"]["hey_hal"]["active"])
+
     def test_menu_shows_meeting_auto_record_section(self):
         menu = self.menu.build()
         texts = " | ".join(_iter_texts(menu))

--- a/whisper_sync/config.defaults.json
+++ b/whisper_sync/config.defaults.json
@@ -61,5 +61,6 @@
   "wake_phrase_model": "hey_jarvis",
   "wake_threshold": 0.5,
   "wake_outro_model": "",
-  "wake_silence_stop_s": 8
+  "wake_silence_stop_s": 8,
+  "wake_phrases": {}
 }

--- a/whisper_sync/config.py
+++ b/whisper_sync/config.py
@@ -39,7 +39,7 @@ _VALID_KEYS = {
     "meeting_watch_toasts", "meeting_watch_toast_optin",
     "meeting_watch_toast_optout",
     "wake_listener", "wake_phrase_model", "wake_threshold",
-    "wake_outro_model", "wake_silence_stop_s",
+    "wake_outro_model", "wake_silence_stop_s", "wake_phrases",
 }
 
 

--- a/whisper_sync/dictation_flow.py
+++ b/whisper_sync/dictation_flow.py
@@ -449,14 +449,26 @@ class DictationFlow:
                     # phrase, and the dictation mic hears the outro
                     # phrase before the listener can stop the session;
                     # both are summons, not dictation (listener.py owns
-                    # the strip logic).
-                    from .listener import (strip_leading_phrase,
-                                           strip_trailing_phrase)
-                    text = strip_leading_phrase(
-                        text, app.cfg.get("wake_phrase_model", "hey_jarvis"))
-                    outro = app.cfg.get("wake_outro_model", "")
-                    if outro and text:
-                        text = strip_trailing_phrase(text, outro)
+                    # the strip logic). Which saved phrase fired is not
+                    # threaded through, so each candidate is tried; the
+                    # strips are conservative and only the spoken one
+                    # matches.
+                    from .listener import (
+                        strip_leading_phrase, strip_trailing_phrase,
+                        wake_strip_names, outro_strip_names,
+                    )
+                    for name in wake_strip_names(app.cfg):
+                        stripped = strip_leading_phrase(text, name)
+                        if stripped != text:
+                            text = stripped
+                            break
+                    for name in outro_strip_names(app.cfg):
+                        if not text:
+                            break
+                        stripped = strip_trailing_phrase(text, name)
+                        if stripped != text:
+                            text = stripped
+                            break
                 char_count = len(text) if text else 0
 
                 if is_feature:

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -91,6 +91,66 @@ SESSION_GRACE_S = 2.0
 VAD_VOICE_THRESHOLD = 0.3
 
 
+def _model_stem(name: str) -> str:
+    """Model path/name -> the stem openWakeWord keys scores by."""
+    return re.sub(r"\.(onnx|tflite)$", "",
+                  re.split(r"[\\/]", str(name))[-1],
+                  flags=re.IGNORECASE).lower()
+
+
+def _registry(cfg) -> dict:
+    """The wake_phrases saved-phrase registry (name -> entry dict)."""
+    phrases = cfg.get("wake_phrases", {})
+    return phrases if isinstance(phrases, dict) else {}
+
+
+def active_phrase_entries(cfg, role: str):
+    """(name, path) pairs of active registry entries for a role.
+
+    Malformed entries (non-dict, missing path, unknown role) are
+    skipped - a broken registry can disable a phrase but never crash
+    the listener or load the wrong model.
+    """
+    for name, entry in _registry(cfg).items():
+        if (isinstance(entry, dict) and entry.get("active")
+                and entry.get("role", "wake") == role
+                and entry.get("path")):
+            yield name, str(entry["path"])
+
+
+def wake_model_paths(cfg) -> list[str]:
+    """Models that WAKE: active custom phrases, else the pretrained
+    fallback (wake_phrase_model) so the listener never goes deaf."""
+    paths = [p for _, p in active_phrase_entries(cfg, "wake")]
+    return paths or [str(cfg.get("wake_phrase_model", "hey_jarvis"))]
+
+
+def outro_model_paths(cfg) -> list[str]:
+    """Models that END a wake dictation: active outro phrases plus the
+    legacy wake_outro_model key (empty = none)."""
+    paths = [p for _, p in active_phrase_entries(cfg, "outro")]
+    legacy = str(cfg.get("wake_outro_model", "") or "")
+    if legacy:
+        paths.append(legacy)
+    return paths
+
+
+def wake_strip_names(cfg) -> list[str]:
+    """Phrase-name candidates for the leading text strip (registry
+    names encode the typed words, e.g. hey_hal)."""
+    return ([n for n, _ in active_phrase_entries(cfg, "wake")]
+            + [str(cfg.get("wake_phrase_model", "hey_jarvis"))])
+
+
+def outro_strip_names(cfg) -> list[str]:
+    """Phrase-name candidates for the trailing text strip."""
+    names = [n for n, _ in active_phrase_entries(cfg, "outro")]
+    legacy = str(cfg.get("wake_outro_model", "") or "")
+    if legacy:
+        names.append(legacy)
+    return names
+
+
 def _phrase_tokens(phrase_name: str) -> list[str]:
     """Model name -> spoken words ("hey_jarvis_v0.1" -> ["hey", "jarvis"]).
 
@@ -190,18 +250,27 @@ class WakeListener:
     def enabled(self) -> bool:
         return bool(self.app.cfg.get("wake_listener", False))
 
-    def _phrase(self) -> str:
-        return str(self.app.cfg.get("wake_phrase_model", "hey_jarvis"))
-
     def _threshold(self) -> float:
         try:
             return float(self.app.cfg.get("wake_threshold", 0.5))
         except (TypeError, ValueError):
             return 0.5
 
-    def _outro(self) -> str:
-        """Outro phrase model name; empty string = no outro configured."""
-        return str(self.app.cfg.get("wake_outro_model", "") or "")
+    def _model_list(self) -> list[str]:
+        """Every model the listener loads: wake models first, then
+        outro models, deduplicated preserving order."""
+        return list(dict.fromkeys(
+            wake_model_paths(self.app.cfg)
+            + outro_model_paths(self.app.cfg)))
+
+    def _outro_keys(self) -> set[str]:
+        """Score-dict keys that mean OUTRO, not wake (full value and
+        openWakeWord's stem form, lowercased)."""
+        keys = set()
+        for model in outro_model_paths(self.app.cfg):
+            keys.add(model.lower())
+            keys.add(_model_stem(model))
+        return keys
 
     def _silence_stop_s(self) -> float:
         """Seconds of sustained silence that end a wake dictation.
@@ -214,17 +283,6 @@ class WakeListener:
             return float(self.app.cfg.get("wake_silence_stop_s", 8))
         except (TypeError, ValueError):
             return 8.0
-
-    @staticmethod
-    def _is_outro_key(score_key: str, outro: str) -> bool:
-        """openWakeWord keys scores by the model file's basename minus
-        its extension; the config value may be a bare pretrained name or
-        a path to a custom .onnx."""
-        if not outro:
-            return False
-        stem = re.sub(r"\.(onnx|tflite)$", "",
-                      re.split(r"[\\/]", outro)[-1], flags=re.IGNORECASE)
-        return score_key.lower() in (outro.lower(), stem.lower())
 
     # -- Lifecycle ---------------------------------------------------------------
 
@@ -291,7 +349,7 @@ class WakeListener:
         import sounddevice as sd
 
         logger.info(
-            f"Wake listener active: phrase model '{self._phrase()}', "
+            f"Wake listener active: models {self._model_list()}, "
             f"threshold {self._threshold():.2f}")
         self._was_paused = False
         self._ring.clear()
@@ -311,15 +369,12 @@ class WakeListener:
     def _load_model(self):
         """Load the openWakeWord model (lazy heavy import).
 
-        The outro phrase, when configured, loads into the SAME model:
-        predict() returns one score per loaded model and the decision
-        logic routes wake keys and the outro key separately.
+        All active saved phrases and outro models load into the SAME
+        model: predict() returns one score per loaded model and the
+        decision logic routes wake keys and outro keys separately.
         """
         from openwakeword.model import Model
-        models = [self._phrase()]
-        outro = self._outro()
-        if outro:
-            models.append(outro)
+        models = self._model_list()
         try:
             return Model(wakeword_models=models,
                          inference_framework="onnx",
@@ -379,12 +434,12 @@ class WakeListener:
             self._last_voice = now
         if now - self._session_started < SESSION_GRACE_S:
             return
-        outro = self._outro()
-        if outro:
+        outro_keys = self._outro_keys()
+        if outro_keys:
             threshold = self._threshold()
             hit = any(score >= threshold
                       for name, score in (scores or {}).items()
-                      if self._is_outro_key(name, outro))
+                      if name.lower() in outro_keys)
             if hit:
                 self._stop_wake_dictation(model, "outro phrase")
                 return
@@ -461,14 +516,14 @@ class WakeListener:
         """Evaluate one frame's model scores; fire at most one wake.
 
         Returns True when a wake fired (refractory window applies).
-        The outro model shares the score dict but never wakes: saying
-        the outro phrase while idle must not start a dictation.
+        The outro models share the score dict but never wake: saying
+        an outro phrase while idle must not start a dictation.
         """
         threshold = self._threshold()
-        outro = self._outro()
+        outro_keys = self._outro_keys()
         hit = any(score >= threshold
                   for name, score in (scores or {}).items()
-                  if not self._is_outro_key(name, outro))
+                  if name.lower() not in outro_keys)
         if not hit:
             return False
         now = time.monotonic()

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -992,8 +992,13 @@ class TrayMenu:
         """Flip a saved phrase's active flag and reload the listener
         (the model list is bound at thread start)."""
         cfg = self.app.cfg
-        phrases = dict(cfg.get("wake_phrases", {}) or {})
-        entry = dict(phrases.get(name) or {})
+        raw = cfg.get("wake_phrases", {})
+        # Same malformed-config tolerance as listener.py: a corrupted
+        # registry (non-dict, string entries) must never take down the
+        # tray menu.
+        phrases = dict(raw) if isinstance(raw, dict) else {}
+        raw_entry = phrases.get(name)
+        entry = dict(raw_entry) if isinstance(raw_entry, dict) else {}
         entry["active"] = not entry.get("active")
         phrases[name] = entry
         cfg["wake_phrases"] = phrases

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -520,6 +520,8 @@ class TrayMenu:
                         f"  Phrase: "
                         f"{self.app.cfg.get('wake_phrase_model', 'hey_jarvis')}",
                         None, enabled=False),
+                    pystray.MenuItem("Saved Phrases", pystray.Menu(
+                        *self._build_saved_phrase_items())),
                 )),
                 pystray.MenuItem(f"Diarization (Speaker Detection)\t{primary_label}",
                                  pystray.Menu(*diarize_sub_items)),
@@ -962,6 +964,43 @@ class TrayMenu:
         logger.info(
             f"Wake listener: {'on' if cfg['wake_listener'] else 'off'}")
         self.app.wake_listener.restart_if_toggled()
+        self._save_and_refresh()
+
+    def _build_saved_phrase_items(self):
+        """Saved-phrase entries (wake_phrases registry) with active
+        checkmarks. Until the PR C dialog exists, phrases arrive via
+        training/train_phrase.py plus a registry entry."""
+        import pystray  # lazy: not installed on the CI system python
+        phrases = self.app.cfg.get("wake_phrases", {}) or {}
+        if not isinstance(phrases, dict) or not phrases:
+            return [pystray.MenuItem(
+                "No saved phrases (train via training/train_phrase.py)",
+                None, enabled=False)]
+        items = []
+        for name in sorted(phrases):
+            entry = phrases[name] if isinstance(phrases[name], dict) else {}
+            items.append(pystray.MenuItem(
+                f"{name} ({entry.get('role', 'wake')})",
+                menu_callback(self._toggle_saved_phrase, name),
+                checked=lambda item, n=name: bool(
+                    ((self.app.cfg.get("wake_phrases", {}) or {})
+                     .get(n) or {}).get("active")),
+            ))
+        return items
+
+    def _toggle_saved_phrase(self, name):
+        """Flip a saved phrase's active flag and reload the listener
+        (the model list is bound at thread start)."""
+        cfg = self.app.cfg
+        phrases = dict(cfg.get("wake_phrases", {}) or {})
+        entry = dict(phrases.get(name) or {})
+        entry["active"] = not entry.get("active")
+        phrases[name] = entry
+        cfg["wake_phrases"] = phrases
+        logger.info(f"Saved phrase '{name}': "
+                    f"{'active' if entry['active'] else 'inactive'}")
+        self.app.wake_listener.stop()
+        self.app.wake_listener.start()
         self._save_and_refresh()
 
     def _toggle_always_available_dictation(self):


### PR DESCRIPTION
## What

Step 5 PR B of 3, per the plan doc. Custom phrases trained by PR A's CLI become first-class citizens the listener loads and the tray manages.

- **`wake_phrases` registry** (new config key): `name -> {path, role wake/outro, active}`. Malformed entries are skipped, never crash.
- **Listener multi-model loading**: all active phrase models load into ONE openWakeWord Model. `wake_model_paths` falls back to the pretrained `wake_phrase_model` when no custom wake phrase is active - the listener never goes deaf. Outro routing generalizes to the `_outro_keys` set (legacy `wake_outro_model` still honored); registry outros never fire a wake and do end wake sessions.
- **Strips follow the registry**: leading/trailing strips try every active phrase name plus the legacy keys; only the spoken one matches (the strips are window/end-anchored).
- **Tray**: Settings > Wake Word Listener > Saved Phrases - active checkmarks, toggle flips + saves + bounces the listener thread (model list binds at thread start). Empty registry shows a pointer to the training CLI.
- Checklist section 7 updated to the registry flow.

## Tests

System suite 437 passed, 2 skipped; venv 107 passed (registry fallbacks/filtering/malformed tolerance, dedup, outro-stem routing both ways, registry-driven strips end to end, tray items + toggle).