### PR TITLE
fix: trainer export polish - optional tflite, self-contained onnx

### DIFF
--- a/tests/test_phrase_trainer.py
+++ b/tests/test_phrase_trainer.py
@@ -225,9 +225,21 @@ class PatchFileTests(unittest.TestCase):
     def test_skips_when_already_patched(self):
         content = "# Patched by setup_trainer.py\nb = 3\n"
         self.target.write_text(content, encoding="utf-8")
-        self.st._patch_file(self.target, "b = 2", "never applied")
+        self.st._patch_file(self.target, "b = 2",
+                            "# Patched by setup_trainer.py\nb = 3")
         self.assertEqual(
             self.target.read_text(encoding="utf-8"), content)
+
+    def test_second_patch_applies_to_an_already_patched_file(self):
+        # A file can carry several patches; an earlier patch must not
+        # block a later one (idempotence is per-patch, not per-file).
+        self.target.write_text(
+            "# Patched by setup_trainer.py\nb = 3\nz = 1\n",
+            encoding="utf-8")
+        self.st._patch_file(self.target, "z = 1", "z = 2")
+        text = self.target.read_text(encoding="utf-8")
+        self.assertIn("z = 2", text)
+        self.assertIn("b = 3", text)
 
     def test_fails_loudly_when_the_anchor_drifted(self):
         self.target.write_text("something else entirely\n",

--- a/training/README.md
+++ b/training/README.md
@@ -79,6 +79,14 @@ verified against):
 - **PYTHONUTF8=1** for trainer subprocesses: torch's onnx exporter
   prints emoji progress marks, which raise UnicodeEncodeError on the
   cp1252 console and kill the export after a successful run.
+- **Optional tflite conversion**: train.py converts onnx to tflite
+  unconditionally, but the tensorflow chain is deliberately not
+  installed (the listener loads onnx); the patch downgrades a missing
+  onnx_tf to a warning after the onnx export succeeds.
+- **Self-contained .onnx**: torch 2.x's exporter can split weights
+  into a sidecar `.onnx.data` file; train_phrase.py re-embeds them
+  via onnx.load/save when copying into `phrases/` (a plain file copy
+  of the graph alone would not load).
 
 Rerunning `setup_trainer.py` applies all of this to an existing
 workspace (every step is idempotent).

--- a/training/setup_trainer.py
+++ b/training/setup_trainer.py
@@ -336,15 +336,16 @@ def phase_venv(root: Path, base_python: str, torch_index: str) -> None:
 
 
 def _patch_file(target: Path, old: str, new: str) -> None:
-    """Idempotent in-place patch: skip when the patch marker is already
-    present, fail loudly when the expected code is missing (the pinned
-    version drifted and the patch must be re-verified)."""
+    """Idempotent in-place patch: skip when THIS patch's replacement is
+    already present (a file can carry several patches), fail loudly
+    when the expected code is missing (the pinned version drifted and
+    the patch must be re-verified)."""
     if not target.exists():
         raise SystemExit(
             f"[setup] patch target missing: {target}; the pinned "
             "package layout changed - re-verify and update the patch.")
     text = target.read_text(encoding="utf-8")
-    if "Patched by setup_trainer.py" in text:
+    if new in text:
         log(f"already patched: {target.name}")
         return
     count = text.count(old)
@@ -403,6 +404,23 @@ def phase_package_patches(root: Path) -> None:
         "        else:\n"
         "            X_train = torch.utils.data.DataLoader(IterDataset(batch_generator),\n"
         "                                                  batch_size=None, num_workers=n_cpus, prefetch_factor=16)")
+    # The tflite chain (onnx_tf + tensorflow) is deliberately not
+    # installed - the listener loads onnx. train.py converts
+    # unconditionally after the onnx export; make it optional so a
+    # successful training run does not end in ModuleNotFoundError.
+    _patch_file(
+        site / "openwakeword" / "train.py",
+        "        # Convert the model from onnx to tflite format\n"
+        "        convert_onnx_to_tflite(os.path.join(config[\"output_dir\"], config[\"model_name\"] + \".onnx\"),\n"
+        "                               os.path.join(config[\"output_dir\"], config[\"model_name\"] + \".tflite\"))",
+        "        # Patched by setup_trainer.py: the tflite chain (onnx_tf +\n"
+        "        # tensorflow) is deliberately not installed; the .onnx above\n"
+        "        # is the product the listener loads.\n"
+        "        try:\n"
+        "            convert_onnx_to_tflite(os.path.join(config[\"output_dir\"], config[\"model_name\"] + \".onnx\"),\n"
+        "                                   os.path.join(config[\"output_dir\"], config[\"model_name\"] + \".tflite\"))\n"
+        "        except ImportError:\n"
+        "            logging.warning(\"tflite conversion skipped (tensorflow chain not installed; the .onnx is the product)\")")
 
 
 def _verify_sha256(path: Path, expected: str) -> None:

