### PR TITLE
feat: in-app phrase manager - typed phrase to active model, no CLI (step 5, PR C)

### DIFF
--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -41,7 +41,7 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   a second mic stream and the backup model (CPU or secondary GPU).
 - **Feature suggestions** - a dedicated hotkey records a voice note to
   the feature log and formats it via Claude CLI.
-- **Wake-word listener (POC)** - off by default (Settings > Wake Word
+- **Wake-word listener** - off by default (Settings > Wake Word
   Listener). An always-on, shared (never exclusive) mic stream feeds
   an openWakeWord model on the CPU; audio stays in RAM and nothing is
   written before a wake. Detection starts a normal disk-first
@@ -54,10 +54,16 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   second openWakeWord model; also stripped from the text tail) or
   after `wake_silence_stop_s` of silence (silero VAD; 0 disables) -
   the dictation hotkey still works at any time. Ships with the
-  pretrained "hey jarvis" phrase until custom phrases are trained
-  (training/README.md); trained phrases register in `wake_phrases`
-  and toggle via Settings > Wake Word Listener > Saved Phrases
-  (active checkmarks; multiple wake and outro phrases load at once). Pauses during whisper mode and while recording
+  pretrained "hey jarvis" phrase until custom phrases are trained:
+  Settings > Wake Word Listener > "Set New Wake Phrase..." / "Set New
+  Outro Phrase..." takes a TYPED phrase, trains it on the GPU in the
+  background (20-40 min; live status in the menu; refuses while the
+  app is busy or the model is deliberately asleep), and activates it
+  automatically on success. Trained phrases live in `wake_phrases`
+  and toggle via Saved Phrases (active checkmarks; multiple wake and
+  outro phrases load at once). Headless alternative:
+  training/README.md. One-time environment setup:
+  training/setup_trainer.py --yes (~20 GB). Pauses during whisper mode and while recording
   (except during its own wake dictations, which it watches for the
   stop signals). Needs `openwakeword` in the venv (in
   requirements.txt); without it the toggle simply reports unavailable.

--- a/docs/owner-test-checklist.md
+++ b/docs/owner-test-checklist.md
@@ -140,3 +140,15 @@ gaming).
   Word Listener > Saved Phrases - saying "hey hal" starts a
   dictation; "hey jarvis" no longer does (custom phrases replace the
   pretrained fallback while any is active).
