### PR TITLE
fix: adapt pinned trainer stack to torch 2.x on Windows

### DIFF
--- a/tests/test_phrase_trainer.py
+++ b/tests/test_phrase_trainer.py
@@ -190,5 +190,54 @@ class StatusAndRegistryTests(_Harness):
             "set_phrase")
 
 
+def _load_setup_trainer():
+    """setup_trainer.py is a script under training/, not a package
+    module; load it by path. Its top level imports only stdlib, so
+    this stays CI-safe (no torch)."""
+    import importlib.util
+    path = (Path(__file__).resolve().parent.parent / "training" /
+            "setup_trainer.py")
+    spec = importlib.util.spec_from_file_location("setup_trainer", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class PatchFileTests(unittest.TestCase):
+    """_patch_file backs the Windows/torch-2.x compat patches applied
+    to the pinned training stack (first supervised run, 2026-07-05):
+    it must apply once, skip when already applied, and fail loudly
+    when the pinned code drifts from the patch anchor."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.target = Path(self._tmp.name) / "mod.py"
+        self.st = _load_setup_trainer()
+
+    def test_applies_the_patch(self):
+        self.target.write_text("a = 1\nb = 2\n", encoding="utf-8")
+        self.st._patch_file(
+            self.target, "b = 2",
+            "# Patched by setup_trainer.py\nb = 3")
+        self.assertIn("b = 3", self.target.read_text(encoding="utf-8"))
+
+    def test_skips_when_already_patched(self):
+        content = "# Patched by setup_trainer.py\nb = 3\n"
+        self.target.write_text(content, encoding="utf-8")
+        self.st._patch_file(self.target, "b = 2", "never applied")
+        self.assertEqual(
+            self.target.read_text(encoding="utf-8"), content)
+
+    def test_fails_loudly_when_the_anchor_drifted(self):
+        self.target.write_text("something else entirely\n",
+                               encoding="utf-8")
+        with self.assertRaises(SystemExit):
+            self.st._patch_file(self.target, "b = 2", "b = 3")
+
+    def test_shim_constant_compiles(self):
+        compile(self.st.SITECUSTOMIZE_SHIM, "sitecustomize.py", "exec")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phrase_trainer.py
+++ b/tests/test_phrase_trainer.py
@@ -240,6 +240,11 @@ class PatchFileTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.st._patch_file(self.target, "b = 2", "b = 3")
 
+    def test_fails_loudly_when_the_target_is_missing(self):
+        with self.assertRaises(SystemExit):
+            self.st._patch_file(self.target.with_name("gone.py"),
+                                "b = 2", "b = 3")
+
     def test_shim_constant_compiles(self):
         compile(self.st.SITECUSTOMIZE_SHIM, "sitecustomize.py", "exec")
 

--- a/tests/test_phrase_trainer.py
+++ b/tests/test_phrase_trainer.py
@@ -235,8 +235,22 @@ class PatchFileTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.st._patch_file(self.target, "b = 2", "b = 3")
 
+    def test_fails_loudly_when_the_anchor_is_ambiguous(self):
+        self.target.write_text("b = 2\nc = 9\nb = 2\n", encoding="utf-8")
+        with self.assertRaises(SystemExit):
+            self.st._patch_file(self.target, "b = 2", "b = 3")
+
     def test_shim_constant_compiles(self):
         compile(self.st.SITECUSTOMIZE_SHIM, "sitecustomize.py", "exec")
+
+    def test_verify_sha256_accepts_match_and_rejects_mismatch(self):
+        import hashlib
+        blob = self.target.with_suffix(".bin")
+        blob.write_bytes(b"checkpoint bytes")
+        good = hashlib.sha256(b"checkpoint bytes").hexdigest()
+        self.st._verify_sha256(blob, good)  # must not raise
+        with self.assertRaises(SystemExit):
+            self.st._verify_sha256(blob, "0" * 64)
 
 
 if __name__ == "__main__":

--- a/training/README.md
+++ b/training/README.md
@@ -76,6 +76,9 @@ verified against):
 - **`download_models()`** step: openwakeword ships without its
   melspectrogram/embedding feature extractors; the augment stage needs
   them.
+- **PYTHONUTF8=1** for trainer subprocesses: torch's onnx exporter
+  prints emoji progress marks, which raise UnicodeEncodeError on the
+  cp1252 console and kill the export after a successful run.
 
 Rerunning `setup_trainer.py` applies all of this to an existing
 workspace (every step is idempotent).

--- a/training/README.md
+++ b/training/README.md
@@ -51,6 +51,35 @@ tests and for inspection). Config values the notebook did not pin are
 marked PROVISIONAL in `whisper_sync/phrase_training.py`; the first
 supervised run validates them (train.py fails fast on a bad key).
 
+## torch 2.x / Windows compatibility (first supervised run, 2026-07-05)
+
+The upstream notebook targets Linux and a torch 1.x-era stack; this
+machine forces CUDA torch 2.x (RTX 5070 Ti is sm_120, cu128 wheels
+only) on Windows. setup_trainer.py adapts the pinned stack rather than
+upgrading it (newer package majors change APIs the notebook was
+verified against):
+
+- **sitecustomize shim** in the trainer venv restores the removed
+  `torchaudio.set/get_audio_backend` no-ops (speechbrain 0.5.14 and
+  torch-audiomentations 0.11.0 call them at import) and routes
+  `torchaudio.load/info` through soundfile (torchaudio 2.9+ needs
+  TorchCodec + shared FFmpeg; every training input here is plain WAV).
+- **scipy<1.17** pin: acoustics 0.2.6 imports `sph_harm`, removed in
+  scipy 1.17.
+- **In-place patches** (`phase_package_patches`, idempotent, fail
+  loudly if the pinned code drifts): openwakeword's memmap trim closes
+  handles before remove/rename (Windows locks open files); train.py
+  uses an in-process DataLoader on Windows (spawned workers cannot
+  pickle the generator's lambdas); piper's `torch.load` passes
+  `weights_only=False` for the pinned trusted checkpoint (torch 2.6
+  default flip).
+- **`download_models()`** step: openwakeword ships without its
+  melspectrogram/embedding feature extractors; the augment stage needs
+  them.
+
+Rerunning `setup_trainer.py` applies all of this to an existing
+workspace (every step is idempotent).
+
 ## What the later PRs add
 
 - **PR B**: saved-phrase registry (name -> path + active + wake/outro

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -36,6 +36,13 @@ PIPER_REPO = "https://github.com/rhasspy/piper-sample-generator"
 PIPER_REF = "v2.0.0"
 PIPER_CHECKPOINT = ("https://github.com/rhasspy/piper-sample-generator/"
                     "releases/download/v2.0.0/en_US-libritts_r-medium.pt")
+# SHA256 of the v2.0.0 release artifact (computed 2026-07-05 from the
+# HTTPS download). generate_samples.py unpickles this checkpoint with
+# weights_only=False (torch 2.6 patch below), so integrity MUST be
+# verified before any unpickling - a swapped artifact would be code
+# execution.
+PIPER_CHECKPOINT_SHA256 = \
+    "e95ee53770bf598c354a6e6dbfc95ccb259aeeb501d35a86be8a767429ab0ff6"
 
 FEATURES_BASE = ("https://huggingface.co/datasets/davidscripka/"
                  "openwakeword_features/resolve/main/")
@@ -319,7 +326,9 @@ def phase_venv(root: Path, base_python: str, torch_index: str) -> None:
     # from download_models() (notebook step; observed live 2026-07-05).
     resources = (root / "trainer-env" / "Lib" / "site-packages" /
                  "openwakeword" / "resources" / "models")
-    if not (resources / "melspectrogram.onnx").exists():
+    feature_models = [resources / "melspectrogram.onnx",
+                      resources / "embedding_model.onnx"]
+    if not all(p.exists() for p in feature_models):
         run([py, "-c",
              "import openwakeword.utils as u; u.download_models()"])
     else:
@@ -334,10 +343,12 @@ def _patch_file(target: Path, old: str, new: str) -> None:
     if "Patched by setup_trainer.py" in text:
         log(f"already patched: {target.name}")
         return
-    if old not in text:
+    count = text.count(old)
+    if count != 1:
         raise SystemExit(
-            f"[setup] expected code not found in {target}; the pinned "
-            "version changed - re-verify and update the patch.")
+            f"[setup] expected exactly one patch anchor in {target}, "
+            f"found {count}; the pinned version changed - re-verify "
+            "and update the patch.")
     target.write_text(text.replace(old, new), encoding="utf-8")
     log(f"patched: {target.name}")
 
@@ -390,6 +401,23 @@ def phase_package_patches(root: Path) -> None:
         "                                                  batch_size=None, num_workers=n_cpus, prefetch_factor=16)")
 
 
+def _verify_sha256(path: Path, expected: str) -> None:
+    """Refuse to proceed when a downloaded artifact does not match its
+    pinned digest. Required for the piper checkpoint because it is
+    unpickled with weights_only=False - a swapped artifact would be
+    arbitrary code execution."""
+    import hashlib
+    with open(path, "rb") as fh:
+        digest = hashlib.file_digest(fh, "sha256").hexdigest()
+    if digest != expected:
+        raise SystemExit(
+            f"[setup] SHA256 mismatch for {path.name}: got {digest}, "
+            f"expected {expected}. The upstream artifact changed - "
+            "verify it manually before trusting it (it is unpickled "
+            "with weights_only=False). Delete the file to re-download.")
+    log(f"sha256 verified: {path.name}")
+
+
 def phase_piper(root: Path) -> None:
     piper = root / "piper-sample-generator"
     if not piper.exists():
@@ -397,7 +425,9 @@ def phase_piper(root: Path) -> None:
              PIPER_REPO, piper])
     else:
         log("piper-sample-generator exists, skipping clone")
-    download(PIPER_CHECKPOINT, piper / "models" / "en_US-libritts_r-medium.pt")
+    checkpoint = piper / "models" / "en_US-libritts_r-medium.pt"
+    download(PIPER_CHECKPOINT, checkpoint)
+    _verify_sha256(checkpoint, PIPER_CHECKPOINT_SHA256)
     # torch 2.6 flipped torch.load's default to weights_only=True; the
     # pinned v2.0.0 libritts checkpoint is a full pickled model (a
     # trusted release artifact downloaded above), so the generator's

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -62,7 +62,9 @@ AUDIOSET_PARQUETS = [
 # no unconditional tensorflow import). torch is installed separately
 # with the CUDA index.
 TRAINER_PACKAGES = [
-    "openwakeword",
+    # pinned because phase_package_patches edits its files in place;
+    # a version bump must re-verify the patch anchors
+    "openwakeword==0.6.0",
     # upstream piper-phonemize ships no Windows wheels at all; the
     # -fix rebuild provides the same piper_phonemize module (verified
     # importable on py3.11 2026-07-05)
@@ -78,12 +80,71 @@ TRAINER_PACKAGES = [
     "audiomentations==0.33.0",
     "torch-audiomentations==0.11.0",
     "acoustics==0.2.6",
+    # acoustics 0.2.6 imports scipy.special.sph_harm, removed in
+    # scipy 1.17 (observed live 2026-07-05)
+    "scipy<1.17",
     "pronouncing==0.2.0",
     "datasets==2.14.6",
     # datasets 2.14 uses pa.PyExtensionType, removed in pyarrow 17
     "pyarrow<17",
     "deep-phonemizer==0.0.19",
 ]
+
+# torchaudio 2.2 removed the long-deprecated set/get_audio_backend
+# no-ops (backend dispatch is automatic in 2.x), but the pinned
+# notebook stack (speechbrain 0.5.14, torch-audiomentations 0.11.0)
+# still calls them at import time on Windows. Restoring them as no-ops
+# via sitecustomize keeps the notebook pins verbatim; newer package
+# majors (speechbrain 1.x) change APIs the notebook was verified
+# against. The eager torch import cost is irrelevant in a venv that
+# exists only for training stages.
+SITECUSTOMIZE_SHIM = '''\
+"""Trainer-env compatibility shim (written by setup_trainer.py).
+
+Adapts the pinned openwakeword-notebook stack (speechbrain 0.5.14,
+torch-audiomentations 0.11.0, openwakeword 0.6.0) to torch 2.x, which
+the RTX 5070 Ti (sm_120, cu128 wheels) forces:
+
+- torchaudio 2.2 removed the deprecated set/get_audio_backend no-ops
+  that speechbrain/torch-audiomentations call at import time on
+  Windows; restore them as no-ops.
+- torchaudio 2.9+ delegates load/info to TorchCodec, which needs
+  shared FFmpeg DLLs (fragile on Windows). Every training input here
+  is a plain WAV, so route load/info through soundfile instead.
+  soundfile errors subclass RuntimeError, matching the except clauses
+  in openwakeword.data.
+"""
+try:
+    import torchaudio
+
+    if not hasattr(torchaudio, "set_audio_backend"):
+        torchaudio.set_audio_backend = lambda *args, **kwargs: None
+    if not hasattr(torchaudio, "get_audio_backend"):
+        torchaudio.get_audio_backend = lambda: None
+
+    def _sf_load(filepath, *args, **kwargs):
+        import soundfile as sf
+        import torch
+
+        data, sr = sf.read(str(filepath), dtype="float32", always_2d=True)
+        return torch.from_numpy(data.T).contiguous(), sr
+
+    class _SfInfo:
+        def __init__(self, path):
+            import soundfile as sf
+
+            info = sf.info(str(path))
+            self.sample_rate = int(info.samplerate)
+            self.num_frames = int(info.frames)
+            self.num_channels = int(info.channels)
+            self.bits_per_sample = 16
+            self.encoding = "PCM_S"
+
+    torchaudio.load = _sf_load
+    torchaudio.info = lambda filepath, *args, **kwargs: _SfInfo(filepath)
+except Exception:  # torch not installed yet mid-setup
+    pass
+'''
 
 # Runs inside the trainer venv: materialize audio as 16 kHz mono int16
 # wavs, the layout train.py expects.
@@ -244,6 +305,86 @@ def phase_venv(root: Path, base_python: str, torch_index: str) -> None:
     run([py, "-m", "pip", "install", "torch",
          "--index-url", torch_index])
     run([py, "-m", "pip", "install"] + TRAINER_PACKAGES)
+    shim = root / "trainer-env" / "Lib" / "site-packages" / "sitecustomize.py"
+    if not shim.exists() or shim.read_text(encoding="utf-8") != SITECUSTOMIZE_SHIM:
+        shim.write_text(SITECUSTOMIZE_SHIM, encoding="utf-8")
+        log(f"wrote compat shim: {shim.name}")
+    else:
+        log("compat shim current, skipping")
+    # openwakeword ships WITHOUT its feature-extractor models; the
+    # augment stage needs melspectrogram.onnx + embedding_model.onnx
+    # from download_models() (notebook step; observed live 2026-07-05).
+    resources = (root / "trainer-env" / "Lib" / "site-packages" /
+                 "openwakeword" / "resources" / "models")
+    if not (resources / "melspectrogram.onnx").exists():
+        run([py, "-c",
+             "import openwakeword.utils as u; u.download_models()"])
+    else:
+        log("openwakeword feature models present, skipping download")
+
+
+def _patch_file(target: Path, old: str, new: str) -> None:
+    """Idempotent in-place patch: skip when the patch marker is already
+    present, fail loudly when the expected code is missing (the pinned
+    version drifted and the patch must be re-verified)."""
+    text = target.read_text(encoding="utf-8")
+    if "Patched by setup_trainer.py" in text:
+        log(f"already patched: {target.name}")
+        return
+    if old not in text:
+        raise SystemExit(
+            f"[setup] expected code not found in {target}; the pinned "
+            "version changed - re-verify and update the patch.")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+    log(f"patched: {target.name}")
+
+
+def phase_package_patches(root: Path) -> None:
+    """Windows fixes for the pinned training stack, applied in place
+    (observed live 2026-07-05; the upstream notebook runs on Linux
+    where none of this bites). Idempotent via _patch_file."""
+    site = root / "trainer-env" / "Lib" / "site-packages"
+    # openwakeword's post-feature memmap trim removes/renames files
+    # while numpy memmap handles are still open - fine on POSIX, a
+    # PermissionError (WinError 32) on Windows. Close handles first.
+    _patch_file(
+        site / "openwakeword" / "utils.py",
+        "    # Trip empty rows from the mmapped array\n"
+        "    trim_mmap(output_file)",
+        "    # Patched by setup_trainer.py: close the writer memmap first -\n"
+        "    # Windows cannot remove/rename a file with an open handle.\n"
+        "    del fp\n"
+        "\n"
+        "    # Trip empty rows from the mmapped array\n"
+        "    trim_mmap(output_file)")
+    _patch_file(
+        site / "openwakeword" / "data.py",
+        "    # Remove old mmaped file\n"
+        "    os.remove(mmap_path)",
+        "    # Patched by setup_trainer.py: close both memmaps first - Windows\n"
+        "    # cannot remove/rename a file with an open handle.\n"
+        "    del mmap_file1\n"
+        "    mmap_file2.flush()\n"
+        "    del mmap_file2\n"
+        "\n"
+        "    # Remove old mmaped file\n"
+        "    os.remove(mmap_path)")
+    # Windows DataLoader workers spawn (not fork) and cannot pickle the
+    # lambdas/closures train.py feeds the batch generator; stream
+    # in-process instead (train.py already imports sys).
+    _patch_file(
+        site / "openwakeword" / "train.py",
+        "        X_train = torch.utils.data.DataLoader(IterDataset(batch_generator),\n"
+        "                                              batch_size=None, num_workers=n_cpus, prefetch_factor=16)",
+        "        # Patched by setup_trainer.py: Windows DataLoader workers spawn\n"
+        "        # (not fork) and cannot pickle the lambdas/closures inside the\n"
+        "        # batch generator; stream in-process instead.\n"
+        "        if sys.platform == \"win32\":\n"
+        "            X_train = torch.utils.data.DataLoader(IterDataset(batch_generator),\n"
+        "                                                  batch_size=None, num_workers=0)\n"
+        "        else:\n"
+        "            X_train = torch.utils.data.DataLoader(IterDataset(batch_generator),\n"
+        "                                                  batch_size=None, num_workers=n_cpus, prefetch_factor=16)")
 
 
 def phase_piper(root: Path) -> None:
@@ -254,6 +395,17 @@ def phase_piper(root: Path) -> None:
     else:
         log("piper-sample-generator exists, skipping clone")
     download(PIPER_CHECKPOINT, piper / "models" / "en_US-libritts_r-medium.pt")
+    # torch 2.6 flipped torch.load's default to weights_only=True; the
+    # pinned v2.0.0 libritts checkpoint is a full pickled model (a
+    # trusted release artifact downloaded above), so the generator's
+    # plain torch.load fails to unpickle without the override.
+    _patch_file(
+        piper / "generate_samples.py",
+        "    model = torch.load(model_path)",
+        "    # Patched by setup_trainer.py: torch 2.6 defaults\n"
+        "    # weights_only=True, but this checkpoint is a full pickled\n"
+        "    # model from the pinned rhasspy release (trusted source).\n"
+        "    model = torch.load(model_path, weights_only=False)")
 
 
 def phase_datasets(root: Path) -> None:
@@ -317,6 +469,7 @@ def main() -> int:
     root = args.root.resolve()
     log(f"workspace: {root}")
     phase_venv(root, args.python, args.torch_index)
+    phase_package_patches(root)
     phase_piper(root)
     if args.skip_datasets:
         log("datasets skipped (--skip-datasets)")

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -339,6 +339,10 @@ def _patch_file(target: Path, old: str, new: str) -> None:
     """Idempotent in-place patch: skip when the patch marker is already
     present, fail loudly when the expected code is missing (the pinned
     version drifted and the patch must be re-verified)."""
+    if not target.exists():
+        raise SystemExit(
+            f"[setup] patch target missing: {target}; the pinned "
+            "package layout changed - re-verify and update the patch.")
     text = target.read_text(encoding="utf-8")
     if "Patched by setup_trainer.py" in text:
         log(f"already patched: {target.name}")

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -88,6 +88,9 @@ TRAINER_PACKAGES = [
     # datasets 2.14 uses pa.PyExtensionType, removed in pyarrow 17
     "pyarrow<17",
     "deep-phonemizer==0.0.19",
+    # torch 2.x's torch.onnx.export requires onnxscript (the final
+    # model-export step; observed live 2026-07-05)
+    "onnxscript",
 ]
 
 # torchaudio 2.2 removed the long-deprecated set/get_audio_backend

--- a/training/train_phrase.py
+++ b/training/train_phrase.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -75,9 +76,14 @@ def main() -> int:
               "rerun with --go.")
         return 1
 
+    # PYTHONUTF8=1: torch's onnx exporter prints emoji progress marks;
+    # without UTF-8 mode the cp1252 console raises UnicodeEncodeError
+    # and kills the export after an otherwise successful run (observed
+    # live 2026-07-05).
+    env = {**os.environ, "PYTHONUTF8": "1"}
     for cmd in training_commands(config_path, trainer_python):
         print("[train] run: " + " ".join(cmd), flush=True)
-        result = subprocess.run(cmd, cwd=root)
+        result = subprocess.run(cmd, cwd=root, env=env)
         if result.returncode != 0:
             print(f"[train] step failed (exit {result.returncode}); "
                   "artifacts kept for inspection in "


### PR DESCRIPTION
## What

The first supervised phrase-training run (2026-07-05, owner GPU go) surfaced six incompatibilities between the notebook-pinned training stack and the torch 2.x/cu128 stack the RTX 5070 Ti (sm_120) requires. This PR makes setup_trainer.py apply all of them durably; every step is idempotent, so rerunning setup on an existing workspace repairs it in place.

## Fixes (all keep the notebook pins verbatim)

- **sitecustomize shim** in the trainer venv: restores the removed `torchaudio.set/get_audio_backend` no-ops (speechbrain 0.5.14 and torch-audiomentations 0.11.0 call them at import on Windows) and routes `torchaudio.load/info` through soundfile (torchaudio 2.9+ delegates to TorchCodec, which needs shared FFmpeg DLLs; every training input is plain WAV, and soundfile errors subclass RuntimeError to match openwakeword's except clauses).
- **scipy<1.17** pin: acoustics 0.2.6 imports `scipy.special.sph_harm`, removed in scipy 1.17.
- **openwakeword pinned to 0.6.0** and patched in place via the new `_patch_file` helper (skips when applied, fails loudly when the pinned code drifts):
  - memmap trim closes handles before remove/rename (Windows locks open files, WinError 32)
  - train.py streams the training DataLoader in-process on Windows (spawned workers cannot pickle the batch generator's lambdas; Linux forks and never pickles)
- **piper generate_samples.py**: `weights_only=False` for the pinned v2.0.0 checkpoint (torch 2.6 flipped the default; the artifact is the trusted rhasspy release the script itself downloads).
- **download_models() step**: openwakeword ships without its melspectrogram/embedding feature extractors; the augment stage needs them.

## Evidence

Live end-to-end validation on the dev machine tonight: generate (4000 clips, 143 GPU batches), augment (all four feature .npy files), train stage running at PR time. Each fix above corresponds to an observed live failure, in order.

## Docs and tests

- training/README.md: torch 2.x / Windows compatibility section
- tests: `_patch_file` apply/skip/drift + shim-compiles (24 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)