### PR TITLE
fix: wake listener unavailable - onnxruntime preload before windows_toasts

### DIFF
--- a/docs/owner-test-checklist.md
+++ b/docs/owner-test-checklist.md
@@ -84,6 +84,14 @@ Enable Settings > Meeting Auto-Record first (off by default).
 Enable Settings > Wake Word Listener (off by default; first enable
 downloads the openWakeWord models - watch the log).
 
+> Owner-reported failure 2026-07-05 ("nothing happens"): root-caused
+> to a DLL-load-order conflict (windows_toasts' WinRT bindings break
+> onnxruntime when loaded first) - the listener silently reported
+> itself unavailable with a misleading "not installed" message. Fixed
+> by an onnxruntime preload at app startup + an honest error split;
+> reproduced and verified by bisect. Retest after the next app start
+> picks up the fix.
+
 - [x] automated (LiveWakePipelineTests): synthesized "hey jarvis"
   through the real model + real decision loop fires EXACTLY one wake
   and hands a well-formed >1s ring-buffer prefix to the dictation

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -355,6 +355,25 @@ training job with menu status/ETA + completion toast.
   the first supervised training run wait for an explicit owner go -
   PROVISIONAL config values are validated by that first run.
 
+- **2026-07-05 (owner-reported listener failure, root-caused +
+  fixed)**: the owner enabled the wake listener and "nothing
+  happened". The app log showed the listener reporting "openwakeword
+  is not installed" - it IS installed; the real failure was
+  onnxruntime's pybind11 DLL init, which fails when windows_toasts'
+  WinRT bindings load first (bisected across the app's import set;
+  scipy/portaudio/pystray/PIL/keyboard/whisperx are all innocent).
+  Fix: onnxruntime preload at the top of __main__.py before any app
+  import, plus an honest error split in the listener
+  (ModuleNotFoundError = install hint; any other ImportError = real
+  traceback + "could not load" toast, regression-tested). Reproduced
+  and proven in-process: without preload the import fails after
+  windows_toasts; with it the model loads and predicts. Also: owner
+  gaming - the app was STOPPED to free VRAM (stronger than sleep;
+  one start.ps1 relaunch brings it back on the fixed code), and all
+  GPU/model use now ASKS FIRST until further notice. Trainer setup:
+  the 17.5 GB feature downloads completed; datasets 2.14.6 needed
+  pyarrow<17 (PyExtensionType removal); conversion resumed.
+
 - **2026-07-05 (owner directives: automate validation, real-meeting
   fixture, hardware freed)**: the owner asked that nothing require his
   hand-testing, that a real 5-10 minute multi-speaker meeting be

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -297,8 +297,18 @@ class LoadFailureMessageTests(unittest.TestCase):
 
     def test_missing_package_gets_the_install_hint(self):
         notify = self._run_with(
-            ModuleNotFoundError("No module named 'openwakeword'"))
+            ModuleNotFoundError("No module named 'openwakeword'",
+                                name="openwakeword"))
         self.assertIn("not installed", notify.call_args[0][1])
