### PR TITLE
feat: settings IA - formal names, H1 listening toggle, honest device picker

### DIFF
--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -37,12 +37,15 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
 - **Per-channel stereo diarization** - 3-tier cascade
   (balanced mix, per channel, raw audio) selectable per meeting from
   the save dialog.
-- **Always-available dictation** - dictate during an active meeting via
+- **Always-On Dictation** - dictate during an active meeting via
   a second mic stream and the backup model (CPU or secondary GPU).
+  Settings > Always-On Dictation groups the toggle with its backup
+  device/model.
 - **Feature suggestions** - a dedicated hotkey records a voice note to
   the feature log and formats it via Claude CLI.
-- **Wake-word listener** - off by default (Settings > Wake Word
-  Listener). An always-on, shared (never exclusive) mic stream feeds
+- **Always-On Listening** (wake-word listener) - off by default;
+  quick toggle at the MAIN tray menu, detailed settings under
+  Settings > Always-On Listening. An always-on, shared (never exclusive) mic stream feeds
   an openWakeWord model on the CPU; audio stays in RAM and nothing is
   written before a wake. Detection starts a normal disk-first
   dictation, prefixed with the listener's rolling ~2.5s ring buffer so
@@ -55,7 +58,7 @@ Companion files: [shortcuts.md](shortcuts.md) (how to interact),
   after `wake_silence_stop_s` of silence (silero VAD; 0 disables) -
   the dictation hotkey still works at any time. Ships with the
   pretrained "hey jarvis" phrase until custom phrases are trained:
-  Settings > Wake Word Listener > "Set New Wake Phrase..." / "Set New
+  Settings > Always-On Listening > "Set New Wake Phrase..." / "Set New
   Outro Phrase..." takes a TYPED phrase, trains it on the GPU in the
   background (20-40 min; live status in the menu; refuses while the
   app is busy or the model is deliberately asleep), and activates it

--- a/docs/owner-test-checklist.md
+++ b/docs/owner-test-checklist.md
@@ -81,7 +81,8 @@ Enable Settings > Meeting Auto-Record first (off by default).
 
 ## 5. Wake listener + tier-2 splice (#187, #189, #190)
 
-Enable Settings > Wake Word Listener (off by default; first enable
+Enable Always-On Listening (quick toggle at the MAIN tray menu, or
+Settings > Always-On Listening; off by default; first enable
 downloads the openWakeWord models - watch the log).
 
 > Owner-reported failure 2026-07-05 ("nothing happens"): root-caused
@@ -143,7 +144,7 @@ gaming).
 
 ## 8. In-app phrase manager (step 5 PR C) - the no-CLI path
 
-- [ ] Settings > Wake Word Listener > "Set New Wake Phrase...", type
+- [ ] Settings > Always-On Listening > "Set New Wake Phrase...", type
   a phrase, Start Training - toast confirms, the menu shows a live
   status line (stage + minutes), and after 20-40 min a "Phrase
   ready" toast fires with the phrase ACTIVE in Saved Phrases.
@@ -152,3 +153,13 @@ gaming).
 - [ ] While a job is running, starting a second one refuses politely;
   starting one while the model is asleep (gaming) refuses with a
   clear message and touches nothing.
+
+## 9. Settings IA + device picker (owner review 2026-07-05)
+
+- [ ] Main tray menu shows "Always-On Listening" with a checkmark;
+  toggling it there works without opening Settings.
+- [ ] Settings shows "Always-On Dictation" and "Always-On Listening"
+  (no "Always Available Dictation", no "Wake Word Listener").
+- [ ] Settings > Device: the CPU row names your CPU, and the
+  Auto/GPU rows name the RTX 5070 Ti even while the model is asleep
+  or the worker is on CPU (no more "no GPU detected" lie).

--- a/docs/plans/2026-07-04-assistant-build-round.md
+++ b/docs/plans/2026-07-04-assistant-build-round.md
@@ -437,3 +437,20 @@ training job with menu status/ETA + completion toast.
   is not killed on app exit; the finished model is picked up by the
   next run. The FIRST real training run still awaits the owner's GPU
   go (he is gaming; all GPU use asks first).