--- a/training/train_phrase.py
+++ b/training/train_phrase.py
@@ -105,11 +105,14 @@ def main() -> int:
                    "onnx.save(onnx.load(sys.argv[1]), sys.argv[2])")
     result = subprocess.run(
         [str(trainer_python), "-c", consolidate, str(produced),
-         str(final)], cwd=root, env=env)
+         str(final)], cwd=root, env=env, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"[train] onnx consolidation failed (exit "
               f"{result.returncode}); the raw export stays in "
               f"{produced.parent}")
+        detail = (result.stderr or result.stdout or "").strip()
+        if detail:
+            print(f"[train] consolidation error: {detail[-500:]}")
         return result.returncode
     print(f"[train] done: {final}")
     print("[train] set it as wake_phrase_model or wake_outro_model "

--- a/training/train_phrase.py
+++ b/training/train_phrase.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -98,7 +97,20 @@ def main() -> int:
     phrases_dir = root / "phrases"
     phrases_dir.mkdir(parents=True, exist_ok=True)
     final = phrases_dir / produced.name
-    shutil.copy2(produced, final)
+    # torch 2.x's onnx exporter can split weights into a sidecar
+    # <name>.onnx.data file; the listener expects one self-contained
+    # model. onnx.load resolves external data and onnx.save re-embeds
+    # it (a plain copy of the graph file alone would be broken).
+    consolidate = ("import onnx, sys; "
+                   "onnx.save(onnx.load(sys.argv[1]), sys.argv[2])")
+    result = subprocess.run(
+        [str(trainer_python), "-c", consolidate, str(produced),
+         str(final)], cwd=root, env=env)
+    if result.returncode != 0:
+        print(f"[train] onnx consolidation failed (exit "
+              f"{result.returncode}); the raw export stays in "
+              f"{produced.parent}")
+        return result.returncode
     print(f"[train] done: {final}")
     print("[train] set it as wake_phrase_model or wake_outro_model "
           "(full path) and restart the listener toggle to load it.")


### PR DESCRIPTION
## What

Closes out the first supervised training run. Two export-stage failures surfaced after #204 merged:

- **Optional tflite conversion**: train.py converts onnx to tflite unconditionally, but the tensorflow chain (onnx_tf) is deliberately not installed - the listener loads onnx. A fully successful training run died in ModuleNotFoundError AFTER the onnx export. A new in-place patch wraps the conversion and downgrades a missing onnx_tf to a warning.
- **Self-contained .onnx**: torch 2.x's exporter split the model weights into a sidecar `.onnx.data` file; the plain `shutil.copy2` into `phrases/` produced a graph file onnxruntime cannot load (verified live: RUNTIME_EXCEPTION, missing .data). train_phrase.py now re-embeds external data via `onnx.load`/`onnx.save` in the trainer venv.

Enabling change: `_patch_file` idempotence is now **per-patch** (skip when the replacement text is present) instead of per-file, so a second patch can land in the already-patched train.py. Validated live via a setup rerun: existing patches logged "already patched", the new tflite patch applied, checkpoint SHA256 verified.

## Evidence

`training/workspace/phrases/hey_hal.onnx` (215 KB, self-contained) loads in the production listener stack (whisper-env openwakeword, onnx framework), exposes score key `hey_hal`, and scores 0.0 on silence. Trained metrics: accuracy 0.74 (target 0.6), recall 0.49 (target 0.25), 0.35 FP/hr.

## Docs and tests

- training/README.md: two new compat bullets (optional tflite, self-contained onnx)
- tests: per-patch idempotence (second patch applies to a patched file) + updated skip test; 28 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)