+
+    def test_missing_transitive_dep_reports_honestly(self):
+        # Review catch: a dependency missing INSIDE openwakeword must
+        # not claim openwakeword itself is absent.
+        notify = self._run_with(
+            ModuleNotFoundError("No module named 'tflite_runtime'",
+                                name="tflite_runtime"))
+        self.assertNotIn("not installed", notify.call_args[0][1])
+        self.assertIn("could not load", notify.call_args[0][1])
 
     def test_dll_init_failure_reports_the_load_failure_honestly(self):
         notify = self._run_with(ImportError(

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -6,6 +6,7 @@ live audio loop is exercised manually for the POC and gets harness
 coverage with the tier-2 splice.
 """
 
+import threading
 import time
 import types
 import unittest
@@ -16,6 +17,7 @@ try:
 except ImportError:  # dependency-light system python (CI)
     np = None
 
+from whisper_sync import listener as listener_mod
 from whisper_sync.listener import (
     WakeListener, strip_leading_phrase, RING_FRAMES,
     wake_model_paths, outro_model_paths, wake_strip_names,
@@ -275,6 +277,34 @@ class WakeActionSpliceTests(unittest.TestCase):
         self.listener._default_wake_action()
         self.app.dictation.begin_via_wake.assert_called_once_with(None)
         self.assertEqual(len(self.listener._ring), 0)
+
+
+class LoadFailureMessageTests(unittest.TestCase):
+    """Owner report 2026-07-05: a DLL-init ImportError (onnxruntime
+    loaded too late in the process) was reported as 'openwakeword is
+    not installed', pointing at the wrong fix. Only a genuinely
+    missing package gets the install hint."""
+
+    def setUp(self):
+        self.listener = WakeListener(_FakeApp())
+
+    def _run_with(self, exc):
+        with mock.patch.object(self.listener, "_load_model",
+                               side_effect=exc), \
+             mock.patch.object(listener_mod, "notify") as notify:
+            self.listener._run(threading.Event())
+        return notify
+
+    def test_missing_package_gets_the_install_hint(self):
+        notify = self._run_with(
+            ModuleNotFoundError("No module named 'openwakeword'"))
+        self.assertIn("not installed", notify.call_args[0][1])
+
+    def test_dll_init_failure_reports_the_load_failure_honestly(self):
+        notify = self._run_with(ImportError(
+            "DLL load failed while importing onnxruntime_pybind11_state"))
+        self.assertNotIn("not installed", notify.call_args[0][1])
+        self.assertIn("could not load", notify.call_args[0][1])
 
 
 class WakeSessionTests(unittest.TestCase):

--- a/tests/test_live_validation.py
+++ b/tests/test_live_validation.py
@@ -53,10 +53,11 @@ except ImportError:
     np = None
     _HAS_NUMPY = False
 
-# onnxruntime must initialize BEFORE scipy/torch/portaudio DLLs enter
-# the process: loaded later (as the wake tests would, mid-suite) its
-# pybind11 DLL init fails on Windows. Import here at collection time;
+# onnxruntime must initialize BEFORE windows_toasts' WinRT bindings
+# enter the process (bisected 2026-07-05): loaded later, its pybind11
+# DLL init fails on Windows. Import here at collection time;
 # openwakeword picks up the already-loaded module. Harmless if absent.
+# The app applies the same preload at the top of __main__.py.
 try:
     import onnxruntime
     _ORT_PRELOADED = bool(onnxruntime)

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -72,6 +72,8 @@ TRAINER_PACKAGES = [
     "acoustics==0.2.6",
     "pronouncing==0.2.0",
     "datasets==2.14.6",
+    # datasets 2.14 uses pa.PyExtensionType, removed in pyarrow 17
+    "pyarrow<17",
     "deep-phonemizer==0.0.19",
 ]
 

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -31,11 +31,14 @@ logging.getLogger("whisperx.diarize").setLevel(logging.WARNING)
 # (owner-reported 2026-07-05; bisected to windows_toasts specifically,
 # reproduced and fixed the same way in the live test suite). ~50ms and
 # a few MB when present; a harmless no-op when the package is absent.
+_ORT_PRELOAD_ERROR: Exception | None = None
 try:
     import onnxruntime as _ort_dll_preload
     del _ort_dll_preload
-except Exception:
-    pass
+except ModuleNotFoundError:
+    pass  # optional dependency; the listener reports its own absence
+except Exception as _exc:  # noqa: BLE001 - logged once the logger exists
+    _ORT_PRELOAD_ERROR = _exc
 
 from pathlib import Path
 
@@ -74,6 +77,14 @@ from .app_control import AppControl
 from .auto_sleep import AutoSleep, ClickRouter
 from .meeting_dialogs import MeetingDialogs
 from .dialog_dispatcher import DialogDispatcher
+
+if _ORT_PRELOAD_ERROR is not None:
+    # The preload exists to beat windows_toasts into the process; a
+    # failure here means the wake listener will be unavailable, and
+    # silence would hide the reason (review catch).
+    logger.warning("onnxruntime preload failed at startup: %r - the "
+                   "wake listener will be unavailable",
+                   _ORT_PRELOAD_ERROR)
 
 def _get_cpu_name() -> str:
     """Get CPU model name via PowerShell CIM on Windows, platform.processor() fallback."""

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -24,6 +24,19 @@ warnings.filterwarnings("ignore", message="std\\(\\): degrees of freedom is <= 0
 logging.getLogger("lightning.pytorch.utilities.migration.utils").setLevel(logging.ERROR)
 logging.getLogger("whisperx.vads.pyannote").setLevel(logging.WARNING)
 logging.getLogger("whisperx.diarize").setLevel(logging.WARNING)
+
+# onnxruntime (the wake listener's inference engine) must initialize
+# BEFORE windows_toasts: with the WinRT bindings loaded first, its
+# pybind11 DLL init fails and the listener reports itself unavailable
+# (owner-reported 2026-07-05; bisected to windows_toasts specifically,
+# reproduced and fixed the same way in the live test suite). ~50ms and
+# a few MB when present; a harmless no-op when the package is absent.
+try:
+    import onnxruntime as _ort_dll_preload
+    del _ort_dll_preload
+except Exception:
+    pass
+
 from pathlib import Path
 
 import keyboard

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -326,7 +326,12 @@ class WakeListener:
     def _run(self, stop_event: threading.Event) -> None:
         try:
             model = self._load_model()
-        except ImportError as exc:
+        except ModuleNotFoundError as exc:
+            # ONLY a genuinely missing package gets the install hint.
+            # A DLL-init ImportError (the 2026-07-05 owner report:
+            # onnxruntime loaded too late in the process) used to land
+            # here and lie about the cause; it now falls through to the
+            # generic branch with the real traceback.
             logger.warning(
                 f"Wake listener unavailable: openwakeword is not "
                 f"installed ({exc}) - pip install openwakeword in "

--- a/whisper_sync/listener.py
+++ b/whisper_sync/listener.py
@@ -327,17 +327,23 @@ class WakeListener:
         try:
             model = self._load_model()
         except ModuleNotFoundError as exc:
-            # ONLY a genuinely missing package gets the install hint.
-            # A DLL-init ImportError (the 2026-07-05 owner report:
-            # onnxruntime loaded too late in the process) used to land
-            # here and lie about the cause; it now falls through to the
-            # generic branch with the real traceback.
-            logger.warning(
-                f"Wake listener unavailable: openwakeword is not "
-                f"installed ({exc}) - pip install openwakeword in "
-                "whisper-env to enable it")
-            notify("Wake listener unavailable",
-                   "openwakeword is not installed; see the log.")
+            # ONLY a genuinely missing openwakeword gets the install
+            # hint. A DLL-init ImportError (the 2026-07-05 owner
+            # report) or a missing TRANSITIVE dependency (review
+            # catch: exc.name says which module is actually absent)
+            # gets the truthful failure instead.
+            if (exc.name or "").split(".")[0] == "openwakeword":
+                logger.warning(
+                    f"Wake listener unavailable: openwakeword is not "
+                    f"installed ({exc}) - pip install openwakeword in "
+                    "whisper-env to enable it")
+                notify("Wake listener unavailable",
+                       "openwakeword is not installed; see the log.")
+                return
+            logger.warning("Wake listener failed to load its model",
+                           exc_info=True)
+            notify("Wake listener failed",
+                   "Wake model could not load; see the log.")
             return
         except Exception:
             # Distinct from the missing dependency (review catch):


### PR DESCRIPTION
## The bug (owner-reported)

Enabling Settings > Wake Word Listener did nothing. The log claimed `openwakeword is not installed` - it is installed.

## Root cause (bisected)

`onnxruntime`'s pybind11 DLL init fails on Windows when `windows_toasts`' WinRT bindings load first. Bisected across the app's import set: windows_toasts REPRODUCES, scipy/portaudio/pystray/PIL/keyboard/whisperx are all innocent. The listener's lazy import always loses that race in the app process, and the error handling then mislabeled the DLL failure as a missing package.

## Fix

- **onnxruntime preload at the very top of `__main__.py`**, before any app import (notifications pulls windows_toasts). Proven in-process: without preload, import fails after windows_toasts; with it, the model loads and predicts.
- **Honest error split in the listener**: only `ModuleNotFoundError` gets the install hint; any other `ImportError` reports the real traceback + a "Wake model could not load" toast. Regression tests pin both messages.
- Riding along: trainer `datasets==2.14.6` needs `pyarrow<17` (`pa.PyExtensionType` removed), found during dataset conversion.

## Tests

Suite 440 passed, 11 skipped. CPU-only live classes (wake pipeline, consent store) 4/4. GPU live classes deliberately not run - the owner is gaming; GPU use asks first. Checklist and plan doc updated with the full finding.