### PR TITLE
feat: live validation suite - real hardware, no human (WS_LIVE=1)

### DIFF
--- a/docs/owner-test-checklist.md
+++ b/docs/owner-test-checklist.md
@@ -11,17 +11,31 @@ Automated coverage lives in the suites (docs/testing.md); this list is
 only for what needs the owner's hands: real mic, real calls, real GPU,
 real days of uptime.
 
+**Automated evidence (owner directive 2026-07-05: verify outcomes with
+software tests, not hand-testing):** `tests/test_live_validation.py`
+(WS_LIVE=1, app venv) exercises the real mic, the real consent store,
+the real openWakeWord model on synthesized speech, the real GPU probe,
+a real CPU-pinned worker, and the full production pipeline on the
+pinned real-meeting fixture (tests/fixtures/). Items below marked
+`[x] automated` passed there on 2026-07-05 (9/9 green); unchecked
+items still need a human or multi-day soak.
+
 ## 0. Restart the tray app (gates everything below)
 
-- [ ] Quit the tray app and start it again from the checkout.
-  Everything from #167 onward (auto-sleep, failover, auto-record,
-  wake listener, all the fixes) only activates after this restart.
+- [x] DONE 2026-07-05: the app was not running; the session started
+  it fresh from the checkout via start.ps1 (post-#194 code, worker
+  spawned, guard_started logged). Everything from #167 onward is now
+  active.
 
 ## 1. Post-restart smoke (5 min)
 
 - [ ] Normal dictation: hotkey, speak a sentence, hotkey - text pastes.
-- [ ] Normal meeting: record ~1 min with system audio, stop, name it -
-  minutes + transcript appear, no error toast.
+- [x] automated (LiveRealMeetingTests): the full production pipeline
+  (GPU model, align, diarize) on the pinned 5.9-min 4-speaker meeting
+  fixture produced 60%+ of the reference word volume, 2+ speakers,
+  and full-duration coverage. 2026-07-05.
+- [ ] Normal meeting via the tray: record ~1 min with system audio,
+  stop, name it - minutes + transcript appear, no error toast.
 - [ ] The #167 fixes ride along: the meeting completes (no
   post-transcription abort) and saving with a name that already
   exists does not clobber anything.
@@ -35,16 +49,16 @@ real days of uptime.
   recording starts at once (yellow loading flash), text arrives
   after the model loads. Nothing you said is lost.
 
-## 3. GPU power-state failover (#180-#182) - opportunistic
+## 3. GPU power-state failover (#180-#182)
 
-Hard to trigger on demand; validate whenever the hybrid laptop powers
-the dGPU off mid-session (or via a driver toggle).
-
-- [ ] On dGPU loss: failover toast, dictation still works (cpu +
-  `cpu_fallback_model`), no crash, no CUDA-retry loop in the log.
-- [ ] When the dGPU returns and the app is idle: switch-back toast,
-  next dictation is fast (GPU) again.
-- [ ] `gpu-guard.jsonl` shows gpu_device_lost / gpu_device_recovered.
+- [x] automated (LiveFailoverTests): with the probe reporting the
+  device gone, the guard declares loss, pins the spawn to cpu +
+  `cpu_fallback_model`, and a REAL worker transcribes speech
+  correctly on CPU; with the real probe, the GPU is seen and no
+  pinning happens. 2026-07-05.
+- [ ] Opportunistic (real dGPU power-off only): failover toast +
+  switch-back toast in the running tray app, gpu_device_lost /
+  gpu_device_recovered in `gpu-guard.jsonl`.
 
 ## 4. Per-app meeting auto-record (#183, #184, #186)
 
@@ -57,6 +71,9 @@ Enable Settings > Meeting Auto-Record first (off by default).
   save dialog, nothing on disk.
 - [ ] Discord (default "ask"): joining a call shows the opt-out toast
   with a one-click "Record" button; ignoring it records nothing.
+- [x] automated (LiveConsentStoreTests): the consent-store probe that
+  powers detection and "Detect apps..." reads real entries on this
+  machine. 2026-07-05.
 - [ ] Settings > Meeting Auto-Record > Apps > "Detect apps..." - apps
   that have used the mic appear; new ones arrive as Ignore.
 - [ ] Manual hotkey recording still works exactly as before with the
@@ -67,9 +84,15 @@ Enable Settings > Meeting Auto-Record first (off by default).
 Enable Settings > Wake Word Listener (off by default; first enable
 downloads the openWakeWord models - watch the log).
 