+
+- **2026-07-05 (settings IA + device picker, owner review)**: formal
+  feature names shipped - "Always-On Dictation" (was Always Available
+  Dictation) and "Always-On Listening" (was Wake Word Listener), with
+  an H1 QUICK TOGGLE for Always-On Listening at the main tray menu
+  (owner: it must be switchable without opening Settings; the
+  detailed surface stays at H2). Device picker bugs from the owner's
+  review, both confirmed real: (1) the CPU row never named the CPU -
+  it now shows _cpu_name like the GPU rows; (2) worker.gpu_name only
+  exists after a CUDA worker loads, so with the model asleep or on
+  cpu the menu claimed "no GPU detected" next to an installed RTX
+  5070 Ti - a startup nvidia-smi hardware probe (_gpu_hw_name) now
+  backs the display, and the honest "no GPU detected" only shows
+  when the hardware probe also finds nothing. The owner's suspicion
+  of GPU-defaulting-to-CPU was checked against the logs: the app
+  loaded [cuda] large-v3 on its last run; the defaulting was a
+  DISPLAY lie, not a routing bug.

--- a/tests/test_tray_menu.py
+++ b/tests/test_tray_menu.py
@@ -214,8 +214,38 @@ class MenuBuildTests(unittest.TestCase):
 
     def test_full_menu_has_no_poc_label(self):
         texts = " | ".join(_iter_texts(self.menu.build()))
-        self.assertIn("Wake Word Listener", texts)
+        self.assertIn("Always-On Listening", texts)
         self.assertNotIn("(POC)", texts)
+
+    def test_formal_feature_names_and_h1_quick_toggle(self):
+        # Owner IA request 2026-07-05: formal names, and the listening
+        # toggle reachable at the top level, not only under Settings.
+        menu = self.menu.build()
+        texts = " | ".join(_iter_texts(menu))
+        self.assertIn("Always-On Dictation", texts)
+        self.assertNotIn("Always Available Dictation", texts)
+        self.assertNotIn("Wake Word Listener", texts)
+        top_level = [i.text for i in menu.items
+                     if isinstance(i, _MenuItem)]
+        self.assertIn("Always-On Listening", top_level,
+                      "quick toggle must live at the main menu level")
+
+    def test_device_picker_names_the_cpu_and_falls_back_for_gpu(self):
+        # Owner report 2026-07-05: the CPU entry never named the CPU,
+        # and with no CUDA worker loaded the menu claimed "no GPU
+        # detected" on a machine with a GPU installed.
+        self.app.worker.gpu_name = None
+        self.app._gpu_hw_name = "FakeGPU-HW"
+        texts = " | ".join(_iter_texts(self.menu.build()))
+        self.assertIn("CPU	FakeCPU", texts)
+        self.assertIn("FakeGPU-HW", texts)
+        self.assertNotIn("no GPU detected", texts)
+
+    def test_device_picker_honest_when_no_gpu_exists(self):
+        self.app.worker.gpu_name = None
+        self.app._gpu_hw_name = None
+        texts = " | ".join(_iter_texts(self.menu.build()))
+        self.assertIn("no GPU detected", texts)
 
     def test_saved_phrases_empty_registry_shows_info_line(self):
         items = self.menu._build_saved_phrase_items()

--- a/whisper_sync/__main__.py
+++ b/whisper_sync/__main__.py
@@ -109,6 +109,29 @@ def _get_cpu_name() -> str:
     return name if name else "Unknown CPU"
 
 
+def _get_gpu_hw_name() -> str | None:
+    """The installed NVIDIA GPU's name via nvidia-smi, or None.
+
+    worker.gpu_name only exists once a CUDA worker has loaded a model;
+    the tray device picker needs the HARDWARE answer even while the
+    model sleeps or runs on cpu (owner report 2026-07-05: the menu
+    claimed "no GPU detected" next to an installed RTX 5070 Ti).
+    Probed once at startup, same pattern as _get_cpu_name.
+    """
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=5,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip().splitlines()[0]
+    except Exception:
+        pass
+    return None
+
+
 class WhisperSync:
     def __init__(self):
         self._migrate_data()
@@ -145,6 +168,7 @@ class WhisperSync:
         self._dialog_dispatcher = DialogDispatcher()
         self._dialog_dispatcher.start()
         self._cpu_name = _get_cpu_name()
+        self._gpu_hw_name = _get_gpu_hw_name()
         # Session stats: lock-guarded; mutated from dictation/overlay/meeting
         # worker threads concurrently (see session_stats.py).
         from .session_stats import SessionStats