+
+## 8. In-app phrase manager (step 5 PR C) - the no-CLI path
+
+- [ ] Settings > Wake Word Listener > "Set New Wake Phrase...", type
+  a phrase, Start Training - toast confirms, the menu shows a live
+  status line (stage + minutes), and after 20-40 min a "Phrase
+  ready" toast fires with the phrase ACTIVE in Saved Phrases.
+- [ ] Saying the new phrase starts a dictation without any manual
+  registry edit or listener toggle.
+- [ ] While a job is running, starting a second one refuses politely;
+  starting one while the model is asleep (gaming) refuses with a
+  clear message and touches nothing.

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -17,7 +17,7 @@
 | 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC MERGED (#187, pretrained phrase) |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | MERGED (#189, #190) |
 | 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | MERGED (#183, #184) |
-| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Owner decisions, fourth intake: the phrase manager | QUEUED |
+| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Owner decisions, fourth intake: the phrase manager | PR A #193 + PR B #194 MERGED; PR C (dialog + background job) IN REVIEW |
 | 6 | NPU/OpenVINO backup-transcriber backend (committed scope) | NPU section | QUEUED |
 | - | Installer refresh (screens generated from docs/features/) | BACKLOG.md | QUEUED |
 
@@ -419,3 +419,21 @@ training job with menu status/ETA + completion toast.
   entries are skipped, never crash. Remaining for step 5: PR C (Set
   Phrase dialog + background training job + tray status/ETA +
   registry auto-registration on training success).
+
+- **2026-07-05 (step 5 PR C)**: the full phrase manager per the
+  fourth intake - no more POC. whisper_sync/phrase_trainer.py owns
+  the typed-phrase dialog (dialog-dispatcher pattern, reuses the
+  meeting_dialogs styling helpers) and the background training job:
+  three trainer stages as subprocesses in a daemon thread with stage
+  + elapsed-minutes status in the tray menu, output to a per-phrase
+  training.log, and on success the .onnx copies to workspace/phrases,
+  auto-registers ACTIVE in wake_phrases, and the listener reloads.
+  Readiness gates: trainer env present, model not asleep (gaming
+  signal), app not busy, one job at a time - each refusal is a
+  truthful toast. Tray: "Wake Word Listener" (POC label dropped) with
+  Set New Wake Phrase... / Set New Outro Phrase..., active wake/outro
+  summary lines, Saved Phrases, and the live status line. Known
+  limitation recorded in the module docstring: a training subprocess
+  is not killed on app exit; the finished model is picked up by the
+  next run. The FIRST real training run still awaits the owner's GPU
+  go (he is gaming; all GPU use asks first).

--- a/tests/test_phrase_trainer.py
+++ b/tests/test_phrase_trainer.py
@@ -99,6 +99,13 @@ class ReadinessGateTests(_Harness):
         self.assertFalse(self.trainer.start("!!!", "wake"))
         self.assertIn("not usable", self.notify.call_args[0][0])
 
+    def test_refuses_an_unknown_role(self):
+        # Review catch: any other role would register an entry the
+        # listener never loads.
+        _provision(self.workspace)
+        self.assertFalse(self.trainer.start("hey hal", "command"))
+        self.assertIn("role", self.notify.call_args[0][1])
+
 
 class JobOutcomeTests(_Harness):
     def _fake_run(self, create_model=True):

--- a/tests/test_phrase_trainer.py
+++ b/tests/test_phrase_trainer.py
@@ -1,0 +1,187 @@
+"""Tests for whisper_sync.phrase_trainer - the step 5 PR C component.
+
+The trainer subprocesses are faked; these pin the orchestration: the
+readiness gates (workspace, sleeping, busy, already-running), the
+success path (registry auto-registration + listener reload + save),
+the failure path (honest status, registry untouched), and the status
+line. All CI-safe: no torch, no openwakeword, no Tk.
+"""
+
+import tempfile
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from whisper_sync import config
+from whisper_sync import phrase_trainer as trainer_mod
+from whisper_sync.config_store import ConfigStore
+from whisper_sync.phrase_trainer import PhraseTrainer
+from whisper_sync.state_manager import StateManager, SLEEP_STARTED
+
+
+class _FakeApp:
+    def __init__(self):
+        self.cfg = ConfigStore(config.load())
+        self.state = StateManager(None, {})
+        self.wake_listener = types.SimpleNamespace(
+            stop=mock.Mock(), start=mock.Mock())
+        self._dialog_dispatcher = mock.Mock()
+        self.refreshes = 0
+
+    def _refresh_menu(self):
+        self.refreshes += 1
+
+
+def _provision(workspace: Path):
+    """Create the marker file the readiness gate checks."""
+    py = workspace / "trainer-env" / "Scripts" / "python.exe"
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_bytes(b"")
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.workspace = Path(self._tmp.name)
+        self.app = _FakeApp()
+        self.trainer = PhraseTrainer(self.app, workspace=self.workspace)
+        patches = [
+            mock.patch.object(trainer_mod, "notify"),
+            mock.patch.object(trainer_mod.config, "save"),
+            mock.patch.object(trainer_mod, "app_busy", return_value=False),
+        ]
+        self.notify, self.save, self.busy = [p.start() for p in patches]
+        for p in patches:
+            self.addCleanup(p.stop)
+
+    def _join(self):
+        thread = self.trainer._thread
+        if thread is not None:
+            thread.join(timeout=10)
+
+
+class ReadinessGateTests(_Harness):
+    def test_refuses_without_the_trainer_environment(self):
+        self.assertFalse(self.trainer.start("hey hal", "wake"))
+        self.assertIn("not set up", self.notify.call_args[0][1])
+
+    def test_refuses_while_the_model_sleeps(self):
+        _provision(self.workspace)
+        self.app.state.emit(SLEEP_STARTED, sleeping=True)
+        self.assertFalse(self.trainer.start("hey hal", "wake"))
+        self.assertIn("asleep", self.notify.call_args[0][1])
+
+    def test_refuses_while_the_app_is_busy(self):
+        _provision(self.workspace)
+        self.busy.return_value = True
+        self.assertFalse(self.trainer.start("hey hal", "wake"))
+        self.assertIn("busy", self.notify.call_args[0][1])
+
+    def test_refuses_a_second_concurrent_job(self):
+        _provision(self.workspace)
+        release = threading.Event()
+        self.trainer._phrase = "first"
+        self.trainer._thread = threading.Thread(target=release.wait,
+                                                daemon=True)
+        self.trainer._thread.start()
+        try:
+            self.assertFalse(self.trainer.start("hey hal", "wake"))
+            self.assertIn("already running", self.notify.call_args[0][0])
+        finally:
+            release.set()
+
+    def test_refuses_an_unusable_phrase(self):
+        _provision(self.workspace)
+        self.assertFalse(self.trainer.start("!!!", "wake"))
+        self.assertIn("not usable", self.notify.call_args[0][0])
+
+
+class JobOutcomeTests(_Harness):
+    def _fake_run(self, create_model=True):
+        workspace = self.workspace
+
+        def _run(cmd, **kw):
+            if create_model and cmd[-1] == "--train_model":
+                onnx = workspace / "output" / "hey_hal" / "hey_hal.onnx"
+                onnx.parent.mkdir(parents=True, exist_ok=True)
+                onnx.write_bytes(b"model")
+            return types.SimpleNamespace(returncode=0)
+        return _run
+
+    def test_success_registers_active_phrase_and_reloads_listener(self):
+        _provision(self.workspace)
+        with mock.patch.object(trainer_mod.subprocess, "run",
+                               side_effect=self._fake_run()):
+            self.assertTrue(self.trainer.start("hey hal", "wake"))
+            self._join()
+        entry = self.app.cfg["wake_phrases"]["hey_hal"]
+        self.assertTrue(entry["active"])
+        self.assertEqual(entry["role"], "wake")
+        self.assertTrue(entry["path"].endswith("hey_hal.onnx"))
+        self.assertIn("phrases", entry["path"],
+                      "model must be copied to the phrases dir")
+        self.app.wake_listener.stop.assert_called_once()
+        self.app.wake_listener.start.assert_called_once()
+        self.save.assert_called()
+        self.assertIn("Phrase ready", self.notify.call_args[0][0])
+        self.assertIsNone(self.trainer.status_line())
+
+    def test_stage_failure_reports_and_leaves_registry_untouched(self):
+        _provision(self.workspace)
+
+        def _fail(cmd, **kw):
+            return types.SimpleNamespace(returncode=3)
+        with mock.patch.object(trainer_mod.subprocess, "run",
+                               side_effect=_fail):
+            self.assertTrue(self.trainer.start("hey hal", "wake"))
+            self._join()
+        self.assertNotIn("hey_hal",
+                         self.app.cfg.get("wake_phrases", {}) or {})
+        self.assertIn("Training failed", self.notify.call_args[0][0])
+        self.assertIn("failed", self.trainer.status_line())
+
+    def test_missing_output_model_is_a_failure(self):
+        _provision(self.workspace)
+        with mock.patch.object(trainer_mod.subprocess, "run",
+                               side_effect=self._fake_run(
+                                   create_model=False)):
+            self.trainer.start("hey hal", "wake")
+            self._join()
+        self.assertIn("missing", self.trainer.status_line())
+
+
+class StatusAndRegistryTests(_Harness):
+    def test_status_line_while_running(self):
+        self.trainer._phrase = "hey hal"
+        self.trainer._stage = "training"
+        self.trainer._started = time.monotonic() - 300
+        with mock.patch.object(PhraseTrainer, "running",
+                               new_callable=mock.PropertyMock,
+                               return_value=True):
+            line = self.trainer.status_line()
+        self.assertIn("hey hal", line)
+        self.assertIn("training", line)
+        self.assertIn("5 min", line)
+
+    def test_register_repairs_a_malformed_registry(self):
+        self.app.cfg["wake_phrases"] = ["not", "a", "dict"]
+        self.trainer._register("hey_hal", Path("C:/p/hey_hal.onnx"),
+                               "outro")
+        entry = self.app.cfg["wake_phrases"]["hey_hal"]
+        self.assertEqual(entry["role"], "outro")
+        self.assertTrue(entry["active"])
+
+    def test_ask_new_phrase_routes_to_the_dialog_dispatcher(self):
+        self.trainer.ask_new_phrase("wake")
+        self.app._dialog_dispatcher.run.assert_called_once()
+        self.assertEqual(
+            self.app._dialog_dispatcher.run.call_args.kwargs["label"],
+            "set_phrase")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -114,6 +114,9 @@ class _FakeApp:
             recover_meeting_speakers=lambda d: None)
         self.github = _FakeGitHub()
         self.auto_sleep = types.SimpleNamespace(toggle=lambda: None)
+        self.phrase_trainer = types.SimpleNamespace(
+            status_line=lambda: None,
+            ask_new_phrase=lambda role: None)
         self._cpu_name = "FakeCPU"
         self._dialog_dispatcher = None
         self.saved = 0
@@ -191,6 +194,28 @@ class MenuBuildTests(unittest.TestCase):
         self.assertTrue(self.app.cfg["wake_listener"])
         self.app.wake_listener.restart_if_toggled.assert_called_once()
         save.assert_called_once()
+
+    def test_wake_listener_menu_has_the_full_phrase_manager(self):
+        # Fourth intake: not a POC - set new wake/outro phrase, saved
+        # phrases, active summary. Status line appears while training.
+        items = self.menu._build_wake_listener_items()
+        texts = " | ".join(_iter_texts(_Menu(*items)))
+        self.assertIn("Set New Wake Phrase...", texts)
+        self.assertIn("Set New Outro Phrase...", texts)
+        self.assertIn("Saved Phrases", texts)
+        self.assertIn("Wake: hey_jarvis", texts)
+        self.assertNotIn("POC", texts)
+
+        self.app.phrase_trainer.status_line = (
+            lambda: "Training 'hey hal': training, 5 min")
+        items = self.menu._build_wake_listener_items()
+        texts = " | ".join(_iter_texts(_Menu(*items)))
+        self.assertIn("Training 'hey hal'", texts)
+
+    def test_full_menu_has_no_poc_label(self):
+        texts = " | ".join(_iter_texts(self.menu.build()))
+        self.assertIn("Wake Word Listener", texts)
+        self.assertNotIn("(POC)", texts)
 
     def test_saved_phrases_empty_registry_shows_info_line(self):
         items = self.menu._build_saved_phrase_items()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -175,10 +175,14 @@ class WhisperSync:
         # store polling; auto-starts/stops recordings for watched apps.
         from .meeting_watch import MeetingWatch
         self.meeting_watch = MeetingWatch(self)
-        # Always-on wake-word listener POC (listener.py): inert unless
+        # Always-on wake-word listener (listener.py): inert unless
         # wake_listener is on AND openwakeword is installed in the venv.
         from .listener import WakeListener
         self.wake_listener = WakeListener(self)
+        # Self-serve phrase training (phrase_trainer.py): typed-phrase
+        # dialog + background dGPU job + auto-registration.
+        from .phrase_trainer import PhraseTrainer
+        self.phrase_trainer = PhraseTrainer(self)
 
     @staticmethod
     def _migrate_data():

--- a/whisper_sync/phrase_trainer.py
+++ b/whisper_sync/phrase_trainer.py
@@ -1,0 +1,239 @@
+"""Self-serve phrase training - step 5, PR C (fourth intake).
+
+The owner types a phrase into a dialog; a background job trains a
+custom openWakeWord model on the dGPU (tens of minutes), the tray
+shows status while it runs, and on success the phrase auto-registers
+in ``wake_phrases`` (active, correct role) and the listener reloads -
+no CLI, no speaking, no manual registry edit.
+
+Composition follows the meeting_job/gpu_guard pattern: this component
+owns the behavior, the app is the wiring surface. The heavyweight
+pipeline itself is the PR A machinery (whisper_sync.phrase_training
+for config/commands, training/setup_trainer.py for the one-time
+environment); this module only orchestrates subprocesses in a daemon
+thread and never imports torch or openwakeword.
+
+GPU posture: starting a job is an explicit owner action (they typed
+the phrase and clicked Start), but the job still refuses while the
+app is busy (recording/transcribing) or the model is deliberately
+asleep (the gaming signal) - training must never grab the GPU out
+from under either. Known limitation, recorded here on purpose: the
+training subprocess is not killed if the app exits mid-run; the
+finished .onnx lands in the workspace and the NEXT successful in-app
+run (or a manual registry entry) picks it up.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+from . import config
+from .auto_sleep import app_busy
+from .logger import logger
+from .notifications import notify
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORKSPACE = REPO_ROOT / "training" / "workspace"
+TYPICAL_MINUTES = "20-40"
+
+# Stage labels for the three official trainer invocations, in order.
+STAGES = ("generating samples", "augmenting", "training")
+
+
+class PhraseTrainer:
+    """Owns the typed-phrase dialog and the background training job."""
+
+    def __init__(self, app, workspace: Path | None = None):
+        self.app = app
+        self.workspace = Path(workspace or DEFAULT_WORKSPACE)
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._phrase = ""
+        self._stage = ""
+        self._started = 0.0
+        self._last_error: str | None = None
+
+    # -- Status (menu surface) ------------------------------------------------
+
+    @property
+    def running(self) -> bool:
+        thread = self._thread
+        return thread is not None and thread.is_alive()
+
+    def status_line(self) -> str | None:
+        """One line for the tray menu; None when idle and clean."""
+        if self.running:
+            minutes = int((time.monotonic() - self._started) / 60)
+            return (f"Training '{self._phrase}': {self._stage}, "
+                    f"{minutes} min (typically {TYPICAL_MINUTES})")
+        if self._last_error:
+            return f"Last training failed: {self._last_error}"
+        return None
+
+    # -- Entry points ----------------------------------------------------------
+
+    def ask_new_phrase(self, role: str) -> None:
+        """Open the typed-phrase dialog on the dialog dispatcher."""
+        from .meeting_dialogs import (center_window, flat_button,
+                                      run_modal, style_window)
+
+        kind = "wake" if role == "wake" else "outro"
+
+        def _show(_proot):
+            import tkinter as tk
+
+            dlg = tk.Toplevel(_proot)
+            style_window(dlg)
+            dlg.title(f"New {kind} phrase")
+            tk.Label(dlg, text=f"Type the new {kind} phrase exactly as "
+                               "you would say it:",
+                     bg="#1e1e2e", fg="#cdd6f4").pack(padx=16, pady=(14, 4))
+            entry = tk.Entry(dlg, width=32, bg="#313244", fg="#cdd6f4",
+                             insertbackground="#cdd6f4", relief="flat")
+            entry.pack(padx=16, pady=4)
+            entry.focus_set()
+            tk.Label(dlg, text="Training runs on the GPU for "
+                               f"{TYPICAL_MINUTES} minutes in the "
+                               "background; the phrase activates "
+                               "automatically when it finishes.",
+                     bg="#1e1e2e", fg="#a6adc8",
+                     wraplength=300, justify="left").pack(padx=16, pady=4)
+
+            def _start(_ev=None):
+                phrase = entry.get().strip()
+                if not phrase:
+                    return
+                dlg.destroy()
+                self.start(phrase, role)
+
+            row = tk.Frame(dlg, bg="#1e1e2e")
+            row.pack(pady=(6, 14))
+            flat_button(row, "Start Training", _start).pack(
+                side="left", padx=6)
+            flat_button(row, "Cancel", dlg.destroy).pack(
+                side="left", padx=6)
+            entry.bind("<Return>", _start)
+            center_window(dlg)
+            run_modal(_proot, dlg)
+
+        self.app._dialog_dispatcher.run(_show, label="set_phrase",
+                                        wants_root=True)
+
+    def start(self, phrase: str, role: str) -> bool:
+        """Validate and launch the background job. Returns True when
+        the job actually started."""
+        from .phrase_training import sanitize_model_name
+
+        try:
+            name = sanitize_model_name(phrase)
+        except ValueError:
+            notify("Phrase not usable",
+                   "The phrase needs letters or digits.")
+            return False
+        with self._lock:
+            if self.running:
+                notify("Training already running",
+                       f"'{self._phrase}' is still training; one job "
+                       "at a time.")
+                return False
+            problem = self._not_ready_reason()
+            if problem:
+                notify("Training not started", problem)
+                logger.info(f"Phrase training refused: {problem}")
+                return False
+            self._phrase = phrase
+            self._stage = "starting"
+            self._started = time.monotonic()
+            self._last_error = None
+            self._thread = threading.Thread(
+                target=self._run, args=(phrase, name, role),
+                daemon=True, name="phrase-trainer")
+            self._thread.start()
+        logger.info(f"Phrase training started: '{phrase}' ({role})")
+        notify("Training started",
+               f"'{phrase}' is training in the background "
+               f"(typically {TYPICAL_MINUTES} min).")
+        self.app._refresh_menu()
+        return True
+
+    def _not_ready_reason(self) -> str | None:
+        """Why a job cannot start right now (None = good to go)."""
+        trainer_python = (self.workspace / "trainer-env" / "Scripts"
+                          / "python.exe")
+        if not trainer_python.exists():
+            return ("The training environment is not set up - run "
+                    "training/setup_trainer.py --yes once (~20 GB).")
+        current = self.app.state.current if self.app.state else None
+        if current is not None and current.sleeping:
+            return ("The model is asleep (gaming?). Wake the app "
+                    "before training - it needs the GPU.")
+        if app_busy(self.app):
+            return "The app is busy recording or transcribing."
+        return None
+
+    # -- The job ---------------------------------------------------------------
+
+    def _run(self, phrase: str, name: str, role: str) -> None:
+        from .phrase_training import (build_training_config,
+                                      trained_model_path,
+                                      training_commands,
+                                      write_training_config)
+
+        trainer_python = (self.workspace / "trainer-env" / "Scripts"
+                          / "python.exe")
+        try:
+            cfg = build_training_config(phrase, self.workspace)
+            config_path = write_training_config(
+                cfg, self.workspace / "output" / name / f"{name}.yml")
+            log_path = config_path.with_name("training.log")
+            with open(log_path, "a", encoding="utf-8") as log_file:
+                for stage, cmd in zip(STAGES,
+                                      training_commands(config_path,
+                                                        trainer_python)):
+                    self._stage = stage
+                    self.app._refresh_menu()
+                    result = subprocess.run(cmd, cwd=self.workspace,
+                                            stdout=log_file,
+                                            stderr=subprocess.STDOUT)
+                    if result.returncode != 0:
+                        raise RuntimeError(
+                            f"{stage} failed (exit {result.returncode}); "
+                            f"log: {log_path}")
+            produced = trained_model_path(cfg)
+            if not produced.exists():
+                raise RuntimeError(
+                    f"trainer finished but {produced.name} is missing; "
+                    f"log: {log_path}")
+            phrases_dir = self.workspace / "phrases"
+            phrases_dir.mkdir(parents=True, exist_ok=True)
+            final = phrases_dir / produced.name
+            shutil.copy2(produced, final)
+            self._register(name, final, role)
+            logger.info(f"Phrase '{phrase}' trained and activated: {final}")
+            notify("Phrase ready",
+                   f"'{phrase}' is trained and ACTIVE as a {role} "
+                   "phrase.")
+        except Exception as exc:
+            self._last_error = str(exc)
+            logger.warning(f"Phrase training failed: {exc}", exc_info=True)
+            notify("Training failed", f"'{phrase}': {exc}")
+        finally:
+            self.app._refresh_menu()
+
+    def _register(self, name: str, path: Path, role: str) -> None:
+        """Add the trained phrase to wake_phrases, active, and reload
+        the listener (same malformed-registry tolerance as the tray)."""
+        cfg = self.app.cfg
+        raw = cfg.get("wake_phrases", {})
+        phrases = dict(raw) if isinstance(raw, dict) else {}
+        phrases[name] = {"path": str(path), "role": role, "active": True}
+        cfg["wake_phrases"] = phrases
+        config.save(cfg.snapshot())
+        listener = getattr(self.app, "wake_listener", None)
+        if listener is not None:
+            listener.stop()
+            listener.start()

--- a/whisper_sync/phrase_trainer.py
+++ b/whisper_sync/phrase_trainer.py
@@ -128,6 +128,11 @@ class PhraseTrainer:
         the job actually started."""
         from .phrase_training import sanitize_model_name
 
+        if role not in ("wake", "outro"):
+            # Anything else would register an entry the listener never
+            # loads (review catch) - refuse loudly instead.
+            notify("Phrase not started", f"Unknown phrase role {role!r}.")
+            return False
         try:
             name = sanitize_model_name(phrase)
         except ValueError:
@@ -196,9 +201,13 @@ class PhraseTrainer:
                                                         trainer_python)):
                     self._stage = stage
                     self.app._refresh_menu()