-- [ ] Say "hey jarvis, take a note about X" in one breath - dictation
-  starts, and the pasted text is "take a note about X" WITHOUT the
-  wake phrase and without clipped syllables at the start.
+- [x] automated (LiveWakePipelineTests): synthesized "hey jarvis"
+  through the real model + real decision loop fires EXACTLY one wake
+  and hands a well-formed >1s ring-buffer prefix to the dictation
+  seam; unrelated speech never fires; the silero VAD separates speech
+  from silence (the silence auto-stop signal). 2026-07-05.
+- [ ] Say "hey jarvis, take a note about X" into the real mic with
+  the tray app running - text pastes WITHOUT the wake phrase and
+  without clipped syllables (the last human-only step: your voice,
+  your mic, the running app).
 - [ ] Stop by hotkey mid-dictation - works, listener resumes normal
   listening.
 - [ ] After waking it, stay silent ~8s - the dictation stops itself

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -355,6 +355,36 @@ training job with menu status/ETA + completion toast.
   the first supervised training run wait for an explicit owner go -
   PROVISIONAL config values are validated by that first run.
 
+- **2026-07-05 (owner directives: automate validation, real-meeting
+  fixture, hardware freed)**: the owner asked that nothing require his
+  hand-testing, that a real 5-10 minute multi-speaker meeting be
+  pinned into the test folder as a standing fixture, and freed the
+  GPU/machine for real testing until further notice. Shipped
+  tests/test_live_validation.py (WS_LIVE=1): shared-mic coexistence +
+  prefix ordering on the real mic, consent-store read, synthesized
+  "hey jarvis" through the real model + decision loop (one wake, >1s
+  prefix, negative control silent, VAD speech/silence split), GPU
+  probe healthy + dead-probe -> CPU-pinned real worker transcribing
+  correctly, and the FULL production pipeline on the pinned fixture
+  (tests/fixtures/real-meeting/, gitignored - private audio never
+  enters the public repo) judged against its reference transcript.
+  9/9 green on the dev machine 2026-07-05. Findings fixed along the
+  way: onnxruntime DLL-init order conflict (preload at collection),
+  live guard tests polluting the production gpu-guard.jsonl
+  (event_path pinned to temp). Trainer-env execution findings (PR A
+  scaffold validated by running it): torch must come from the cu128
+  index (Blackwell sm_120 + the proven whisper-env build), the
+  piper-sample-generator clone must pin v2.0.0 (v3 broke train.py's
+  generate_samples import), piper-phonemize -> piper-phonemize-fix
+  and webrtcvad -> webrtcvad-wheels (upstream ships no Windows
+  wheels), and the trainer venv must be Python 3.11. Machine note:
+  a crash-reboot occurred 20:59 local while the machine was idle of
+  session workloads (HYPERVISOR_ERROR bugcheck + WHEA fatal hardware
+  error; this laptop has a documented chronic GPU-driver instability
+  history); the full GPU pipeline test ran clean immediately after
+  reboot. The tray app was found not running and was started fresh
+  from the checkout (post-#194 code) - the restart gate is cleared.
+
 - **2026-07-05 (step 5 PR B)**: saved-phrase registry. New config key
   wake_phrases (name -> {path, role wake/outro, active}); the
   listener loads ALL active models into one openWakeWord Model

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -363,7 +363,8 @@ training job with menu status/ETA + completion toast.
   tests/test_live_validation.py (WS_LIVE=1): shared-mic coexistence +
   prefix ordering on the real mic, consent-store read, synthesized
   "hey jarvis" through the real model + decision loop (one wake, >1s
-  prefix, negative control silent, VAD speech/silence split), GPU
+  prefix, an unrelated spoken phrase never fires, VAD speech/silence
+  split), GPU
   probe healthy + dead-probe -> CPU-pinned real worker transcribing
   correctly, and the FULL production pipeline on the pinned fixture
   (tests/fixtures/real-meeting/, gitignored - private audio never

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,6 +11,7 @@ page disagree, fix the other doc.
 | Venv suite | 36 tests: audio capture (open ladder, downmix, speaker streaming) + real-data harness | Local only (needs numpy/scipy in whisper-env) | see development.md |
 | Real-data harness | `flatten()` reproduced byte-for-byte against real shipped meetings | Local only; discovers via `WS_MEETINGS_DIR`, skips cleanly when absent. **Private audio never enters this repo.** | part of the venv suite |
 | End-to-end | Production worker subprocess on the smallest real recording (~1 min) | Local, opt-in (`WS_E2E=1`); run after worker-protocol or pipeline changes | see development.md |
+| Live validation | Real hardware, no human: shared mic streams, consent store, openWakeWord on synthesized speech, GPU probe + CPU failover with a real worker, full pipeline on the pinned real-meeting fixture (tests/fixtures/) | Local, opt-in (`WS_LIVE=1`); automates the owner-test-checklist items a machine can measure | `WS_LIVE=1 python -m pytest tests/test_live_validation.py` (app venv) |
 | Manual checklist | Hardware-in-the-loop checks no automated test covers (real mic, hotkeys, tray, GPU) | Local, before releases and after audio/tray changes | [.claude/rules/testing.md](../.claude/rules/testing.md) |
 
 ## Test-run isolation

--- a/tests/fixtures/.gitignore
+++ b/tests/fixtures/.gitignore
@@ -1,0 +1,5 @@
+# Private audio never enters the public repo (test fixtures are
+# machine-local; see README.md for what belongs here).
+*
+!.gitignore
+!README.md

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,26 @@
+# Test fixtures - machine-local, never committed
+
+Everything in this directory except this README and the .gitignore is
+ignored by git: the repo is public and REAL MEETING AUDIO STAYS OUT.
+The fixtures are pinned locally so live tests run against a stable,
+known recording instead of re-finding one every session (owner
+directive, 2026-07-05).
+
+## real-meeting/
+
+A real 5-10 minute multi-speaker meeting used by
+`tests/test_live_validation.py::LiveRealMeetingTests` (WS_LIVE=1).
+
+- `recording.wav` - the meeting audio (16 kHz stereo mic+speaker mix).
+- `reference-transcript.json` - the transcript the production pipeline
+  produced for this recording when it was originally processed. The
+  live test uses it as the accuracy baseline (word volume, speaker
+  count), NOT as an exact-match target - models change.
+
+Current fixture (dev machine): 2026-04-20 credit meeting, 5.9 min,
+4 speakers, 767 reference words, real conversation throughout.
+
+To (re)provision on a new machine: copy a recording.wav +
+transcript.json pair from any WhisperSync meeting folder that is
+5-10 minutes long with at least 2 real speakers. The live test skips
+with instructions when the fixture is absent.

--- a/tests/test_live_validation.py
+++ b/tests/test_live_validation.py
@@ -1,0 +1,401 @@
+"""Opt-in LIVE validation: real hardware, real models, no human.
+
+Automates the owner-test-checklist items a machine can measure (owner
+directive 2026-07-05: verify outcomes with typical software tests
+instead of hand-testing). Everything here is deliberately
+non-disruptive: shared-mode mic streams, read-only registry reads, a
+CPU-only worker spawn, and synthetic Windows-TTS audio fed DIRECTLY to
+models - nothing is played out loud and no user file is touched.
+
+    set WS_LIVE=1
+    whisper-env/Scripts/python.exe -m pytest tests/test_live_validation.py -v
+
+Runtime: ~1-3 minutes (the CPU failover transcription dominates).
+Never runs in CI (hardware-dependent; gated like WS_E2E).
+
+What each class proves, mapped to docs/owner-test-checklist.md:
+- LiveMicTests: the listener's shared stream coexists with the
+  recorder on the real default mic (the splice's core hardware claim).
+- LiveConsentStoreTests: meeting auto-record's detection source is
+  readable on this machine and has real entries.
+- LiveWakePipelineTests: a spoken wake phrase (synthesized speech)
+  fires exactly one wake through the REAL openWakeWord model and the
+  REAL decision logic, hands a well-formed ring-buffer prefix to the
+  dictation seam, and unrelated speech never fires. Also proves the
+  silero VAD signal that drives the silence auto-stop.
+- LiveFailoverTests: with the GPU probe reporting the device gone,
+  the guard pins the spawn to cpu and the REAL worker still
+  transcribes speech correctly - the failover outcome end to end.
+  A second test proves the healthy-probe path on the real GPU.
+- LiveRealMeetingTests: the full production pipeline (GPU model,
+  align, diarize) on the pinned real-meeting fixture
+  (tests/fixtures/real-meeting/, machine-local - see the fixtures
+  README), judged against the reference transcript's word volume and
+  speaker count. The heavyweight test: ~3-6 minutes on the GPU.
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+import types
+import unittest
+import wave
+from pathlib import Path
+from unittest import mock
+
+_LIVE = os.environ.get("WS_LIVE") == "1"
+
+try:
+    import numpy as np
+    _HAS_NUMPY = True
+except ImportError:
+    np = None
+    _HAS_NUMPY = False
+
+# onnxruntime must initialize BEFORE scipy/torch/portaudio DLLs enter
+# the process: loaded later (as the wake tests would, mid-suite) its
+# pybind11 DLL init fails on Windows. Import here at collection time;
+# openwakeword picks up the already-loaded module. Harmless if absent.
+try:
+    import onnxruntime
+    _ORT_PRELOADED = bool(onnxruntime)
+except Exception:
+    _ORT_PRELOADED = False
+
+
+def _tts_wav(text: str, dest: Path) -> bool:
+    """Synthesize 16 kHz mono speech via Windows SAPI (no audio out)."""
+    script = (
+        "Add-Type -AssemblyName System.Speech; "
+        "$fmt = New-Object System.Speech.AudioFormat.SpeechAudioFormatInfo("
+        "16000, [System.Speech.AudioFormat.AudioBitsPerSample]::Sixteen, "
+        "[System.Speech.AudioFormat.AudioChannel]::Mono); "
+        "$s = New-Object System.Speech.Synthesis.SpeechSynthesizer; "
+        "$s.Rate = -1; "
+        f"$s.SetOutputToWaveFile('{dest}', $fmt); "
+        f"$s.Speak('{text}'); $s.SetOutputToNull(); $s.Dispose()"
+    )
+    # Two attempts: a cold PowerShell + .NET assembly load can
+    # occasionally blow the first timeout on a busy machine.
+    for _ in range(2):
+        try:
+            result = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", script],
+                capture_output=True, timeout=120)
+            if result.returncode == 0 and dest.exists():
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def _wav_frames(path: Path, pad_s: float = 1.0):
+    """A wav as 80ms int16 frames with silence padding either side."""
+    with wave.open(str(path)) as wf:
+        assert wf.getframerate() == 16000 and wf.getnchannels() == 1
+        data = np.frombuffer(wf.readframes(wf.getnframes()), dtype=np.int16)
+    pad = np.zeros(int(16000 * pad_s), dtype=np.int16)
+    data = np.concatenate([pad, data, pad])
+    return [data[i:i + 1280] for i in range(0, len(data) - 1279, 1280)]
+
+
+def _wav_float32(path: Path):
+    """A wav as the float32 mono array transcribe_fast expects."""
+    with wave.open(str(path)) as wf:
+        data = np.frombuffer(wf.readframes(wf.getnframes()), dtype=np.int16)
+    return data.astype(np.float32) / 32768.0
+
+
+class _ListenerApp:
+    """Minimal real-config app surface for WakeListener decisions."""
+
+    def __init__(self):
+        from whisper_sync.state_manager import StateManager
+        self.cfg = {"wake_listener": True, "wake_threshold": 0.5,
+                    "sample_rate": 16000, "wake_phrases": {}}
+        self.state = StateManager(None, {})
+        self.recorder = types.SimpleNamespace(is_recording=False)
+        self.auto_sleep = types.SimpleNamespace(wake=mock.Mock())
+        self.dictation = types.SimpleNamespace(
+            begin_via_wake=mock.Mock(return_value=True))
+        self.flashes = 0
+
+    def _yellow_flash(self):
+        self.flashes += 1
+
+
+@unittest.skipUnless(_LIVE, "set WS_LIVE=1 to run live hardware validation")
+@unittest.skipUnless(_HAS_NUMPY, "requires the app venv (numpy)")
+class LiveMicTests(unittest.TestCase):
+    def test_listener_stream_and_recorder_share_the_real_mic(self):
+        # The splice's hardware claim: the always-on listener stream is
+        # shared-mode and never blocks the dictation recorder from
+        # opening the same device.
+        import sounddevice as sd
+        from whisper_sync.capture import AudioRecorder, get_default_devices
+
+        mic = get_default_devices().get("input")
+        recorder = AudioRecorder(sample_rate=16000)
+        with sd.InputStream(samplerate=16000, channels=1, dtype="int16",
+                            blocksize=1280) as stream:
+            frame, _ = stream.read(1280)
+            self.assertEqual(frame.shape[0], 1280)
+            self.assertEqual(frame.dtype, np.int16)
+
+            recorder.start(mic_device=mic)
+            try:
+                time.sleep(0.5)  # let callbacks deliver
+                frame, _ = stream.read(1280)  # listener still fed
+                self.assertEqual(frame.shape[0], 1280)
+            finally:
+                audio = recorder.stop()
+        self.assertIn("mic", audio, "recorder captured nothing while "
+                                    "the listener stream was open")
+        self.assertGreater(len(audio["mic"]), 0)
+
+    def test_recorder_prefix_lands_ahead_of_real_capture(self):
+        # PR 1's splice seam on real hardware: prefix first, live
+        # capture after.
+        from whisper_sync.capture import AudioRecorder, get_default_devices
+
+        prefix = np.full((1600, 1), 0.123, dtype=np.float32)
+        recorder = AudioRecorder(sample_rate=16000)
+        recorder.start(mic_device=get_default_devices().get("input"),
+                       prefix_audio=prefix)
+        try:
+            time.sleep(0.4)
+        finally:
+            audio = recorder.stop()
+        self.assertIn("mic", audio)
+        self.assertGreater(len(audio["mic"]), len(prefix),
+                           "live capture must follow the prefix")
+        np.testing.assert_array_equal(audio["mic"][:len(prefix)], prefix)
+
+
+@unittest.skipUnless(_LIVE, "set WS_LIVE=1 to run live hardware validation")
+class LiveConsentStoreTests(unittest.TestCase):
+    def test_consent_store_is_readable_and_populated(self):
+        # Meeting auto-record's detection source (read-only registry).
+        from whisper_sync.meeting_watch import read_mic_entries
+
+        entries = read_mic_entries()
+        self.assertIsNotNone(entries, "consent store must be readable")
+        self.assertGreater(len(entries), 0,
+                           "a real machine has mic-use history")
+        for key, value in entries.items():
+            self.assertEqual(key, key.lower())
+            self.assertIsInstance(value, bool)
+
+
+@unittest.skipUnless(_LIVE, "set WS_LIVE=1 to run live hardware validation")
+@unittest.skipUnless(_HAS_NUMPY, "requires the app venv (numpy)")
+class LiveWakePipelineTests(unittest.TestCase):
+    """Synthesized speech through the REAL model + REAL decision loop."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        tmp = Path(cls._tmp.name)
+        cls.wake_wav = tmp / "wake.wav"
+        cls.other_wav = tmp / "other.wav"
+        if not (_tts_wav("hey jarvis", cls.wake_wav)
+                and _tts_wav("the weather is quite nice today",
+                             cls.other_wav)):
+            raise unittest.SkipTest("Windows TTS unavailable")
+        try:
+            from openwakeword.model import Model
+        except ImportError as exc:
+            raise unittest.SkipTest(f"openwakeword unavailable: {exc}")
+        cls.Model = Model
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def _model(self):
+        return self.Model(wakeword_models=["hey_jarvis"],
+                          inference_framework="onnx", vad_threshold=0.5)
+
+    def test_spoken_phrase_fires_exactly_one_wake_with_prefix(self):
+        from whisper_sync.listener import WakeListener
+
+        app = _ListenerApp()
+        listener = WakeListener(app)
+        model = self._model()
+        for frame in _wav_frames(self.wake_wav):
+            listener.handle_frame(frame, model)
+            # A successful wake arms the session watcher; drop back to
+            # normal listening (mode never becomes "dictation" here)
+            # so the refractory window is what prevents double fires.
+        begin = app.dictation.begin_via_wake
+        self.assertEqual(begin.call_count, 1,
+                         "one spoken phrase = exactly one wake")
+        prefix = begin.call_args[0][0]
+        self.assertIsNotNone(prefix, "ring buffer must produce a prefix")
+        self.assertEqual(prefix.dtype, np.float32)
+        self.assertEqual(prefix.shape[1], 1)
+        self.assertLessEqual(float(np.abs(prefix).max()), 1.0)
+        self.assertGreater(len(prefix), 16000,
+                           "prefix should hold >1s of pre-wake audio")
+
+    def test_unrelated_speech_never_wakes(self):
+        from whisper_sync.listener import WakeListener
+
+        app = _ListenerApp()
+        listener = WakeListener(app)
+        model = self._model()
+        for frame in _wav_frames(self.other_wav):
+            listener.handle_frame(frame, model)
+        app.dictation.begin_via_wake.assert_not_called()
+
+    def test_vad_distinguishes_speech_from_silence(self):
+        # The signal behind wake_silence_stop_s, on the real silero VAD:
+        # speech frames must score as voice, silence must not.
+        from whisper_sync.listener import VAD_VOICE_THRESHOLD
+
+        model = self._model()
+        speech_top = 0.0
+        for frame in _wav_frames(self.wake_wav, pad_s=0.0):
+            model.predict(frame)
+            speech_top = max(speech_top,
+                             float(model.vad.prediction_buffer[-1]))
+        self.assertGreaterEqual(speech_top, VAD_VOICE_THRESHOLD,
+                                "speech must register as voice")
+
+        model = self._model()
+        for frame in [np.zeros(1280, dtype=np.int16)] * 25:  # 2s silence
+            model.predict(frame)
+        self.assertLess(float(model.vad.prediction_buffer[-1]),
+                        VAD_VOICE_THRESHOLD,
+                        "silence must not register as voice")
+
+
+@unittest.skipUnless(_LIVE, "set WS_LIVE=1 to run live hardware validation")
+@unittest.skipUnless(_HAS_NUMPY, "requires the app venv (numpy)")
+class LiveFailoverTests(unittest.TestCase):
+    """GPU power-state failover measured end to end, CPU-only."""
+
+    def test_lost_device_pins_spawn_to_cpu_and_transcribes(self):
+        # The failover OUTCOME: with the dGPU unreachable (probe
+        # returns nothing), the guard pins the spawn to cpu + fallback
+        # model and a real worker still transcribes speech correctly.
+        # Uses the tiny TTS clip - light, CPU-only, no VRAM touched.
+        from whisper_sync import config as ws_config
+        from whisper_sync.gpu_guard import GpuGuard
+        from whisper_sync.worker_manager import TranscriptionWorker
+
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "wake.wav"
+            if not _tts_wav("hey jarvis how are you", wav):
+                raise unittest.SkipTest("Windows TTS unavailable")
+
+            cfg = ws_config.load()
+            # event_path pinned to the temp dir: the guard must not
+            # write test events into the production gpu-guard.jsonl.
+            guard = GpuGuard(cfg, probe=lambda: None, probe_name="dead",
+                             event_path=Path(tmp) / "gpu-guard.jsonl")
+            guard.prime()
+            self.assertTrue(guard.device_lost,
+                            "a dead probe at startup must declare loss")
+            overlay = guard.respawn_overlay()
+            self.assertEqual(overlay["device"], "cpu")
+            self.assertEqual(overlay["model"], cfg.get("cpu_fallback_model",
+                                                       "base"))
+
+            worker_cfg = {**cfg, **overlay}
+            worker = TranscriptionWorker(worker_cfg,
+                                         preload_model=overlay["model"])
+            worker.start()
+            try:
+                self.assertTrue(worker.wait_ready(timeout=300),
+                                "cpu fallback worker must come up")
+                text = worker.transcribe_fast(
+                    _wav_float32(wav), model_override=overlay["model"],
+                    timeout=120)
+                self.assertTrue(text and "jarvis" in text.lower(),
+                                f"cpu transcription must be usable, "
+                                f"got: {text!r}")
+            finally:
+                worker.stop()
+
+    def test_healthy_real_probe_reports_gpu_present(self):
+        # The other half of the switch: on THIS machine the real probe
+        # must see the GPU, so the guard never fails over spuriously.
+        from whisper_sync import config as ws_config
+        from whisper_sync.gpu_guard import GpuGuard
+
+        with tempfile.TemporaryDirectory() as tmp:
+            guard = GpuGuard(ws_config.load(),
+                             event_path=Path(tmp) / "gpu-guard.jsonl")
+            guard.prime()
+        self.assertFalse(guard.device_lost,
+                         "real probe must reach the GPU on this machine")
+        self.assertIsNone(guard.respawn_overlay(),
+                          "healthy device -> live config, no pinning")
+
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "real-meeting"
+
+
+@unittest.skipUnless(_LIVE, "set WS_LIVE=1 to run live hardware validation")
+@unittest.skipUnless(_HAS_NUMPY, "requires the app venv (numpy)")
+@unittest.skipUnless(
+    (_FIXTURE_DIR / "recording.wav").exists()
+    and (_FIXTURE_DIR / "reference-transcript.json").exists(),
+    "real-meeting fixture missing - see tests/fixtures/README.md")
+class LiveRealMeetingTests(unittest.TestCase):
+    """The production pipeline on the pinned real meeting (GPU)."""
+
+    def test_full_pipeline_matches_reference_quality(self):
+        import json
+        import shutil
+        from whisper_sync import config as ws_config
+        from whisper_sync.worker_manager import TranscriptionWorker
+
+        reference = json.loads(
+            (_FIXTURE_DIR / "reference-transcript.json")
+            .read_text(encoding="utf-8"))
+        ref_segments = reference.get("segments", [])
+        ref_words = sum(len(s.get("text", "").split()) for s in ref_segments)
+        ref_speakers = {s.get("speaker") for s in ref_segments
+                        if s.get("speaker")}
+        self.assertGreater(ref_words, 100, "fixture sanity")
+
+        cfg = ws_config.load()
+        worker = TranscriptionWorker(cfg,
+                                     preload_model=cfg.get("model",
+                                                           "large-v3"))
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "recording.wav"
+            shutil.copy2(_FIXTURE_DIR / "recording.wav", wav)
+            worker.start()
+            try:
+                self.assertTrue(worker.wait_ready(timeout=300),
+                                "production model must load")
+                result = worker.transcribe(str(wav), diarize=True,
+                                           timeout=1800)
+                json_path = Path(result["json_path"])
+                data = json.loads(json_path.read_text(encoding="utf-8"))
+            finally:
+                worker.stop()
+
+        segments = data.get("segments", [])
+        self.assertGreater(len(segments), 20,
+                           "a 6-minute conversation yields many segments")
+        words = sum(len(s.get("text", "").split()) for s in segments)
+        self.assertGreaterEqual(
+            words, int(ref_words * 0.6),
+            f"word volume collapsed vs reference ({words}/{ref_words})")
+        speakers = {s.get("speaker") for s in segments if s.get("speaker")}
+        self.assertGreaterEqual(
+            len(speakers), 2,
+            f"diarization must separate real speakers "
+            f"(reference had {len(ref_speakers)})")
+        last_end = max((s.get("end", 0) for s in segments), default=0)
+        self.assertGreater(last_end, 250,
+                           "transcription must cover most of the meeting")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_live_validation.py
+++ b/tests/test_live_validation.py
@@ -66,6 +66,8 @@ except Exception:
 
 def _tts_wav(text: str, dest: Path) -> bool:
     """Synthesize 16 kHz mono speech via Windows SAPI (no audio out)."""
+    if os.name != "nt":
+        return False
     script = (
         "Add-Type -AssemblyName System.Speech; "
         "$fmt = New-Object System.Speech.AudioFormat.SpeechAudioFormatInfo("
@@ -81,7 +83,7 @@ def _tts_wav(text: str, dest: Path) -> bool:
     for _ in range(2):
         try:
             result = subprocess.run(
-                ["powershell", "-NoProfile", "-Command", script],
+                ["powershell.exe", "-NoProfile", "-Command", script],
                 capture_output=True, timeout=120)
             if result.returncode == 0 and dest.exists():
                 return True
@@ -180,9 +182,12 @@ class LiveConsentStoreTests(unittest.TestCase):
         from whisper_sync.meeting_watch import read_mic_entries
 
         entries = read_mic_entries()
-        self.assertIsNotNone(entries, "consent store must be readable")
-        self.assertGreater(len(entries), 0,
-                           "a real machine has mic-use history")
+        if entries is None:
+            self.skipTest("consent store unreadable (non-Windows or "
+                          "registry access denied)")
+        if not entries:
+            self.skipTest("no mic-use history on this profile yet - "
+                          "use any mic app once, then rerun")
         for key, value in entries.items():
             self.assertEqual(key, key.lower())
             self.assertIsInstance(value, bool)

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -149,11 +149,29 @@ def trainer_python(root: Path) -> Path:
     return root / "trainer-env" / "Scripts" / "python.exe"
 
 
+def _require_py311(python_exe: str) -> None:
+    """Fail fast on the wrong interpreter: piper-phonemize wheels stop
+    at 3.11, and a mismatched venv only fails later, mid-pip, with a
+    far less actionable error."""
+    out = subprocess.run(
+        [python_exe, "-c",
+         "import sys; print('%d.%d' % sys.version_info[:2])"],
+        capture_output=True, text=True, check=True)
+    version = out.stdout.strip()
+    if version != "3.11":
+        raise SystemExit(
+            f"[setup] base python is {version}; the trainer venv MUST "
+            "be 3.11 (piper-phonemize ships no newer wheels). Pass "
+            "--python <path to a 3.11 interpreter> (py -3.11).")
+
+
 def phase_venv(root: Path, base_python: str, torch_index: str) -> None:
     py = trainer_python(root)
     if py.exists():
         log("trainer venv exists, skipping create")
+        _require_py311(str(py))
     else:
+        _require_py311(base_python)
         run([base_python, "-m", "venv", root / "trainer-env"])
     run([py, "-m", "pip", "install", "--upgrade", "pip"])
     # CUDA torch first (its own index), then the notebook stack.

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -29,6 +29,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_ROOT = Path(__file__).resolve().parent / "workspace"
 
 PIPER_REPO = "https://github.com/rhasspy/piper-sample-generator"
+# openwakeword's train.py does `from generate_samples import ...` -
+# the v1/v2 top-level-script layout. v3 refactored into a package and
+# breaks that import, so the clone is PINNED to the tag that matches
+# both the layout and the v2.0.0 checkpoint below.
+PIPER_REF = "v2.0.0"
 PIPER_CHECKPOINT = ("https://github.com/rhasspy/piper-sample-generator/"
                     "releases/download/v2.0.0/en_US-libritts_r-medium.pt")
 
@@ -50,8 +55,14 @@ AUDIOSET_TAR = ("https://huggingface.co/datasets/agkphysics/AudioSet/"
 # with the CUDA index.
 TRAINER_PACKAGES = [
     "openwakeword",
-    "piper-phonemize",
-    "webrtcvad",
+    # upstream piper-phonemize ships no Windows wheels at all; the
+    # -fix rebuild provides the same piper_phonemize module (verified
+    # importable on py3.11 2026-07-05)
+    "piper-phonemize-fix",
+    "setuptools<82",  # torch cu128 constraint; -fix pulls in 83
+    # upstream webrtcvad is sdist-only on Windows (needs MSVC); the
+    # -wheels fork ships the same module prebuilt
+    "webrtcvad-wheels",
     "mutagen==1.47.0",
     "torchinfo==1.8.0",
     "torchmetrics==1.2.0",
@@ -138,7 +149,7 @@ def trainer_python(root: Path) -> Path:
     return root / "trainer-env" / "Scripts" / "python.exe"
 
 
-def phase_venv(root: Path, base_python: str) -> None:
+def phase_venv(root: Path, base_python: str, torch_index: str) -> None:
     py = trainer_python(root)
     if py.exists():
         log("trainer venv exists, skipping create")
@@ -146,15 +157,19 @@ def phase_venv(root: Path, base_python: str) -> None:
         run([base_python, "-m", "venv", root / "trainer-env"])
     run([py, "-m", "pip", "install", "--upgrade", "pip"])
     # CUDA torch first (its own index), then the notebook stack.
+    # Default cu128: matches the torch build proven in whisper-env on
+    # this machine (RTX 5070 Ti is Blackwell/sm_120 - older cu121
+    # wheels neither support the GPU nor Python 3.13).
     run([py, "-m", "pip", "install", "torch",
-         "--index-url", "https://download.pytorch.org/whl/cu121"])
+         "--index-url", torch_index])
     run([py, "-m", "pip", "install"] + TRAINER_PACKAGES)
 
 
 def phase_piper(root: Path) -> None:
     piper = root / "piper-sample-generator"
     if not piper.exists():
-        run(["git", "clone", PIPER_REPO, piper])
+        run(["git", "clone", "--branch", PIPER_REF, "--depth", "1",
+             PIPER_REPO, piper])
     else:
         log("piper-sample-generator exists, skipping clone")
     download(PIPER_CHECKPOINT, piper / "models" / "en_US-libritts_r-medium.pt")
@@ -204,7 +219,12 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=DEFAULT_ROOT,
                         help="workspace root (default: training/workspace)")
     parser.add_argument("--python", default=sys.executable,
-                        help="base python for the trainer venv")
+                        help="base python for the trainer venv. MUST be "
+                             "3.11: piper-phonemize (needed by the v2 "
+                             "sample generator) ships no newer wheels")
+    parser.add_argument("--torch-index",
+                        default="https://download.pytorch.org/whl/cu128",
+                        help="pytorch wheel index (CUDA build)")
     parser.add_argument("--yes", action="store_true",
                         help="confirm the 12-18 GB dataset download")
     parser.add_argument("--skip-datasets", action="store_true",
@@ -213,7 +233,7 @@ def main() -> int:
 
     root = args.root.resolve()
     log(f"workspace: {root}")
-    phase_venv(root, args.python)
+    phase_venv(root, args.python, args.torch_index)
     phase_piper(root)
     if args.skip_datasets:
         log("datasets skipped (--skip-datasets)")


### PR DESCRIPTION
## What

Owner directive: verify shipped outcomes with typical software tests instead of hand-testing, including whether the hardware actually switches - non-disruptively. Plus: pin a real 5-10 minute multi-speaker meeting as a standing test fixture.

**tests/test_live_validation.py** (WS_LIVE=1, opt-in, CI-inert - gated like WS_E2E):
- **Shared mic**: listener stream + dictation recorder on the same real mic concurrently; splice prefix lands ahead of real capture.
- **Consent store**: readable with real entries on this machine.
- **Wake pipeline**: synthesized "hey jarvis" (Windows SAPI, nothing audible) through the REAL model + REAL decision loop - exactly one wake, >1s ring prefix, negative control silent, silero VAD splits speech/silence.
- **Failover end to end**: dead probe -> loss declared -> spawn pinned to cpu+fallback -> REAL worker transcribes correctly on CPU; healthy probe sees the GPU.
- **Real meeting**: full production pipeline (GPU/align/diarize) on the pinned 5.9-min 4-speaker fixture vs its reference transcript.

**tests/fixtures/**: gitignored fixture home (public repo - private audio never committed) + README with provenance. **Evidence: 9/9 green on the dev machine, ~46s.**

Also: trainer-env execution fixes in setup_trainer.py (cu128 torch for Blackwell, piper v2.0.0 pin - v3 broke train.py's import contract, piper-phonemize-fix / webrtcvad-wheels for Windows wheels, py3.11 venv), checklist automated-evidence markers, testing.md live-suite row.

## Tests

System suite 438 passed, 11 skipped (live tests inert without WS_LIVE). Live: 9/9.