--- a/whisper_sync/tray_menu.py
+++ b/whisper_sync/tray_menu.py
@@ -315,12 +315,22 @@ class TrayMenu:
         # Device (compute) selection
         # Build per-option labels with GPU name from worker (avoids torch import in main process)
         device_options = []
-        gpu_name = self.app.worker.gpu_name if self.app.worker else None
+        # worker.gpu_name only exists after a CUDA worker has loaded;
+        # while the model sleeps (or runs on cpu) it is None and this
+        # menu used to claim "no GPU detected" on a machine with a
+        # perfectly good GPU (owner report 2026-07-05). Fall back to
+        # the hardware name probed once at startup.
+        gpu_name = ((self.app.worker.gpu_name if self.app.worker else None)
+                    or getattr(self.app, "_gpu_hw_name", None))
         auto_suffix = f"\t{gpu_name}" if gpu_name else "\tCPU -- no GPU detected"
         device_options.append(("auto", f"Auto{auto_suffix}"))
         gpu_suffix = f"\t{gpu_name}" if gpu_name else "\tnot available"
         device_options.append(("gpu", f"GPU{gpu_suffix}"))
-        device_options.append(("cpu", "CPU"))
+        # The CPU entry shows WHICH cpu, same as the GPU rows (owner
+        # report: "CPU is not being recognized" - it was never named).
+        cpu_name = getattr(self.app, "_cpu_name", "") or ""
+        cpu_suffix = f"\t{cpu_name}" if cpu_name else ""
+        device_options.append(("cpu", f"CPU{cpu_suffix}"))
         device_items = [
             pystray.MenuItem(
                 label,
@@ -430,6 +440,16 @@ class TrayMenu:
                 "Wake Model" if _sleeping else "Sleep Model\tdouble-click",
                 menu_callback(self.app.auto_sleep.toggle),
             ),
+            # H1 quick toggle (owner request 2026-07-05): Always-On
+            # Listening is reachable without opening Settings. The
+            # detailed surface (phrases, training) stays at the H2
+            # level under Settings > Always-On Listening.
+            pystray.MenuItem(
+                "Always-On Listening",
+                lambda: self._toggle_wake_listener(),
+                checked=lambda item: self.app.cfg.get("wake_listener",
+                                                      False),
+            ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem("Mic Input\tsystem", None, enabled=False)
             if use_sys else
@@ -468,7 +488,7 @@ class TrayMenu:
                                  pystray.Menu(*meeting_model_items)),
                 pystray.MenuItem(f"Device\t{self._get_device_label()}",
                                  pystray.Menu(*device_items)),
-                pystray.MenuItem("Always Available Dictation", pystray.Menu(
+                pystray.MenuItem("Always-On Dictation", pystray.Menu(
                     pystray.MenuItem(
                         "Enabled",
                         lambda: self._toggle_always_available_dictation(),
@@ -509,7 +529,7 @@ class TrayMenu:
                                 "meeting_watch_toast_optout", True)),
                     )),
                 )),
-                pystray.MenuItem("Wake Word Listener", pystray.Menu(
+                pystray.MenuItem("Always-On Listening", pystray.Menu(
                     *self._build_wake_listener_items())),
                 pystray.MenuItem(f"Diarization (Speaker Detection)\t{primary_label}",
                                  pystray.Menu(*diarize_sub_items)),


### PR DESCRIPTION
## Owner review items (2026-07-05)

**Formal names + H1/H2 layering**: "Always-On Dictation" (was Always Available Dictation, already grouping its backup device/model at H2) and "Always-On Listening" (was Wake Word Listener). Always-On Listening gains a **quick toggle at the main tray menu** - switchable without opening Settings - while phrases/training/status stay at H2 under Settings.

**Device picker, both reports confirmed real:**
- The CPU row never named the CPU (`_cpu_name` was probed at startup and only logged). Now: `CPU<tab><name>`, same as the GPU rows.
- `worker.gpu_name` only exists after a CUDA worker loads a model, so with the model asleep/on cpu the menu claimed **"no GPU detected"** next to an installed RTX 5070 Ti. A startup `nvidia-smi` hardware probe now backs the display; the honest "no GPU detected" only shows when hardware is truly absent.
- The suspected GPU-defaulting-to-CPU was checked against logs: the last app run loaded `[cuda] large-v3` - display lie, not a routing bug.

## Tests

Suite 458 passed (new: formal names + H1 toggle presence, CPU naming, hardware-probe fallback, honest no-GPU case). Checklist section 9 added for the owner's visual pass after next app start.