### PR TITLE
fix: skip undecodable clips in the datasets conversion branch

### DIFF
--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -174,8 +174,10 @@ else:
         print(f"skipped {skipped} undecodable clips")
     if n == start:
         # Nothing decoded = wholly bad source; the caller must see a
-        # failure, not an empty success.
-        sys.exit(f"no clips decoded from {source}")
+        # failure, not an empty success. config carries the directory
+        # for local sources and the dataset config for HF sources.
+        sys.exit(f"no clips decoded from {source} "
+                 f"(config={config}, split={split})")
 print(f"wrote {n - start} wavs to {out_dir} ({n} total)")
 """
 

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -157,8 +157,25 @@ else:
         ds = load_dataset(source, config if config != "-" else None,
                           split=split, streaming=False)
     ds = ds.cast_column("audio", Audio(sampling_rate=16000))
-    for row in ds:
-        write_16k(np.asarray(row["audio"]["array"]), 16000)
+    skipped = 0
+    # Index access instead of iteration: audio decodes lazily when a
+    # row materializes, so a corrupt clip raises during the for-row
+    # yield itself, where a loop-body try cannot catch it. FMA ships a
+    # few undecodable mp3s; one bad clip must not kill the conversion
+    # (observed live 2026-07-05: LibsndfileError at clip ~3495).
+    for i in range(len(ds)):
+        try:
+            arr = np.asarray(ds[i]["audio"]["array"])
+        except Exception:
+            skipped += 1
+            continue
+        write_16k(arr, 16000)
+    if skipped:
+        print(f"skipped {skipped} undecodable clips")
+    if n == start:
+        # Nothing decoded = wholly bad source; the caller must see a
+        # failure, not an empty success.
+        sys.exit(f"no clips decoded from {source}")
 print(f"wrote {n - start} wavs to {out_dir} ({n} total)")
 """
 


### PR DESCRIPTION
## What

The trainer dataset setup died mid-FMA at clip ~3495 with soundfile LibsndfileError. Root cause: the datasets branch of HF_TO_WAVS_SNIPPET iterates rows directly, and HF audio decodes lazily during the for-row yield itself, so a corrupt clip raises where a loop-body try can never catch it, killing the whole conversion.

Fix mirrors the parquet branch's guarantees:
- index-based access materializes each row inside a try; corrupt clips are skipped and counted
- `skipped N undecodable clips` reported
- zero decoded clips exits nonzero (continuation-aware: n == start), so a wholly bad source cannot pass as an empty success

## Evidence

Observed live 2026-07-05 during the FMA-small conversion (rudraml/fma). Partial output cleared and conversion re-running with this fix; idempotent phases skip all completed datasets.

Setup script only; no app behavior change, no owner-facing change.