-                    result = subprocess.run(cmd, cwd=self.workspace,
-                                            stdout=log_file,
-                                            stderr=subprocess.STDOUT)
+                    result = subprocess.run(
+                        cmd, cwd=self.workspace, stdout=log_file,
+                        stderr=subprocess.STDOUT,
+                        # Tray context: trainer pythons must not pop
+                        # console windows (vram_probe precedent).
+                        creationflags=getattr(subprocess,
+                                              "CREATE_NO_WINDOW", 0))
                     if result.returncode != 0:
                         raise RuntimeError(
                             f"{stage} failed (exit {result.returncode}); "
@@ -228,10 +237,16 @@ class PhraseTrainer:
         """Add the trained phrase to wake_phrases, active, and reload
         the listener (same malformed-registry tolerance as the tray)."""
         cfg = self.app.cfg
-        raw = cfg.get("wake_phrases", {})
-        phrases = dict(raw) if isinstance(raw, dict) else {}
-        phrases[name] = {"path": str(path), "role": role, "active": True}
-        cfg["wake_phrases"] = phrases
+        # transaction(): the tray's Saved Phrases toggle does the same
+        # read-modify-write; without the lock held across it, whichever
+        # writer finished last would silently drop the other's change
+        # (review catch).
+        with cfg.transaction():
+            raw = cfg.get("wake_phrases", {})
+            phrases = dict(raw) if isinstance(raw, dict) else {}
+            phrases[name] = {"path": str(path), "role": role,
+                             "active": True}
+            cfg["wake_phrases"] = phrases
         config.save(cfg.snapshot())
         listener = getattr(self.app, "wake_listener", None)
         if listener is not None:

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -509,20 +509,8 @@ class TrayMenu:
                                 "meeting_watch_toast_optout", True)),
                     )),
                 )),
