### PR TITLE
docs: build-order table - step 5 phrase manager MERGED (#193, #194, #197)

### DIFF
--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -17,7 +17,7 @@
 | 2 | Tier 0+1 always-on listener (VAD + openWakeWord, off by default) | Staged architecture, step 2 | POC MERGED (#187, pretrained phrase) |
 | 3 | Tier 2 splice: wake -> ring-buffer-prefixed dictation + outro | Staged architecture, step 2 | MERGED (#189, #190) |
 | 4 | Per-app meeting auto-record (mic consent-store watch + app list) | Staged architecture, step 3 | MERGED (#183, #184) |
-| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Owner decisions, fourth intake: the phrase manager | PR A #193 + PR B #194 MERGED; PR C (dialog + background job) IN REVIEW |
+| 5 | Self-serve phrase manager (typed phrases, background training, active checkmarks) | Owner decisions, fourth intake: the phrase manager | MERGED (#193, #194, #197) |
 | 6 | NPU/OpenVINO backup-transcriber backend (committed scope) | NPU section | QUEUED |
 | - | Installer refresh (screens generated from docs/features/) | BACKLOG.md | QUEUED |
 


### PR DESCRIPTION
One-line status refresh: step 5 shipped across #193 (trainer environment + headless CLI), #194 (registry + Saved Phrases), #197 (in-app dialog + background job). Remaining in the round: step 6 NPU backend, installer refresh, and the first supervised training run (awaiting the owner's GPU go).