-                pystray.MenuItem("Wake Word Listener (POC)", pystray.Menu(
-                    pystray.MenuItem(
-                        "Enabled",
-                        lambda: self._toggle_wake_listener(),
-                        checked=lambda item: self.app.cfg.get(
-                            "wake_listener", False),
-                    ),
-                    pystray.MenuItem(
-                        f"  Phrase: "
-                        f"{self.app.cfg.get('wake_phrase_model', 'hey_jarvis')}",
-                        None, enabled=False),
-                    pystray.MenuItem("Saved Phrases", pystray.Menu(
-                        *self._build_saved_phrase_items())),
-                )),
+                pystray.MenuItem("Wake Word Listener", pystray.Menu(
+                    *self._build_wake_listener_items())),
                 pystray.MenuItem(f"Diarization (Speaker Detection)\t{primary_label}",
                                  pystray.Menu(*diarize_sub_items)),
                 pystray.Menu.SEPARATOR,
@@ -965,6 +953,48 @@ class TrayMenu:
             f"Wake listener: {'on' if cfg['wake_listener'] else 'off'}")
         self.app.wake_listener.restart_if_toggled()
         self._save_and_refresh()
+
+    def _build_wake_listener_items(self):
+        """The full wake-listener settings surface (fourth intake):
+        enable, set new wake/outro phrase (typed -> background
+        training), saved phrases with active checkmarks, live
+        training status."""
+        import pystray  # lazy: not installed on the CI system python
+        from .listener import wake_model_paths, outro_model_paths, _model_stem
+
+        cfg = self.app.cfg
+        wake_stems = ", ".join(_model_stem(p) for p in wake_model_paths(cfg))
+        outro_paths = outro_model_paths(cfg)
+        items = [
+            pystray.MenuItem(
+                "Enabled",
+                lambda: self._toggle_wake_listener(),
+                checked=lambda item: self.app.cfg.get(
+                    "wake_listener", False),
+            ),
+            pystray.MenuItem(f"  Wake: {wake_stems}", None, enabled=False),
+        ]
+        if outro_paths:
+            outro_stems = ", ".join(_model_stem(p) for p in outro_paths)
+            items.append(pystray.MenuItem(f"  Outro: {outro_stems}",
+                                          None, enabled=False))
+        items.extend([
+            pystray.MenuItem(
+                "Set New Wake Phrase...",
+                menu_callback(self.app.phrase_trainer.ask_new_phrase,
+                              "wake")),
+            pystray.MenuItem(
+                "Set New Outro Phrase...",
+                menu_callback(self.app.phrase_trainer.ask_new_phrase,
+                              "outro")),
+            pystray.MenuItem("Saved Phrases", pystray.Menu(
+                *self._build_saved_phrase_items())),
+        ])
+        status = self.app.phrase_trainer.status_line()
+        if status:
+            items.append(pystray.MenuItem(f"  {status}", None,
+                                          enabled=False))
+        return items
 
     def _build_saved_phrase_items(self):
         """Saved-phrase entries (wake_phrases registry) with active

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -1004,7 +1004,7 @@ class TrayMenu:
         phrases = self.app.cfg.get("wake_phrases", {}) or {}
         if not isinstance(phrases, dict) or not phrases:
             return [pystray.MenuItem(
-                "No saved phrases (train via training/train_phrase.py)",
+                'No saved phrases yet - use "Set New Wake Phrase..."',
                 None, enabled=False)]
         items = []
         for name in sorted(phrases):
@@ -1022,16 +1022,20 @@ class TrayMenu:
         """Flip a saved phrase's active flag and reload the listener
         (the model list is bound at thread start)."""
         cfg = self.app.cfg
-        raw = cfg.get("wake_phrases", {})
-        # Same malformed-config tolerance as listener.py: a corrupted
-        # registry (non-dict, string entries) must never take down the
-        # tray menu.
-        phrases = dict(raw) if isinstance(raw, dict) else {}
-        raw_entry = phrases.get(name)
-        entry = dict(raw_entry) if isinstance(raw_entry, dict) else {}
-        entry["active"] = not entry.get("active")
-        phrases[name] = entry
-        cfg["wake_phrases"] = phrases
+        # transaction(): the phrase trainer's auto-registration does
+        # the same read-modify-write from its worker thread; the lock
+        # keeps the two writers from dropping each other's changes.
+        with cfg.transaction():
+            raw = cfg.get("wake_phrases", {})
+            # Same malformed-config tolerance as listener.py: a
+            # corrupted registry (non-dict, string entries) must never
+            # take down the tray menu.
+            phrases = dict(raw) if isinstance(raw, dict) else {}
+            raw_entry = phrases.get(name)
+            entry = dict(raw_entry) if isinstance(raw_entry, dict) else {}
+            entry["active"] = not entry.get("active")
+            phrases[name] = entry
+            cfg["wake_phrases"] = phrases
         logger.info(f"Saved phrase '{name}': "
                     f"{'active' if entry['active'] else 'inactive'}")
         self.app.wake_listener.stop()


### PR DESCRIPTION
## What

Completes step 5: the owner's fourth-intake design, fully implemented. The POC label is gone.

- **`phrase_trainer.py`** (new component): "Set New Wake Phrase..." / "Set New Outro Phrase..." open a typed-phrase dialog; Start Training runs the three official trainer stages as background subprocesses with **stage + elapsed-minutes status live in the tray menu** and a per-phrase training.log. On success the .onnx copies to `workspace/phrases`, **auto-registers ACTIVE in `wake_phrases`**, and the listener reloads - the phrase works immediately, no CLI, no manual registry edit.
- **Readiness gates** (each a truthful toast): trainer environment present, model not deliberately asleep (gaming signal), app not recording/transcribing, one job at a time.
- **Tray**: Settings > Wake Word Listener rebuilt - Enabled, active wake/outro summary, both Set New Phrase entries, Saved Phrases, live status line.
- Known limitation documented: a training subprocess is not killed on app exit; the finished model is picked up later.

## Tests

Suite 462 passed (test_phrase_trainer: readiness gates, success path incl. registration + listener reload + save, stage/missing-model failures, status line, malformed-registry repair, dialog routing; tray: full menu without POC, both entries, status line rendering). The first REAL training run awaits the owner's GPU go - he is gaming and GPU use asks first (checklist section 8 holds the validation steps).